### PR TITLE
Allow the user to enable or disable a "Hide When Minimized" option.

### DIFF
--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -44,6 +44,9 @@
       <setting name="debugmodeShowThemeEngineOutput" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="hideWhenMinimized" serializeAs="String">
+        <value>False</value>
+      </setting>
     </UXL_Launcher.My.MySettings>
   </userSettings>
   <system.web>

--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -45,7 +45,7 @@
         <value>True</value>
       </setting>
       <setting name="hideWhenMinimized" serializeAs="String">
-        <value>False</value>
+        <value>True</value>
       </setting>
     </UXL_Launcher.My.MySettings>
   </userSettings>

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -103,6 +103,7 @@ Partial Class aaformMainWindow
         Me.pictureClipOrganizerIcon = New System.Windows.Forms.PictureBox()
         Me.buttonRunClipOrganizer = New System.Windows.Forms.Button()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
+        Me.menubarHideWhenMinimizedButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -153,7 +154,7 @@ Partial Class aaformMainWindow
         '
         'menubarViewMenu
         '
-        Me.menubarViewMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarAlwaysOnTopButton, Me.menubarRevertThemeButton})
+        Me.menubarViewMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarAlwaysOnTopButton, Me.menubarHideWhenMinimizedButton, Me.menubarRevertThemeButton})
         Me.menubarViewMenu.Name = "menubarViewMenu"
         Me.menubarViewMenu.Size = New System.Drawing.Size(44, 19)
         Me.menubarViewMenu.Text = "&View"
@@ -871,6 +872,12 @@ Partial Class aaformMainWindow
         Me.notifyiconTaskbarLaunchers.Text = "UXL Launcher Quickmenu"
         Me.notifyiconTaskbarLaunchers.Visible = True
         '
+        'menubarHideWhenMinimizedButton
+        '
+        Me.menubarHideWhenMinimizedButton.Name = "menubarHideWhenMinimizedButton"
+        Me.menubarHideWhenMinimizedButton.Size = New System.Drawing.Size(242, 22)
+        Me.menubarHideWhenMinimizedButton.Text = "&Hide When Minimized"
+        '
         'aaformMainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -994,4 +1001,5 @@ Partial Class aaformMainWindow
     Friend WithEvents debugLabelXmlThemeTitle As Label
     Friend WithEvents debugLabelXmlThemeAuthor As Label
     Friend WithEvents menubarRevertThemeButton As ToolStripMenuItem
+    Friend WithEvents menubarHideWhenMinimizedButton As ToolStripMenuItem
 End Class

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -29,6 +29,7 @@ Partial Class aaformMainWindow
         Me.menubarExitButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarViewMenu = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarAlwaysOnTopButton = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menubarHideWhenMinimizedButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarRevertThemeButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarToolsMenu = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarOfficeLangPrefsButton = New System.Windows.Forms.ToolStripMenuItem()
@@ -75,6 +76,7 @@ Partial Class aaformMainWindow
         Me.pictureExcelIcon = New System.Windows.Forms.PictureBox()
         Me.pictureWordIcon = New System.Windows.Forms.PictureBox()
         Me.groupboxProApps = New System.Windows.Forms.GroupBox()
+        Me.debugLabelXmlThemeUseThemeEngineVersion = New System.Windows.Forms.Label()
         Me.debugLabelXmlThemeAuthor = New System.Windows.Forms.Label()
         Me.debugLabelXmlThemeTitle = New System.Windows.Forms.Label()
         Me.debugLabelXmlThemeDescription = New System.Windows.Forms.Label()
@@ -83,7 +85,6 @@ Partial Class aaformMainWindow
         Me.debugLabelForuserOfficeVersion = New System.Windows.Forms.Label()
         Me.debugLabelForofficeInstallMethodString = New System.Windows.Forms.Label()
         Me.debugLabelForcpuTypeString = New System.Windows.Forms.Label()
-        Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.buttonRunSharePointWkSp = New System.Windows.Forms.Button()
         Me.buttonRunAccess = New System.Windows.Forms.Button()
         Me.buttonRunInfoPath = New System.Windows.Forms.Button()
@@ -102,8 +103,8 @@ Partial Class aaformMainWindow
         Me.picturePictureManagerIcon = New System.Windows.Forms.PictureBox()
         Me.pictureClipOrganizerIcon = New System.Windows.Forms.PictureBox()
         Me.buttonRunClipOrganizer = New System.Windows.Forms.Button()
