### PR TITLE
Pass EXE files and friendly names directly to the isolated error handler instead of setting strings that the error handler would pull from.

### DIFF
--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -121,7 +121,7 @@ Public Class LaunchApp
 #Region "Office Language Preferences Launcher Code."
     Public Shared Sub LaunchOfficeLangPrefs()
         ' Launch Office Language Preferences. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        isolated_error_handler.launcherErrorHandler("SETLANG.EXE")
+        isolated_error_handler.launcherErrorHandler("SETLANG.EXE", "Office Language Preferences")
     End Sub
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -41,105 +41,105 @@ Public Class LaunchApp
 #Region "Microsoft Excel Launcher Code."
     Public Shared Sub LaunchExcel()
         ' Launch Microsoft Excel. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "EXCEL.EXE"
+        'exeName = "EXCEL.EXE"
         exeFriendlyName = "Microsoft Excel"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("EXCEL.EXE")
     End Sub
 #End Region
 #Region "Microsoft InfoPath Launcher Code."
     Public Shared Sub LaunchInfopath()
         ' Launch Microsoft Infopath. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "INFOPATH.EXE"
+        'exeName = "INFOPATH.EXE"
         exeFriendlyName = "Microsoft InfoPath"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("INFOPATH.EXE")
     End Sub
 #End Region
 #Region "Microsoft OneNote Launcher Code."
     Public Shared Sub LaunchOnenote()
         ' Launch Microsoft Onenote. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "ONENOTE.EXE"
+        'exeName = "ONENOTE.EXE"
         exeFriendlyName = "Microsoft OneNote"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("ONENOTE.EXE")
     End Sub
 #End Region
 #Region "Microsoft Outlook Launcher Code."
     Public Shared Sub LaunchOutlook()
         ' Launch Microsoft Outlook. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "OUTLOOK.EXE"
+        'exeName = "OUTLOOK.EXE"
         exeFriendlyName = "Microsoft Outlook"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("OUTLOOK.EXE")
     End Sub
 #End Region
 #Region "Microsoft PowerPoint Launcher Code."
     Public Shared Sub LaunchPowerpoint()
         ' Launch Microsoft Powerpoint. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "POWERPNT.EXE"
+        'exeName = "POWERPNT.EXE"
         exeFriendlyName = "Microsoft PowerPoint"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("POWERPNT.EXE")
     End Sub
 #End Region
 #Region "Microsoft SharePoint Workspace Launcher Code."
     Public Shared Sub LaunchSharepointWorkspace()
         ' Launch Microsoft Sharepoint Workspace. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "GROOVE.EXE"
+        'exeName = "GROOVE.EXE"
         exeFriendlyName = "Microsoft SharePoint Workspace"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("GROOVE.EXE")
     End Sub
 #End Region
 #Region "Microsoft Publisher Launcher Code."
     Public Shared Sub LaunchPublisher()
         ' Launch Microsoft Publisher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "MSPUB.EXE"
+        'exeName = "MSPUB.EXE"
         exeFriendlyName = "Microsoft Publisher"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("MSPUB.EXE")
     End Sub
 #End Region
 #Region "Microsoft Word Launcher Code."
     Public Shared Sub LaunchWord()
         ' Launch Microsoft Word. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "WINWORD.EXE"
+        'exeName = "WINWORD.EXE"
         exeFriendlyName = "Microsoft Word"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("WINWORD.EXE")
     End Sub
 #End Region
 #Region "Microsoft Query Launcher Code."
     Public Shared Sub LaunchQuery()
         ' Launch Microsoft Query. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "MSQRY32.EXE"
+        'exeName = "MSQRY32.EXE"
         exeFriendlyName = "Microsoft Query"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("MSQRY32.EXE")
     End Sub
 #End Region
 #Region "Microsoft Clip Organizer Launcher Code."
     Public Shared Sub LaunchClipOrganizer()
         ' Launch Microsoft Clip Organizer. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "MSTORE.EXE"
+        'exeName = "MSTORE.EXE"
         exeFriendlyName = "Microsoft Clip Organizer"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("MSTORE.EXE")
     End Sub
 #End Region
 #Region "Microsoft Office Picture Manager Launcher Code."
     Public Shared Sub LaunchPictureManager()
         ' Launch Microsoft Office Picture Manager. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "OIS.EXE"
+        'exeName = "OIS.EXE"
         exeFriendlyName = "Microsoft Office Picture Manager"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("OIS.EXE")
     End Sub
 #End Region
 #Region "Microsoft OneNote Quick Launch Launcher Code."
     Public Shared Sub LaunchOnenoteQuickLaunch()
         ' Launch Microsoft OneNote Quick Launcher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "ONENOTEM.EXE"
