### PR TITLE
Changing how the About window displays app info.

### DIFF
--- a/UXL-Launcher/AboutWindow.Designer.vb
+++ b/UXL-Launcher/AboutWindow.Designer.vb
@@ -37,6 +37,7 @@ Partial Class aaformAboutWindow
         Me.tabpageLicense = New System.Windows.Forms.TabPage()
         Me.webbrowserGPLViewer = New System.Windows.Forms.WebBrowser()
         Me.tabpageAcknowledgments = New System.Windows.Forms.TabPage()
+        Me.WebBrowser1 = New System.Windows.Forms.WebBrowser()
         Me.tableLayoutPanel.SuspendLayout()
         Me.tabcontrolAboutWindow.SuspendLayout()
         Me.tabpageAbout.SuspendLayout()
@@ -44,6 +45,7 @@ Partial Class aaformAboutWindow
         CType(Me.pictureboxUXLBanner, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.flowLayoutPanelButtons.SuspendLayout()
         Me.tabpageLicense.SuspendLayout()
+        Me.tabpageAcknowledgments.SuspendLayout()
         Me.SuspendLayout()
         '
         'tableLayoutPanel
@@ -52,16 +54,17 @@ Partial Class aaformAboutWindow
         Me.tableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 29.96255!))
         Me.tableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 44.37086!))
         Me.tableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 25.60706!))
-        Me.tableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 123.0!))
+        Me.tableLayoutPanel.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 248.0!))
         Me.tableLayoutPanel.Controls.Add(Me.buttonClose, 3, 1)
         Me.tableLayoutPanel.Controls.Add(Me.tabcontrolAboutWindow, 0, 0)
         Me.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tableLayoutPanel.Location = New System.Drawing.Point(0, 0)
+        Me.tableLayoutPanel.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.tableLayoutPanel.Name = "tableLayoutPanel"
         Me.tableLayoutPanel.RowCount = 2
         Me.tableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 93.20595!))
         Me.tableLayoutPanel.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 6.794055!))
-        Me.tableLayoutPanel.Size = New System.Drawing.Size(534, 471)
+        Me.tableLayoutPanel.Size = New System.Drawing.Size(1068, 942)
         Me.tableLayoutPanel.TabIndex = 0
         '
         'buttonClose
@@ -69,9 +72,10 @@ Partial Class aaformAboutWindow
         Me.buttonClose.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.buttonClose.AutoSize = True
         Me.buttonClose.DialogResult = System.Windows.Forms.DialogResult.Cancel
-        Me.buttonClose.Location = New System.Drawing.Point(457, 445)
+        Me.buttonClose.Location = New System.Drawing.Point(908, 884)
+        Me.buttonClose.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.buttonClose.Name = "buttonClose"
-        Me.buttonClose.Size = New System.Drawing.Size(74, 23)
+        Me.buttonClose.Size = New System.Drawing.Size(154, 52)
         Me.buttonClose.TabIndex = 0
         Me.buttonClose.Text = "Close"
         Me.buttonClose.UseVisualStyleBackColor = True
@@ -83,19 +87,21 @@ Partial Class aaformAboutWindow
         Me.tabcontrolAboutWindow.Controls.Add(Me.tabpageLicense)
         Me.tabcontrolAboutWindow.Controls.Add(Me.tabpageAcknowledgments)
         Me.tabcontrolAboutWindow.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.tabcontrolAboutWindow.Location = New System.Drawing.Point(3, 3)
+        Me.tabcontrolAboutWindow.Location = New System.Drawing.Point(6, 6)
+        Me.tabcontrolAboutWindow.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.tabcontrolAboutWindow.Name = "tabcontrolAboutWindow"
         Me.tabcontrolAboutWindow.SelectedIndex = 0
-        Me.tabcontrolAboutWindow.Size = New System.Drawing.Size(528, 433)
+        Me.tabcontrolAboutWindow.Size = New System.Drawing.Size(1056, 866)
         Me.tabcontrolAboutWindow.TabIndex = 2
         '
         'tabpageAbout
         '
         Me.tabpageAbout.Controls.Add(Me.tableLayoutPanelAboutApp)