+        Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
-        Me.menubarHideWhenMinimizedButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -165,6 +166,12 @@ Partial Class aaformMainWindow
         Me.menubarAlwaysOnTopButton.Name = "menubarAlwaysOnTopButton"
         Me.menubarAlwaysOnTopButton.Size = New System.Drawing.Size(242, 22)
         Me.menubarAlwaysOnTopButton.Text = "&Always On Top"
+        '
+        'menubarHideWhenMinimizedButton
+        '
+        Me.menubarHideWhenMinimizedButton.Name = "menubarHideWhenMinimizedButton"
+        Me.menubarHideWhenMinimizedButton.Size = New System.Drawing.Size(242, 22)
+        Me.menubarHideWhenMinimizedButton.Text = "&Hide When Minimized"
         '
         'menubarRevertThemeButton
         '
@@ -553,6 +560,7 @@ Partial Class aaformMainWindow
         'groupboxProApps
         '
         Me.groupboxProApps.BackColor = System.Drawing.Color.Transparent
+        Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
         Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeAuthor)
         Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeTitle)
         Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeDescription)
@@ -561,7 +569,6 @@ Partial Class aaformMainWindow
         Me.groupboxProApps.Controls.Add(Me.debugLabelForuserOfficeVersion)
         Me.groupboxProApps.Controls.Add(Me.debugLabelForofficeInstallMethodString)
         Me.groupboxProApps.Controls.Add(Me.debugLabelForcpuTypeString)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelForAlwaysOnTop)
         Me.groupboxProApps.Controls.Add(Me.buttonRunSharePointWkSp)
         Me.groupboxProApps.Controls.Add(Me.buttonRunAccess)
         Me.groupboxProApps.Controls.Add(Me.buttonRunInfoPath)
@@ -578,6 +585,15 @@ Partial Class aaformMainWindow
         Me.groupboxProApps.TabIndex = 1
         Me.groupboxProApps.TabStop = False
         Me.groupboxProApps.Text = "Professional Apps"
+        '
+        'debugLabelXmlThemeUseThemeEngineVersion
+        '
+        Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(4, 406)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(233, 13)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.TabIndex = 26
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Text = "debugLabelXmlThemeUseThemeEngineVersion"
         '
         'debugLabelXmlThemeAuthor
         '
@@ -654,16 +670,6 @@ Partial Class aaformMainWindow
         Me.debugLabelForcpuTypeString.Size = New System.Drawing.Size(147, 13)
         Me.debugLabelForcpuTypeString.TabIndex = 18
         Me.debugLabelForcpuTypeString.Text = "debugLabelForcpuTypeString"
-        '
-        'debugLabelForAlwaysOnTop
-        '
-        Me.debugLabelForAlwaysOnTop.AutoSize = True
-        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(4, 418)
-        Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
-        Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(167, 26)
-        Me.debugLabelForAlwaysOnTop.TabIndex = 10
-        Me.debugLabelForAlwaysOnTop.Text = "This debug label shows the status" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "of the Always On Top feature."
         '
         'buttonRunSharePointWkSp
         '
@@ -762,6 +768,7 @@ Partial Class aaformMainWindow
         Me.groupboxExtraApps.Controls.Add(Me.picturePictureManagerIcon)
         Me.groupboxExtraApps.Controls.Add(Me.pictureClipOrganizerIcon)
         Me.groupboxExtraApps.Controls.Add(Me.buttonRunClipOrganizer)
+        Me.groupboxExtraApps.Controls.Add(Me.debugLabelForAlwaysOnTop)
         Me.groupboxExtraApps.Location = New System.Drawing.Point(432, 2)
         Me.groupboxExtraApps.Margin = New System.Windows.Forms.Padding(16, 2, 2, 2)
         Me.groupboxExtraApps.Name = "groupboxExtraApps"
@@ -865,18 +872,22 @@ Partial Class aaformMainWindow
         Me.buttonRunClipOrganizer.Text = "Microsoft Clip Organizer"
         Me.buttonRunClipOrganizer.UseVisualStyleBackColor = True
         '