+        'exeName = "ONENOTEM.EXE"
         exeFriendlyName = "Microsoft OneNote Quick Launch"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("ONENOTEM.EXE")
     End Sub
 #End Region
 #Region "Office Language Preferences Launcher Code."
     Public Shared Sub LaunchOfficeLangPrefs()
         ' Launch Office Language Preferences. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "SETLANG.EXE"
+        'exeName = "SETLANG.EXE"
         exeFriendlyName = "Office Language Preferences"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("SETLANG.EXE")
     End Sub
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -33,9 +33,9 @@ Public Class LaunchApp
 #Region "Microsoft Access Launcher Code."
     Public Shared Sub LaunchAccess()
         ' Launch Microsoft Access. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeName = "MSACCESS.EXE"
+        'exeName = "MSACCESS.EXE"
         exeFriendlyName = "Microsoft Access"
-        isolated_error_handler.launcherErrorHandler()
+        isolated_error_handler.launcherErrorHandler("MSACCESS.EXE")
     End Sub
 #End Region
 #Region "Microsoft Excel Launcher Code."

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -26,70 +26,58 @@
 
 Public Class LaunchApp
 #Region "The code in this region is for launching the apps when buttons are pressed."
-
-    Public Shared exeFriendlyName As String
-
 #Region "Microsoft Access Launcher Code."
     Public Shared Sub LaunchAccess()
         ' Launch Microsoft Access. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Access"
-        isolated_error_handler.launcherErrorHandler("MSACCESS.EXE")
+        isolated_error_handler.launcherErrorHandler("MSACCESS.EXE", "Microsoft Access")
     End Sub
 #End Region
 #Region "Microsoft Excel Launcher Code."
     Public Shared Sub LaunchExcel()
         ' Launch Microsoft Excel. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Excel"
-        isolated_error_handler.launcherErrorHandler("EXCEL.EXE")
+        isolated_error_handler.launcherErrorHandler("EXCEL.EXE", "Microsoft Excel")
     End Sub
 #End Region
 #Region "Microsoft InfoPath Launcher Code."
     Public Shared Sub LaunchInfopath()
         ' Launch Microsoft Infopath. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft InfoPath"
-        isolated_error_handler.launcherErrorHandler("INFOPATH.EXE")
+        isolated_error_handler.launcherErrorHandler("INFOPATH.EXE", "Microsoft InfoPath")
     End Sub
 #End Region
 #Region "Microsoft OneNote Launcher Code."
     Public Shared Sub LaunchOnenote()
         ' Launch Microsoft Onenote. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft OneNote"
-        isolated_error_handler.launcherErrorHandler("ONENOTE.EXE")
+        isolated_error_handler.launcherErrorHandler("ONENOTE.EXE", "Microsoft OneNote")
     End Sub
 #End Region
 #Region "Microsoft Outlook Launcher Code."
     Public Shared Sub LaunchOutlook()
         ' Launch Microsoft Outlook. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Outlook"
-        isolated_error_handler.launcherErrorHandler("OUTLOOK.EXE")
+        isolated_error_handler.launcherErrorHandler("OUTLOOK.EXE", "Microsoft Outlook")
     End Sub
 #End Region
 #Region "Microsoft PowerPoint Launcher Code."
     Public Shared Sub LaunchPowerpoint()
         ' Launch Microsoft Powerpoint. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft PowerPoint"
-        isolated_error_handler.launcherErrorHandler("POWERPNT.EXE")
+        isolated_error_handler.launcherErrorHandler("POWERPNT.EXE", "Microsoft PowerPoint")
     End Sub
 #End Region
 #Region "Microsoft SharePoint Workspace Launcher Code."
     Public Shared Sub LaunchSharepointWorkspace()
         ' Launch Microsoft Sharepoint Workspace. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft SharePoint Workspace"
-        isolated_error_handler.launcherErrorHandler("GROOVE.EXE")
+        isolated_error_handler.launcherErrorHandler("GROOVE.EXE", "Microsoft SharePoint Workspace")
     End Sub
 #End Region
 #Region "Microsoft Publisher Launcher Code."
     Public Shared Sub LaunchPublisher()
         ' Launch Microsoft Publisher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Publisher"
-        isolated_error_handler.launcherErrorHandler("MSPUB.EXE")
+        isolated_error_handler.launcherErrorHandler("MSPUB.EXE", "Microsoft Publisher")
     End Sub
 #End Region
 #Region "Microsoft Word Launcher Code."
     Public Shared Sub LaunchWord()
         ' Launch Microsoft Word. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Word"