-        Me.tabpageAbout.Location = New System.Drawing.Point(4, 22)
+        Me.tabpageAbout.Location = New System.Drawing.Point(8, 39)
+        Me.tabpageAbout.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.tabpageAbout.Name = "tabpageAbout"
-        Me.tabpageAbout.Padding = New System.Windows.Forms.Padding(3)
-        Me.tabpageAbout.Size = New System.Drawing.Size(520, 407)
+        Me.tabpageAbout.Padding = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.tabpageAbout.Size = New System.Drawing.Size(1040, 819)
         Me.tabpageAbout.TabIndex = 0
         Me.tabpageAbout.Text = "About"
         Me.tabpageAbout.UseVisualStyleBackColor = True
@@ -110,7 +116,8 @@ Partial Class aaformAboutWindow
         Me.tableLayoutPanelAboutApp.Controls.Add(Me.flowLayoutPanelButtons, 1, 5)
         Me.tableLayoutPanelAboutApp.Controls.Add(Me.textboxAboutApp, 1, 0)
         Me.tableLayoutPanelAboutApp.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.tableLayoutPanelAboutApp.Location = New System.Drawing.Point(3, 3)
+        Me.tableLayoutPanelAboutApp.Location = New System.Drawing.Point(6, 6)
+        Me.tableLayoutPanelAboutApp.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.tableLayoutPanelAboutApp.Name = "tableLayoutPanelAboutApp"
         Me.tableLayoutPanelAboutApp.RowCount = 6
         Me.tableLayoutPanelAboutApp.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 9.374999!))
@@ -119,17 +126,18 @@ Partial Class aaformAboutWindow
         Me.tableLayoutPanelAboutApp.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 9.374999!))
         Me.tableLayoutPanelAboutApp.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50.12469!))
         Me.tableLayoutPanelAboutApp.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 12.96758!))
-        Me.tableLayoutPanelAboutApp.Size = New System.Drawing.Size(514, 401)
+        Me.tableLayoutPanelAboutApp.Size = New System.Drawing.Size(1028, 807)
         Me.tableLayoutPanelAboutApp.TabIndex = 1
         '
         'pictureboxUXLBanner
         '
         Me.pictureboxUXLBanner.Dock = System.Windows.Forms.DockStyle.Fill
         Me.pictureboxUXLBanner.Image = Global.UXL_Launcher.My.Resources.Resources.UXL_Launcher_Banner
-        Me.pictureboxUXLBanner.Location = New System.Drawing.Point(3, 3)
+        Me.pictureboxUXLBanner.Location = New System.Drawing.Point(6, 6)
+        Me.pictureboxUXLBanner.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.pictureboxUXLBanner.Name = "pictureboxUXLBanner"
         Me.tableLayoutPanelAboutApp.SetRowSpan(Me.pictureboxUXLBanner, 5)
-        Me.pictureboxUXLBanner.Size = New System.Drawing.Size(160, 341)
+        Me.pictureboxUXLBanner.Size = New System.Drawing.Size(321, 690)
         Me.pictureboxUXLBanner.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureboxUXLBanner.TabIndex = 0
         Me.pictureboxUXLBanner.TabStop = False
@@ -141,19 +149,20 @@ Partial Class aaformAboutWindow
         Me.flowLayoutPanelButtons.Controls.Add(Me.linkUpdateCheck)
         Me.flowLayoutPanelButtons.Controls.Add(Me.linkMyWebsite)
         Me.flowLayoutPanelButtons.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.flowLayoutPanelButtons.Location = New System.Drawing.Point(169, 350)