+        'debugLabelForAlwaysOnTop
+        '
+        Me.debugLabelForAlwaysOnTop.AutoSize = True
+        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(4, 368)
+        Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
+        Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(167, 26)
+        Me.debugLabelForAlwaysOnTop.TabIndex = 10
+        Me.debugLabelForAlwaysOnTop.Text = "This debug label shows the status" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "of the Always On Top feature."
+        '
         'notifyiconTaskbarLaunchers
         '
         Me.notifyiconTaskbarLaunchers.ContextMenuStrip = Me.contextmenuNotifyicon
         Me.notifyiconTaskbarLaunchers.Icon = CType(resources.GetObject("notifyiconTaskbarLaunchers.Icon"), System.Drawing.Icon)
         Me.notifyiconTaskbarLaunchers.Text = "UXL Launcher Quickmenu"
         Me.notifyiconTaskbarLaunchers.Visible = True
-        '
-        'menubarHideWhenMinimizedButton
-        '
-        Me.menubarHideWhenMinimizedButton.Name = "menubarHideWhenMinimizedButton"
-        Me.menubarHideWhenMinimizedButton.Size = New System.Drawing.Size(242, 22)
-        Me.menubarHideWhenMinimizedButton.Text = "&Hide When Minimized"
         '
         'aaformMainWindow
         '
@@ -1002,4 +1013,5 @@ Partial Class aaformMainWindow
     Friend WithEvents debugLabelXmlThemeAuthor As Label
     Friend WithEvents menubarRevertThemeButton As ToolStripMenuItem
     Friend WithEvents menubarHideWhenMinimizedButton As ToolStripMenuItem
+    Friend WithEvents debugLabelXmlThemeUseThemeEngineVersion As Label
 End Class

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -105,6 +105,7 @@ Partial Class aaformMainWindow
         Me.buttonRunClipOrganizer = New System.Windows.Forms.Button()
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
+        Me.notifyiconShowApp = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -169,12 +170,14 @@ Partial Class aaformMainWindow
         '
         'menubarHideWhenMinimizedButton
         '
+        Me.menubarHideWhenMinimizedButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarHideWhenMinimizedButton.Name = "menubarHideWhenMinimizedButton"
         Me.menubarHideWhenMinimizedButton.Size = New System.Drawing.Size(242, 22)
         Me.menubarHideWhenMinimizedButton.Text = "&Hide When Minimized"
         '
         'menubarRevertThemeButton
         '
+        Me.menubarRevertThemeButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarRevertThemeButton.Name = "menubarRevertThemeButton"
         Me.menubarRevertThemeButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.D0), System.Windows.Forms.Keys)
         Me.menubarRevertThemeButton.Size = New System.Drawing.Size(242, 22)
@@ -250,10 +253,10 @@ Partial Class aaformMainWindow
         'contextmenuNotifyicon
         '
         Me.contextmenuNotifyicon.ImageScalingSize = New System.Drawing.Size(32, 32)
-        Me.contextmenuNotifyicon.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.notifyiconWord, Me.notifyiconExcel, Me.notifyiconPowerpoint, Me.notifyiconOutlook, Me.notifyiconOnenote, Me.notifyiconSeparator1, Me.notifyiconAccess, Me.notifyiconPublisher, Me.notifyiconInfopath, Me.notifyiconSharepointWkSp, Me.notifyiconSeparator2, Me.notifyiconOfficeLang, Me.notifyiconUXLOptions, Me.notifyiconSeparator3, Me.notifyiconExitApp})
+        Me.contextmenuNotifyicon.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.notifyiconWord, Me.notifyiconExcel, Me.notifyiconPowerpoint, Me.notifyiconOutlook, Me.notifyiconOnenote, Me.notifyiconSeparator1, Me.notifyiconAccess, Me.notifyiconPublisher, Me.notifyiconInfopath, Me.notifyiconSharepointWkSp, Me.notifyiconSeparator2, Me.notifyiconOfficeLang, Me.notifyiconUXLOptions, Me.notifyiconSeparator3, Me.notifyiconShowApp, Me.notifyiconExitApp})
         Me.contextmenuNotifyicon.Name = "contextmenuNotifyicon"
         Me.contextmenuNotifyicon.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
-        Me.contextmenuNotifyicon.Size = New System.Drawing.Size(255, 382)
+        Me.contextmenuNotifyicon.Size = New System.Drawing.Size(255, 434)
         '
         'notifyiconWord
         '