-        isolated_error_handler.launcherErrorHandler("WINWORD.EXE")
+        isolated_error_handler.launcherErrorHandler("WINWORD.EXE", "Microsoft Word")
     End Sub
 #End Region
 #Region "Microsoft Query Launcher Code."

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -103,27 +103,24 @@ Public Class LaunchApp
     Public Shared Sub LaunchClipOrganizer()
         ' Launch Microsoft Clip Organizer. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
         exeFriendlyName = "Microsoft Clip Organizer"
-        isolated_error_handler.launcherErrorHandler("MSTORE.EXE")
+        isolated_error_handler.launcherErrorHandler("MSTORE.EXE", "Microsoft Clip Organizer")
     End Sub
 #End Region
 #Region "Microsoft Office Picture Manager Launcher Code."
     Public Shared Sub LaunchPictureManager()
         ' Launch Microsoft Office Picture Manager. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Office Picture Manager"
         isolated_error_handler.launcherErrorHandler("OIS.EXE", "Microsoft Office Picture Manager")
     End Sub
 #End Region
 #Region "Microsoft OneNote Quick Launch Launcher Code."
     Public Shared Sub LaunchOnenoteQuickLaunch()
         ' Launch Microsoft OneNote Quick Launcher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft OneNote Quick Launch"
         isolated_error_handler.launcherErrorHandler("ONENOTEM.EXE", "Microsoft OneNote Quick Launch")
     End Sub
 #End Region
 #Region "Office Language Preferences Launcher Code."
     Public Shared Sub LaunchOfficeLangPrefs()
         ' Launch Office Language Preferences. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Office Language Preferences"
         isolated_error_handler.launcherErrorHandler("SETLANG.EXE")
     End Sub
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -27,7 +27,6 @@
 Public Class LaunchApp
 #Region "The code in this region is for launching the apps when buttons are pressed."
 
-    Public Shared exeName As String
     Public Shared exeFriendlyName As String
 
 #Region "Microsoft Access Launcher Code."
@@ -111,14 +110,14 @@ Public Class LaunchApp
     Public Shared Sub LaunchPictureManager()
         ' Launch Microsoft Office Picture Manager. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
         exeFriendlyName = "Microsoft Office Picture Manager"
-        isolated_error_handler.launcherErrorHandler("OIS.EXE")
+        isolated_error_handler.launcherErrorHandler("OIS.EXE", "Microsoft Office Picture Manager")
     End Sub
 #End Region
 #Region "Microsoft OneNote Quick Launch Launcher Code."
     Public Shared Sub LaunchOnenoteQuickLaunch()
         ' Launch Microsoft OneNote Quick Launcher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
         exeFriendlyName = "Microsoft OneNote Quick Launch"
-        isolated_error_handler.launcherErrorHandler("ONENOTEM.EXE")
+        isolated_error_handler.launcherErrorHandler("ONENOTEM.EXE", "Microsoft OneNote Quick Launch")
     End Sub
 #End Region
 #Region "Office Language Preferences Launcher Code."

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -95,14 +95,12 @@ Public Class LaunchApp
 #Region "Microsoft Query Launcher Code."
     Public Shared Sub LaunchQuery()
         ' Launch Microsoft Query. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Query"
-        isolated_error_handler.launcherErrorHandler("MSQRY32.EXE")
+        isolated_error_handler.launcherErrorHandler("MSQRY32.EXE", "Microsoft Query")
     End Sub
 #End Region
 #Region "Microsoft Clip Organizer Launcher Code."
     Public Shared Sub LaunchClipOrganizer()
         ' Launch Microsoft Clip Organizer. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        exeFriendlyName = "Microsoft Clip Organizer"
         isolated_error_handler.launcherErrorHandler("MSTORE.EXE", "Microsoft Clip Organizer")
     End Sub
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -33,7 +33,6 @@ Public Class LaunchApp
 #Region "Microsoft Access Launcher Code."
     Public Shared Sub LaunchAccess()
         ' Launch Microsoft Access. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "MSACCESS.EXE"
         exeFriendlyName = "Microsoft Access"
         isolated_error_handler.launcherErrorHandler("MSACCESS.EXE")
     End Sub
@@ -41,7 +40,6 @@ Public Class LaunchApp
 #Region "Microsoft Excel Launcher Code."
     Public Shared Sub LaunchExcel()
         ' Launch Microsoft Excel. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "EXCEL.EXE"
         exeFriendlyName = "Microsoft Excel"
         isolated_error_handler.launcherErrorHandler("EXCEL.EXE")
     End Sub