+        Me.flowLayoutPanelButtons.Location = New System.Drawing.Point(339, 708)
+        Me.flowLayoutPanelButtons.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.flowLayoutPanelButtons.Name = "flowLayoutPanelButtons"
-        Me.flowLayoutPanelButtons.Size = New System.Drawing.Size(342, 48)
+        Me.flowLayoutPanelButtons.Size = New System.Drawing.Size(683, 93)
         Me.flowLayoutPanelButtons.TabIndex = 5
         '
         'linkRepository
         '
         Me.linkRepository.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.linkRepository.AutoSize = True
-        Me.linkRepository.Location = New System.Drawing.Point(3, 10)
-        Me.linkRepository.Margin = New System.Windows.Forms.Padding(3, 10, 3, 0)
+        Me.linkRepository.Location = New System.Drawing.Point(6, 20)
+        Me.linkRepository.Margin = New System.Windows.Forms.Padding(6, 20, 6, 0)
         Me.linkRepository.Name = "linkRepository"
-        Me.linkRepository.Size = New System.Drawing.Size(110, 13)
+        Me.linkRepository.Size = New System.Drawing.Size(226, 25)
         Me.linkRepository.TabIndex = 1
         Me.linkRepository.TabStop = True
         Me.linkRepository.Text = "Visit GitHub repository"
@@ -162,10 +171,10 @@ Partial Class aaformAboutWindow
         '
         Me.linkUpdateCheck.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.linkUpdateCheck.AutoSize = True
-        Me.linkUpdateCheck.Location = New System.Drawing.Point(119, 10)
-        Me.linkUpdateCheck.Margin = New System.Windows.Forms.Padding(3, 10, 3, 0)
+        Me.linkUpdateCheck.Location = New System.Drawing.Point(244, 20)
+        Me.linkUpdateCheck.Margin = New System.Windows.Forms.Padding(6, 20, 6, 0)
         Me.linkUpdateCheck.Name = "linkUpdateCheck"
-        Me.linkUpdateCheck.Size = New System.Drawing.Size(94, 13)
+        Me.linkUpdateCheck.Size = New System.Drawing.Size(187, 25)
         Me.linkUpdateCheck.TabIndex = 0
         Me.linkUpdateCheck.TabStop = True
         Me.linkUpdateCheck.Text = "Check for updates"
@@ -174,10 +183,10 @@ Partial Class aaformAboutWindow
         '
         Me.linkMyWebsite.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.linkMyWebsite.AutoSize = True
-        Me.linkMyWebsite.Location = New System.Drawing.Point(219, 10)
-        Me.linkMyWebsite.Margin = New System.Windows.Forms.Padding(3, 10, 3, 0)
+        Me.linkMyWebsite.Location = New System.Drawing.Point(443, 20)
+        Me.linkMyWebsite.Margin = New System.Windows.Forms.Padding(6, 20, 6, 0)
         Me.linkMyWebsite.Name = "linkMyWebsite"
-        Me.linkMyWebsite.Size = New System.Drawing.Size(100, 13)
+        Me.linkMyWebsite.Size = New System.Drawing.Size(202, 25)
         Me.linkMyWebsite.TabIndex = 2
         Me.linkMyWebsite.TabStop = True
         Me.linkMyWebsite.Text = "Visit Drew's website"
@@ -186,14 +195,14 @@ Partial Class aaformAboutWindow
         '
         Me.textboxAboutApp.BackColor = System.Drawing.SystemColors.Window
         Me.tableLayoutPanelAboutApp.SetColumnSpan(Me.textboxAboutApp, 2)
-        Me.textboxAboutApp.Location = New System.Drawing.Point(172, 3)
-        Me.textboxAboutApp.Margin = New System.Windows.Forms.Padding(6, 3, 3, 3)
+        Me.textboxAboutApp.Location = New System.Drawing.Point(345, 6)
+        Me.textboxAboutApp.Margin = New System.Windows.Forms.Padding(12, 6, 6, 6)
         Me.textboxAboutApp.Multiline = True
         Me.textboxAboutApp.Name = "textboxAboutApp"
         Me.textboxAboutApp.ReadOnly = True
         Me.tableLayoutPanelAboutApp.SetRowSpan(Me.textboxAboutApp, 5)
         Me.textboxAboutApp.ScrollBars = System.Windows.Forms.ScrollBars.Vertical