@@ -889,6 +892,12 @@ Partial Class aaformMainWindow
         Me.notifyiconTaskbarLaunchers.Text = "UXL Launcher Quickmenu"
         Me.notifyiconTaskbarLaunchers.Visible = True
         '
+        'notifyiconShowApp
+        '
+        Me.notifyiconShowApp.Name = "notifyiconShowApp"
+        Me.notifyiconShowApp.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconShowApp.Text = "Show UXL Launcher"
+        '
         'aaformMainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -1014,4 +1023,5 @@ Partial Class aaformMainWindow
     Friend WithEvents menubarRevertThemeButton As ToolStripMenuItem
     Friend WithEvents menubarHideWhenMinimizedButton As ToolStripMenuItem
     Friend WithEvents debugLabelXmlThemeUseThemeEngineVersion As Label
+    Friend WithEvents notifyiconShowApp As ToolStripMenuItem
 End Class

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -589,7 +589,7 @@ Partial Class aaformMainWindow
         'debugLabelXmlThemeUseThemeEngineVersion
         '
         Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(4, 406)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(4, 407)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
         Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(233, 13)
         Me.debugLabelXmlThemeUseThemeEngineVersion.TabIndex = 26
@@ -598,7 +598,7 @@ Partial Class aaformMainWindow
         'debugLabelXmlThemeAuthor
         '
         Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(4, 393)
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(4, 394)
         Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
         Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(144, 13)
@@ -626,7 +626,7 @@ Partial Class aaformMainWindow
         'debugLabelForMSIInstall
         '
         Me.debugLabelForMSIInstall.AutoSize = True
-        Me.debugLabelForMSIInstall.Location = New System.Drawing.Point(4, 341)
+        Me.debugLabelForMSIInstall.Location = New System.Drawing.Point(4, 342)
         Me.debugLabelForMSIInstall.Name = "debugLabelForMSIInstall"
         Me.debugLabelForMSIInstall.Size = New System.Drawing.Size(124, 13)
         Me.debugLabelForMSIInstall.TabIndex = 22
@@ -645,7 +645,7 @@ Partial Class aaformMainWindow
         'debugLabelForuserOfficeVersion
         '
         Me.debugLabelForuserOfficeVersion.AutoSize = True
-        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(4, 328)
+        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(4, 329)
         Me.debugLabelForuserOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForuserOfficeVersion.Name = "debugLabelForuserOfficeVersion"
         Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(161, 13)
@@ -655,7 +655,7 @@ Partial Class aaformMainWindow
         'debugLabelForofficeInstallMethodString
         '
         Me.debugLabelForofficeInstallMethodString.AutoSize = True
-        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(4, 302)
+        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(4, 303)
         Me.debugLabelForofficeInstallMethodString.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeInstallMethodString.Name = "debugLabelForofficeInstallMethodString"
         Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(167, 26)

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -78,24 +78,41 @@ Public Class aaformMainWindow
         debugmodeStuff.updateDebugLabels()
 #End Region
 
-#Region "Main form loading code for Always On Top menubar button."
+#Region "Main form loading code for Always On Top menubar button and window properties."
 
-        ' See if the Always On Top setting is set to true and if it is, then set
-        ' the window to be on top of other windows.
+        ' See if the Always On Top setting is set to true and if it is,
+        ' then set the window to be on top of other windows
+        ' and check the checkbox in the "Always On Top" menubar button.
 
         If My.Settings.alwaysOnTop = True Then
             Me.TopMost = True
             menubarAlwaysOnTopButton.CheckState = CheckState.Checked
             debugmodeStuff.updateDebugLabels()
 
-            ' But if the Always On Top setting is false, then set the window to not
-            ' be on top of other windows.
+            ' But if the Always On Top setting is false, then set the window
+            ' to not be on top of other windows.
 
         ElseIf My.Settings.alwaysOnTop = False Then
             Me.TopMost = False
             menubarAlwaysOnTopButton.CheckState = CheckState.Unchecked
             debugmodeStuff.updateDebugLabels()
         End If
+#End Region
+
+#Region "Main form loading code for Hide When Minimized menubar button."
+
+        ' See if the Hide When Minimized setting is set to true and if it is,
+        ' check the checkbox in the "Hide When Minimized" menubar button.
+
+        If My.Settings.hideWhenMinimized = True Then
+            menubarHideWhenMinimizedButton.CheckState = CheckState.Checked
+
+            ' Otherwise, if it's false, make the "Hide When Minimized" checkbox
+            ' be unchecked.
+        ElseIf My.Settings.hideWhenMinimized = False Then
+            menubarHideWhenMinimizedButton.CheckState = CheckState.Unchecked
+        End If
+
 #End Region
         ' End of Form1_Load sub.
     End Sub

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -97,9 +97,33 @@ Public Class aaformMainWindow
             debugmodeStuff.updateDebugLabels()
         End If
 #End Region
