### PR TITLE
Allow theme engine debug output to be hidden.

### DIFF
--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -42,7 +42,7 @@
         <value>True</value>
       </setting>
       <setting name="debugmodeShowThemeEngineOutput" serializeAs="String">
-        <value>False</value>
+        <value>True</value>
       </setting>
     </UXL_Launcher.My.MySettings>
   </userSettings>

--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -41,6 +41,9 @@
       <setting name="enableThemeEngine" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="debugmodeShowThemeEngineOutput" serializeAs="String">
+        <value>False</value>
+      </setting>
     </UXL_Launcher.My.MySettings>
   </userSettings>
   <system.web>

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -164,7 +164,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
         Public Property debugmodeShowThemeEngineOutput() As Boolean
             Get
                 Return CType(Me("debugmodeShowThemeEngineOutput"),Boolean)

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -161,6 +161,18 @@ Namespace My
                 Me("enableThemeEngine") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property debugmodeShowThemeEngineOutput() As Boolean
+            Get
+                Return CType(Me("debugmodeShowThemeEngineOutput"),Boolean)
+            End Get
+            Set
+                Me("debugmodeShowThemeEngineOutput") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -30,7 +30,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="debugmodeShowThemeEngineOutput" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="enableThemeEngine" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="debugmodeShowThemeEngineOutput" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -564,12 +564,14 @@ Public Class UXLLauncher_ThemeEngine
         End If
 
         ' After this is all done, we then write the settingsThemeName string and the actual XML document
-        ' containing the theme to the Debugger.
-        Debug.WriteLine("Theme name in config file:")
-        Debug.WriteLine(settingsThemeName)
-        Debug.WriteLine("")
-        Debug.WriteLine("Theme XML Document:")
-        Debug.WriteLine(userTheme)
+        ' containing the theme to the Debugger, if debug labels are showing.
+        If My.Settings.debugmodeShowLabels = True Then
+            Debug.WriteLine("Theme name in config file:")
+            Debug.WriteLine(settingsThemeName)
+            Debug.WriteLine("")
+            Debug.WriteLine("Theme XML Document:")
+            Debug.WriteLine(userTheme)
+        End If
 
         ' Apply the theme.
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme()

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -564,7 +564,7 @@ Public Class UXLLauncher_ThemeEngine
         End If
 
         ' After this is all done, we then write the settingsThemeName string and the actual XML document
-        ' containing the theme to the Debugger, if debug labels are showing.
+        ' containing the theme to the Debugger, if theme output is enabled.
         If My.Settings.debugmodeShowThemeEngineOutput = True Then
             Debug.WriteLine("Theme name in config file:")
             Debug.WriteLine(settingsThemeName)

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -565,7 +565,7 @@ Public Class UXLLauncher_ThemeEngine
 
         ' After this is all done, we then write the settingsThemeName string and the actual XML document
         ' containing the theme to the Debugger, if debug labels are showing.
-        If My.Settings.debugmodeShowLabels = True Then
+        If My.Settings.debugmodeShowThemeEngineOutput = True Then
             Debug.WriteLine("Theme name in config file:")
             Debug.WriteLine(settingsThemeName)
             Debug.WriteLine("")


### PR DESCRIPTION
This is done with My.Settings.debugmodeShowThemeEngineOutput.

When set to True, the Visual Studio Immediate Window will show both the name of the user's chosen theme as well as the theme file being used. If set to False, no theme engine debug output will show.

Eventually, I would like to implement a debug output window for UXL Launcher that allows the user to view the information I currently place into the Immediate Window, including theme engine debug info. When that window is implemented, the debug info will also be placed into that window in addition to the Immediate Window.

When UXL Launcher 3.1 is released, My.Settings.debugmodeShowThemeEngineOutput will be set to False since most users don't need to debug the theme engine.