-        Me.textboxAboutApp.Size = New System.Drawing.Size(339, 341)
+        Me.textboxAboutApp.Size = New System.Drawing.Size(674, 678)
         Me.textboxAboutApp.TabIndex = 0
         Me.textboxAboutApp.TabStop = False
         Me.textboxAboutApp.Text = resources.GetString("textboxAboutApp.Text")
@@ -201,10 +210,11 @@ Partial Class aaformAboutWindow
         'tabpageLicense
         '
         Me.tabpageLicense.Controls.Add(Me.webbrowserGPLViewer)
-        Me.tabpageLicense.Location = New System.Drawing.Point(4, 22)
+        Me.tabpageLicense.Location = New System.Drawing.Point(8, 39)
+        Me.tabpageLicense.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.tabpageLicense.Name = "tabpageLicense"
-        Me.tabpageLicense.Padding = New System.Windows.Forms.Padding(3)
-        Me.tabpageLicense.Size = New System.Drawing.Size(520, 407)
+        Me.tabpageLicense.Padding = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.tabpageLicense.Size = New System.Drawing.Size(1040, 819)
         Me.tabpageLicense.TabIndex = 1
         Me.tabpageLicense.Text = "License"
         Me.tabpageLicense.UseVisualStyleBackColor = True
@@ -214,32 +224,45 @@ Partial Class aaformAboutWindow
         Me.webbrowserGPLViewer.AllowNavigation = False
         Me.webbrowserGPLViewer.AllowWebBrowserDrop = False
         Me.webbrowserGPLViewer.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.webbrowserGPLViewer.Location = New System.Drawing.Point(3, 3)
-        Me.webbrowserGPLViewer.MinimumSize = New System.Drawing.Size(20, 20)
+        Me.webbrowserGPLViewer.Location = New System.Drawing.Point(6, 6)
+        Me.webbrowserGPLViewer.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.webbrowserGPLViewer.MinimumSize = New System.Drawing.Size(40, 40)
         Me.webbrowserGPLViewer.Name = "webbrowserGPLViewer"
         Me.webbrowserGPLViewer.ScriptErrorsSuppressed = True
-        Me.webbrowserGPLViewer.Size = New System.Drawing.Size(514, 401)
+        Me.webbrowserGPLViewer.Size = New System.Drawing.Size(1028, 807)
         Me.webbrowserGPLViewer.TabIndex = 0
         Me.webbrowserGPLViewer.Url = New System.Uri("", System.UriKind.Relative)
         '
         'tabpageAcknowledgments
         '
-        Me.tabpageAcknowledgments.Location = New System.Drawing.Point(4, 22)
+        Me.tabpageAcknowledgments.Controls.Add(Me.WebBrowser1)
+        Me.tabpageAcknowledgments.Location = New System.Drawing.Point(8, 39)
+        Me.tabpageAcknowledgments.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.tabpageAcknowledgments.Name = "tabpageAcknowledgments"
-        Me.tabpageAcknowledgments.Padding = New System.Windows.Forms.Padding(3)
-        Me.tabpageAcknowledgments.Size = New System.Drawing.Size(520, 407)
+        Me.tabpageAcknowledgments.Padding = New System.Windows.Forms.Padding(6, 6, 6, 6)
+        Me.tabpageAcknowledgments.Size = New System.Drawing.Size(1040, 819)
         Me.tabpageAcknowledgments.TabIndex = 2
         Me.tabpageAcknowledgments.Text = "Acknowledgments"
         Me.tabpageAcknowledgments.UseVisualStyleBackColor = True
         '