+        ' End of Form1_Load sub.
+    End Sub
+
+#Region "Hide when minimized code."
+    Private Sub aaformMainWindow_Resize(sender As Object, e As EventArgs) Handles Me.Resize
+        ' If the user has "Hide When Minimized" enabled, hide the window when they minimize it.
+        ' Code based on this sample code: 
+        ' https://www.aspsnippets.com/Articles/Minimize-Windows-Forms-WinForms-Application-to-System-Tray-using-C-And-VBNet.aspx
+
+        If My.Settings.hideWhenMinimized = True Then
+            If WindowState = FormWindowState.Minimized Then
+                ShowInTaskbar = False
+            End If
+        End If
 
     End Sub
 
+    Private Sub notifyiconTaskbarLaunchers_DoubleClick(sender As Object, e As EventArgs) Handles notifyiconTaskbarLaunchers.DoubleClick
+        ' When the user double-clicks on the notification icon, show the main window again.
+        ' Code based on this sample code:
+        ' https://www.aspsnippets.com/Articles/Minimize-Windows-Forms-WinForms-Application-to-System-Tray-using-C-And-VBNet.aspx
+
+        ShowInTaskbar = True
+        WindowState = FormWindowState.Normal
+
+    End Sub
+#End Region
 
 #Region "Menubar code, including menubar buttons."
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -231,6 +231,35 @@ Public Class aaformMainWindow
 
     End Sub
 #End Region
+
+#Region "Hide When Minimized menubar button checkbox and stuff."
+    Private Sub menubarHideWhenMinimizedButton_Click(sender As Object, e As EventArgs) Handles menubarHideWhenMinimizedButton.Click
+        ' When the user clicks on the Hide When Minimized menubar button, the following code will run.
+        ' First, the app will see if the Hide When Minimized menubar button is unchecked, then it will
+        ' check the box for that button.
+        ' Then, the app will check to see what My.Settings.hideWhenMinimized is set to. If it's set to
+        ' False, then the app will set it to True, and the other way if it's set to True.
+        ' After that, My.Settings will be saved.
+
+        If menubarHideWhenMinimizedButton.CheckState = CheckState.Unchecked Then
+            menubarHideWhenMinimizedButton.CheckState = CheckState.Checked
+            If My.Settings.hideWhenMinimized = False Then
+                My.Settings.hideWhenMinimized = True
+            End If
+            My.Settings.Save()
+            My.Settings.Reload()
+
+        ElseIf menubarHideWhenMinimizedButton.CheckState = CheckState.Checked Then
+            menubarHideWhenMinimizedButton.CheckState = CheckState.Unchecked
+            If My.Settings.hideWhenMinimized = True Then
+                My.Settings.hideWhenMinimized = False
+            End If
+            My.Settings.Save()
+            My.Settings.Reload()
+
+        End If
+    End Sub
+#End Region
 #End Region
 
 #Region "App Launcher Code."

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -357,6 +357,16 @@ Public Class aaformMainWindow
         Me.Close()
     End Sub
 
+    Private Sub notifyiconShowApp_Click(sender As Object, e As EventArgs) Handles notifyiconShowApp.Click
+        ' Show UXL Launcher. Useful if "Hide When Minimized" is enabled.
+        ' When the user clicks the "Show UXL Launcher" menu entry, show the main window again.
+        ' Code based on this sample code:
+        ' https://www.aspsnippets.com/Articles/Minimize-Windows-Forms-WinForms-Application-to-System-Tray-using-C-And-VBNet.aspx
+
+        ShowInTaskbar = True
+        WindowState = FormWindowState.Normal
+    End Sub
+
     Private Sub notifyiconUXLOptions_Click(sender As Object, e As EventArgs) Handles notifyiconUXLOptions.Click
         ' Open the Options window. Credit goes to this SO answer: <http://stackoverflow.com/a/2513186>
         Dim forceOptionsWindowTab As New aaformOptionsWindow

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -173,6 +173,18 @@ Namespace My
                 Me("debugmodeShowThemeEngineOutput") = value
             End Set
         End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+        Public Property hideWhenMinimized() As Boolean