@@ -49,7 +47,6 @@ Public Class LaunchApp
 #Region "Microsoft InfoPath Launcher Code."
     Public Shared Sub LaunchInfopath()
         ' Launch Microsoft Infopath. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "INFOPATH.EXE"
         exeFriendlyName = "Microsoft InfoPath"
         isolated_error_handler.launcherErrorHandler("INFOPATH.EXE")
     End Sub
@@ -57,7 +54,6 @@ Public Class LaunchApp
 #Region "Microsoft OneNote Launcher Code."
     Public Shared Sub LaunchOnenote()
         ' Launch Microsoft Onenote. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "ONENOTE.EXE"
         exeFriendlyName = "Microsoft OneNote"
         isolated_error_handler.launcherErrorHandler("ONENOTE.EXE")
     End Sub
@@ -65,7 +61,6 @@ Public Class LaunchApp
 #Region "Microsoft Outlook Launcher Code."
     Public Shared Sub LaunchOutlook()
         ' Launch Microsoft Outlook. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "OUTLOOK.EXE"
         exeFriendlyName = "Microsoft Outlook"
         isolated_error_handler.launcherErrorHandler("OUTLOOK.EXE")
     End Sub
@@ -73,7 +68,6 @@ Public Class LaunchApp
 #Region "Microsoft PowerPoint Launcher Code."
     Public Shared Sub LaunchPowerpoint()
         ' Launch Microsoft Powerpoint. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "POWERPNT.EXE"
         exeFriendlyName = "Microsoft PowerPoint"
         isolated_error_handler.launcherErrorHandler("POWERPNT.EXE")
     End Sub
@@ -81,7 +75,6 @@ Public Class LaunchApp
 #Region "Microsoft SharePoint Workspace Launcher Code."
     Public Shared Sub LaunchSharepointWorkspace()
         ' Launch Microsoft Sharepoint Workspace. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "GROOVE.EXE"
         exeFriendlyName = "Microsoft SharePoint Workspace"
         isolated_error_handler.launcherErrorHandler("GROOVE.EXE")
     End Sub
@@ -89,7 +82,6 @@ Public Class LaunchApp
 #Region "Microsoft Publisher Launcher Code."
     Public Shared Sub LaunchPublisher()
         ' Launch Microsoft Publisher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "MSPUB.EXE"
         exeFriendlyName = "Microsoft Publisher"
         isolated_error_handler.launcherErrorHandler("MSPUB.EXE")
     End Sub
@@ -97,7 +89,6 @@ Public Class LaunchApp
 #Region "Microsoft Word Launcher Code."
     Public Shared Sub LaunchWord()
         ' Launch Microsoft Word. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "WINWORD.EXE"
         exeFriendlyName = "Microsoft Word"
         isolated_error_handler.launcherErrorHandler("WINWORD.EXE")
     End Sub
@@ -105,7 +96,6 @@ Public Class LaunchApp
 #Region "Microsoft Query Launcher Code."
     Public Shared Sub LaunchQuery()
         ' Launch Microsoft Query. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "MSQRY32.EXE"
         exeFriendlyName = "Microsoft Query"
         isolated_error_handler.launcherErrorHandler("MSQRY32.EXE")
     End Sub
@@ -113,7 +103,6 @@ Public Class LaunchApp
 #Region "Microsoft Clip Organizer Launcher Code."
     Public Shared Sub LaunchClipOrganizer()
         ' Launch Microsoft Clip Organizer. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "MSTORE.EXE"
         exeFriendlyName = "Microsoft Clip Organizer"
         isolated_error_handler.launcherErrorHandler("MSTORE.EXE")
     End Sub
@@ -121,7 +110,6 @@ Public Class LaunchApp
 #Region "Microsoft Office Picture Manager Launcher Code."
     Public Shared Sub LaunchPictureManager()
         ' Launch Microsoft Office Picture Manager. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "OIS.EXE"
         exeFriendlyName = "Microsoft Office Picture Manager"
         isolated_error_handler.launcherErrorHandler("OIS.EXE")
     End Sub
@@ -129,7 +117,6 @@ Public Class LaunchApp
 #Region "Microsoft OneNote Quick Launch Launcher Code."
     Public Shared Sub LaunchOnenoteQuickLaunch()
         ' Launch Microsoft OneNote Quick Launcher. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "ONENOTEM.EXE"
         exeFriendlyName = "Microsoft OneNote Quick Launch"
         isolated_error_handler.launcherErrorHandler("ONENOTEM.EXE")
     End Sub
@@ -137,7 +124,6 @@ Public Class LaunchApp
 #Region "Office Language Preferences Launcher Code."
     Public Shared Sub LaunchOfficeLangPrefs()
         ' Launch Office Language Preferences. Try...Catch code source here: <http://www.homeandlearn.co.uk/NET/nets5p4.html>