+        'WebBrowser1
+        '
+        Me.WebBrowser1.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.WebBrowser1.Location = New System.Drawing.Point(6, 6)
+        Me.WebBrowser1.MinimumSize = New System.Drawing.Size(20, 20)
+        Me.WebBrowser1.Name = "WebBrowser1"
+        Me.WebBrowser1.Size = New System.Drawing.Size(1028, 807)
+        Me.WebBrowser1.TabIndex = 0
+        '
         'aaformAboutWindow
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(192.0!, 192.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.CancelButton = Me.buttonClose
-        Me.ClientSize = New System.Drawing.Size(534, 471)
+        Me.ClientSize = New System.Drawing.Size(1068, 942)
         Me.Controls.Add(Me.tableLayoutPanel)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle
+        Me.Margin = New System.Windows.Forms.Padding(6, 6, 6, 6)
         Me.MaximizeBox = False
         Me.MinimizeBox = False
         Me.Name = "aaformAboutWindow"
@@ -257,6 +280,7 @@ Partial Class aaformAboutWindow
         Me.flowLayoutPanelButtons.ResumeLayout(False)
         Me.flowLayoutPanelButtons.PerformLayout()
         Me.tabpageLicense.ResumeLayout(False)
+        Me.tabpageAcknowledgments.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
@@ -275,4 +299,5 @@ Partial Class aaformAboutWindow
     Friend WithEvents linkRepository As LinkLabel
     Friend WithEvents linkMyWebsite As LinkLabel
     Friend WithEvents webbrowserGPLViewer As WebBrowser
+    Friend WithEvents WebBrowser1 As WebBrowser
 End Class

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -45,11 +45,11 @@ UXL Launcher is free software: you can redistribute it and/or modify it under th
 UXL Launcher is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
+You should have received a copy of the GNU General Public License along with UXL Launcher. If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
 "" &
-"I am not intending on infringing on Microsoft" & "'" & "s copyrights, so this is only a shortcut application.
+"Drew is not intending on infringing on Microsoft" & "'" & "s copyrights, so UXL Launcher is only a shortcut application.
 
-Copyright notice Office, Microsoft Office, Word, Excel, PowerPoint, And all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft" & "'" & "s copyrights.")
+Copyright notice: Office, Microsoft Office, Word, Excel, PowerPoint, And all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft" & "'" & "s copyrights.")
 
 
         ' Load the GPL document in the WebBrowser control.

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -33,10 +33,11 @@ Public Class aaformAboutWindow
         ' Put the text in the About box on launch.
         textboxAboutApp.Text = ("UXL Launcher - Unified eXecutable Launcher
 Version  & My.Application.Info.Version.ToString & - Codename ""New Change""
-        App compiled at UTC  & BuildDateString
+        App compiled at UTC" & BuildDateString &
+        "" &
+        "Copyright(C) 2013-2016  Drew Naylor" &
+"UXL Launcher provides launchers for most Microsoft Office apps in one place. 
 
-        My.Application.Info.Copyright
-        UXL Launcher provides launchers for most Microsoft Office apps in one place.
 License notice:
 UXL Launcher is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -49,6 +50,7 @@ but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY o
 You should have received a copy of the GNU General Public License
 along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
 "I am not intending on infringing on Microsoft" & "'" & "s copyrights, so this is only a shortcut application.
+
 Copyright notice Office, Microsoft Office, Word, Excel, PowerPoint, And all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft" & "'" & "s copyrights.")
 
 

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -45,8 +45,7 @@ UXL Launcher is free software: you can redistribute it and/or modify it under th
 UXL Launcher is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
+You should have received a copy of the GNU General Public License along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
 "" &
 "I am not intending on infringing on Microsoft" & "'" & "s copyrights, so this is only a shortcut application.
 

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -32,11 +32,11 @@ Public Class aaformAboutWindow
 
         ' Put the text in the About box on launch.
         textboxAboutApp.Text = ("UXL Launcher - Unified eXecutable Launcher
-Version  & My.Application.Info.Version.ToString & - Codename ""New Change""
-        App compiled at UTC" & BuildDateString &
-        "" &
-        "Copyright(C) 2013-2016  Drew Naylor" &
-"UXL Launcher provides launchers for most Microsoft Office apps in one place. 
+Version " & My.Application.Info.Version.ToString & " - Codename ""New Change""
+App compiled at UTC" & BuildDateString &
+"Copyright (C) 2013-2016  Drew Naylor
+
+UXL Launcher provides launchers for most Microsoft Office apps in one place. 
 
 License notice:
 UXL Launcher is free software: you can redistribute it and/or modify

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -46,7 +46,7 @@ UXL Launcher is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with UXL Launcher. If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
-"" &
+"" & vbCrLf &
 "Drew is not intending on infringing on Microsoft" & "'" & "s copyrights, so UXL Launcher is only a shortcut application.
 
 Copyright notice: Office, Microsoft Office, Word, Excel, PowerPoint, And all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft" & "'" & "s copyrights.")

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -31,13 +31,13 @@ Public Class aaformAboutWindow
         Dim BuildDateString As String = My.Resources.BuildDate
 
         ' Put the text in the About box on launch.
-        textboxAboutApp.Text = ("UXL Launcher - Unified eXecutable Launcher" & Environment.NewLine)
-        textboxAboutApp.AppendText("Version " & My.Application.Info.Version.ToString & " - Codename ""New Change""" & Environment.NewLine)
-        textboxAboutApp.AppendText("App compiled at UTC " & BuildDateString)
-        textboxAboutApp.AppendText("" & Environment.NewLine)
-        textboxAboutApp.AppendText(My.Application.Info.Copyright & Environment.NewLine)
-        textboxAboutApp.AppendText("UXL Launcher provides launchers for most Microsoft Office apps in one place." & Environment.NewLine)
-        textboxAboutApp.AppendText("License notice:
+        textboxAboutApp.Text = ("UXL Launcher - Unified eXecutable Launcher
+Version  & My.Application.Info.Version.ToString & - Codename ""New Change""
+        App compiled at UTC  & BuildDateString
+
+        My.Application.Info.Copyright
+        UXL Launcher provides launchers for most Microsoft Office apps in one place.
+License notice:
 UXL Launcher is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
@@ -47,12 +47,9 @@ UXL Launcher is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & Environment.NewLine)
-        textboxAboutApp.AppendText("I am not intending on infringing on Microsoft's copyrights, so this is only a shortcut application." & Environment.NewLine)
-        textboxAboutApp.AppendText("" & Environment.NewLine)
-        ' Note: In order for the date and time to be updated, you must tell Visual Studio to build the project BEFORE debugging it. In VS2010, you can right-click
-        ' on the toolbar at the top of the window and click "Build" to add the Build Toolbar.
-        textboxAboutApp.AppendText("Copyright notice: Office, Microsoft Office, Word, Excel, PowerPoint, and all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft's copyrights.")
+along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
+"I am not intending on infringing on Microsoft" & "'" & "s copyrights, so this is only a shortcut application.
+Copyright notice Office, Microsoft Office, Word, Excel, PowerPoint, And all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft" & "'" & "s copyrights.")
 
 
         ' Load the GPL document in the WebBrowser control.

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -39,16 +39,15 @@ App compiled at UTC" & BuildDateString &
 UXL Launcher provides launchers for most Microsoft Office apps in one place. 
 
 License notice:
-UXL Launcher is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+UXL Launcher is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by" &
+"the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 
 UXL Launcher is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
 along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>." & vbCrLf &
+"" &
 "I am not intending on infringing on Microsoft" & "'" & "s copyrights, so this is only a shortcut application.
 
 Copyright notice Office, Microsoft Office, Word, Excel, PowerPoint, And all related words (by MSFT) are Copyright [a long time ago]-[sometime in the future] Microsoft Corp. All Rights Reserved for Microsoft" & "'" & "s copyrights.")


### PR DESCRIPTION
Originally I used Microsoft's About window template as a reference but I prefer how it worked in Drew's App Launcher. Also, I added a webbrowser control for the Acknowledgments tab in the About window.