+            Get
+                Return CType(Me("hideWhenMinimized"),Boolean)
+            End Get
+            Set
+                Me("hideWhenMinimized") = value
+            End Set
+        End Property
     End Class
 End Namespace
 

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -176,7 +176,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
         Public Property hideWhenMinimized() As Boolean
             Get
                 Return CType(Me("hideWhenMinimized"),Boolean)

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -33,7 +33,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="hideWhenMinimized" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
+      <Value Profile="(Default)">True</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -32,5 +32,8 @@
     <Setting Name="debugmodeShowThemeEngineOutput" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="hideWhenMinimized" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -89,11 +89,11 @@ Public Class debugmodeStuff
         aaformMainWindow.debugTextboxForFullLauncherCodeString.Text = OfficeLocater.fullLauncherCodeString
 
         ' Debug labels for theme titles and descriptions.
-        aaformMainWindow.debugLabelXmlThemeTitle.Text = UXLLauncher_ThemeEngine.themeSheetTitle
-        aaformMainWindow.debugLabelXmlThemeDescription.Text = UXLLauncher_ThemeEngine.themeSheetDescription
-        aaformMainWindow.debugLabelXmlThemeAuthor.Text = UXLLauncher_ThemeEngine.themeSheetAuthor
-        aaformMainWindow.debugLabelXmlThemeAuthor.Text = aaformMainWindow.debugLabelXmlThemeAuthor.Text & vbCrLf & "UseThemeEngineVersion string:" &
-            vbCrLf & UXLLauncher_ThemeEngine.themeSheetUseThemeEngineVersion
+        aaformMainWindow.debugLabelXmlThemeTitle.Text = "Title string: " & UXLLauncher_ThemeEngine.themeSheetTitle
+        aaformMainWindow.debugLabelXmlThemeDescription.Text = "Description string: " & UXLLauncher_ThemeEngine.themeSheetDescription
+        aaformMainWindow.debugLabelXmlThemeAuthor.Text = "Author string: " & UXLLauncher_ThemeEngine.themeSheetAuthor
+        aaformMainWindow.debugLabelXmlThemeUseThemeEngineVersion.Text = "UseThemeEngineVersion string: " &
+            CType(UXLLauncher_ThemeEngine.themeSheetUseThemeEngineVersion, String)
 
     End Sub
 

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -98,6 +98,8 @@ Public Class debugmodeStuff
     End Sub
 
     Public Shared Sub outputThemeVersionToUse(themeVersionToUse As Decimal)
+        ' Show theme engine version that the theme wants to use in the Immediate Window
+        ' if the proper setting is enabled.
         If My.Settings.debugmodeShowThemeEngineOutput = True Then
             Debug.WriteLine("")
             Debug.WriteLine("UseThemeEngineVersion string:")


### PR DESCRIPTION
This feature is located in "View>Hide When Minimized" and is stored in My.Settings.hideWhenMinimized. When the user minimizes UXL Launcher with this option enabled, the main window will be hidden from the taskbar. To bring the window back, the user can either:

1. Double-click on the "UXL Launcher Quickmenu" icon in the system tray.

or

2. Right-click on the "UXL Launcher Quickmenu" icon in the system tray, then click "Show UXL Launcher" in the resulting menu.

Either way the user chooses to bring the window back will keep their preference for "Hide When Minimized".

Known issues: If the user hides UXL Launcher with "Hide When Minimized" enabled, the application will still appear in the Windows Alt+Tab menu. Tabbing over to UXL Launcher will cause the main window to show up as expected, but there won't be a taskbar entry for it. If it's minimized in this state, it'll minimize to a small window near the Start button with a titlebar, Restore, and Close buttons. To get out of this state, simply use one of the two methods outlined above to show the main window again.


This pull request also contains some debugging-related code cleanup. This is mostly evident in the fact that some debugging labels are now spaced out better from others below or above them, along with one line of code being deleted since it was unnecessary.

Additionally, the debugging label for "Always On Top" has been moved to the right-most column. 

In the middle column, the theme-related debug labels now have descriptions for what each of the labels are for. For example, the debug label for the title found in the theme file now has the text "Title string: " before the theme's title text.