-        'exeName = "SETLANG.EXE"
         exeFriendlyName = "Office Language Preferences"
         isolated_error_handler.launcherErrorHandler("SETLANG.EXE")
     End Sub

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -27,7 +27,7 @@
 
 
 Public Class isolated_error_handler
-    Public Shared Sub launcherErrorHandler(Optional launcherErrorHandler_ExeName As String = "SETLANG.EXE", Optional launcherErrorHandler_ExeFriendlyName As String = "Office Language Preferences")
+    Public Shared Sub launcherErrorHandler(Optional launcherErrorHandler_ExeName As String = "dummy.exe", Optional launcherErrorHandler_ExeFriendlyName As String = "dummy string")
         Try
             Process.Start(OfficeLocater.fullLauncherCodeString & launcherErrorHandler_ExeName)
         Catch ex As System.ComponentModel.Win32Exception

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -27,9 +27,9 @@
 
 
 Public Class isolated_error_handler
-    Public Shared Sub launcherErrorHandler()
+    Public Shared Sub launcherErrorHandler(Optional localExeName As String = "SETLANG.EXE")
         Try
-            Process.Start(OfficeLocater.fullLauncherCodeString & LaunchApp.exeName)
+            Process.Start(OfficeLocater.fullLauncherCodeString & localExeName)
         Catch ex As System.ComponentModel.Win32Exception
             ' If Microsoft Access isn't found in the folder the user chose in the Options window, ask them if they want to
             ' go to the Options window to change it.

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -27,13 +27,13 @@
 
 
 Public Class isolated_error_handler
-    Public Shared Sub launcherErrorHandler(Optional localExeName As String = "SETLANG.EXE", Optional localExeFriendlyName As String = "Office Language Preferences")
+    Public Shared Sub launcherErrorHandler(Optional launcherErrorHandler_ExeName As String = "SETLANG.EXE", Optional launcherErrorHandler_ExeFriendlyName As String = "Office Language Preferences")
         Try
-            Process.Start(OfficeLocater.fullLauncherCodeString & localExeName)
+            Process.Start(OfficeLocater.fullLauncherCodeString & launcherErrorHandler_ExeName)
         Catch ex As System.ComponentModel.Win32Exception
             ' If Microsoft Access isn't found in the folder the user chose in the Options window, ask them if they want to
             ' go to the Options window to change it.
-            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & localExeFriendlyName & " in the location specified in the Options window." &
+            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & launcherErrorHandler_ExeFriendlyName & " in the location specified in the Options window." &
             " Would you like to open the Options window to change your settings?" & vbCrLf &
                 "" & vbCrLf &
                 "Full error message: " & ex.Message, "Couldn't find file",

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -27,13 +27,13 @@
 
 
 Public Class isolated_error_handler
-    Public Shared Sub launcherErrorHandler(Optional localExeName As String = "SETLANG.EXE")
+    Public Shared Sub launcherErrorHandler(Optional localExeName As String = "SETLANG.EXE", Optional localExeFriendlyName As String = "Office Language Preferences")
         Try
             Process.Start(OfficeLocater.fullLauncherCodeString & localExeName)
         Catch ex As System.ComponentModel.Win32Exception
             ' If Microsoft Access isn't found in the folder the user chose in the Options window, ask them if they want to
             ' go to the Options window to change it.
-            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & LaunchApp.exeFriendlyName & " in the location specified in the Options window." &
+            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & localExeFriendlyName & " in the location specified in the Options window." &
             " Would you like to open the Options window to change your settings?" & vbCrLf &
                 "" & vbCrLf &
                 "Full error message: " & ex.Message, "Couldn't find file",

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -27,7 +27,7 @@
 
 
 Public Class isolated_error_handler
-    Public Shared Sub launcherErrorHandler(Optional launcherErrorHandler_ExeName As String = "dummy.exe", Optional launcherErrorHandler_ExeFriendlyName As String = "dummy string")
+    Public Shared Sub launcherErrorHandler(Optional launcherErrorHandler_ExeName As String = "ExeToLaunch.exe", Optional launcherErrorHandler_ExeFriendlyName As String = "Application Name Here")
         Try
             Process.Start(OfficeLocater.fullLauncherCodeString & launcherErrorHandler_ExeName)
         Catch ex As System.ComponentModel.Win32Exception


### PR DESCRIPTION
The reason that this is better is that, by doing it this way, extra strings wouldn't have to be set while also making sure that the strings don't get changed by accident when trying to launch an app.