### PR TITLE
UXL Launcher Theme Engine can now use different colors for the menubar BackColor and MenuItem BackColor. Also includes custom image margin gradients.

### DIFF
--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -37,7 +37,7 @@
         <value>True</value>
       </setting>
       <setting name="userChosenTheme" serializeAs="String">
-        <value>TestTheme</value>
+        <value>(Custom)</value>
       </setting>
       <setting name="enableThemeEngine" serializeAs="String">
         <value>True</value>

--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -37,7 +37,7 @@
         <value>True</value>
       </setting>
       <setting name="userChosenTheme" serializeAs="String">
-        <value>Maudern</value>
+        <value>TestTheme</value>
       </setting>
       <setting name="enableThemeEngine" serializeAs="String">
         <value>True</value>

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -140,7 +140,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("Maudern")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("TestTheme")>  _
         Public Property userChosenTheme() As String
             Get
                 Return CType(Me("userChosenTheme"),String)

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -140,7 +140,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("TestTheme")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("(Custom)")>  _
         Public Property userChosenTheme() As String
             Get
                 Return CType(Me("userChosenTheme"),String)

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -24,7 +24,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="userChosenTheme" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Maudern</Value>
+      <Value Profile="(Default)">TestTheme</Value>
     </Setting>
     <Setting Name="enableThemeEngine" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -24,7 +24,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="userChosenTheme" Type="System.String" Scope="User">
-      <Value Profile="(Default)">TestTheme</Value>
+      <Value Profile="(Default)">(Custom)</Value>
     </Setting>
     <Setting Name="enableThemeEngine" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>

--- a/UXL-Launcher/VB Code-behind/Themes/DefaultTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/DefaultTheme_XML.xml
@@ -47,6 +47,10 @@
         <ForeColor>ControlText</ForeColor>
       </MenuItem>
 
+      <MenuBar>
+        <BackColor>Control</BackColor>
+      </MenuBar>
+      
       <StatusLabel>
         <BackColor>Transparent</BackColor>
         <ForeColor>ControlText</ForeColor>

--- a/UXL-Launcher/VB Code-behind/Themes/DefaultTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/DefaultTheme_XML.xml
@@ -45,6 +45,10 @@
         Default theme uses.-->
         <BackColor>Window</BackColor>
         <ForeColor>ControlText</ForeColor>
+        <ImageMarginGradient>
+          <StartColor>0xFCFCFC</StartColor>
+          <EndColor>0xF1F1F1</EndColor>
+        </ImageMarginGradient>
       </MenuItem>
 
       <MenuBar>

--- a/UXL-Launcher/VB Code-behind/Themes/TestTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/TestTheme_XML.xml
@@ -43,7 +43,7 @@
         Basically, if MenuItem BackColor has an XML element, MenuBar BackColor is set
         to the same thing as MenuItem BackColor, otherwise it's set to the value the
         Default theme uses.-->
-        <BackColor>Purple</BackColor>
+        <BackColor>Teal</BackColor>
         <ForeColor>AntiqueWhite</ForeColor>
         <ImageMarginGradient>
           <StartColor>Red</StartColor>

--- a/UXL-Launcher/VB Code-behind/Themes/TestTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/TestTheme_XML.xml
@@ -45,11 +45,15 @@
         Default theme uses.-->
         <BackColor>Purple</BackColor>
         <ForeColor>AntiqueWhite</ForeColor>
+        <ImageMarginGradient>
+          <StartColor>Red</StartColor>
+          <EndColor>Blue</EndColor>
+        </ImageMarginGradient>
       </MenuItem>
       
       <MenuBar>
         <BackColor>Purple</BackColor>
-        </MenuBar>
+      </MenuBar>
 
       <StatusLabel>
         <BackColor>Maroon</BackColor>

--- a/UXL-Launcher/VB Code-behind/Themes/TestTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/TestTheme_XML.xml
@@ -46,6 +46,10 @@
         <BackColor>Purple</BackColor>
         <ForeColor>AntiqueWhite</ForeColor>
       </MenuItem>
+      
+      <MenuBar>
+        <BackColor>Purple</BackColor>
+        </MenuBar>
 
       <StatusLabel>
         <BackColor>Maroon</BackColor>

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -452,7 +452,7 @@ Public Class UXLLauncher_ThemeEngine
 #End Region
 
 #Region "MenuBar BackColor"
-        ' Only pull the MenuItem BackColor element from XML if it exists.
+        ' Only pull the MenuBar BackColor element from XML if it exists.
         If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuBar/BackColor[1]", themeNamespaceManager) IsNot Nothing Then
             Try
                 colorMenubarBackColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuBar/BackColor[1]", themeNamespaceManager).InnerText)

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -435,7 +435,7 @@ Public Class UXLLauncher_ThemeEngine
         End If
 #End Region
 #Region "End color"
-        ' Only pull the MenuItem Image Margin Gradient Start Color element from XML if it exists.
+        ' Only pull the MenuItem Image Margin Gradient End Color element from XML if it exists.
         If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/EndColor[1]", themeNamespaceManager) IsNot Nothing Then
             Try
                 colorMenuItemImageMarginGradientEndColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/EndColor[1]", themeNamespaceManager).InnerText)

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -698,6 +698,8 @@ Public Class UXLLauncher_ThemeEngine
         aaformMainWindow.UXLToolstripRenderer.BackColor = colorMenubarBackColor
         aaformMainWindow.UXLToolstripRenderer.ForeColor = colorMenuItemForeColor
         aaformMainWindow.UXLToolstripRenderer.DropdownBackColor = colorMenuItemBackColor
+        aaformMainWindow.UXLToolstripRenderer.ImageMarginGradientStartColor = colorMenuItemImageMarginGradientStartColor
+        aaformMainWindow.UXLToolstripRenderer.ImageMarginGradientEndColor = colorMenuItemImageMarginGradientEndColor
         aaformMainWindow.UXLToolstripRenderer.TextHighlightColor = Color.FromKnownColor(KnownColor.ControlText)
 
 #End Region
@@ -1019,6 +1021,8 @@ Public Class uxlProToolstripRenderer
         Dim itembgcolor As New Rectangle(0, 0, e.ToolStrip.Width, e.ToolStrip.Height)
         ' Fill the background of the menuitem.
         e.Graphics.FillRectangle(dropdownBrush, itembgcolor)
+        ' Fill the item image margin gradient.
+        e.Graphics.FillRectangle(ImageMarginGradientBrush, e.AffectedBounds)
     End Sub
 
     ' Change the colors for the menubar text.

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -419,19 +419,34 @@ Public Class UXLLauncher_ThemeEngine
 #End Region
 
 #Region "MenuItem Image margin background gradient"
-#Region "Color 1 (first color)"
-        ' Only pull the MenuItem BackColor element from XML if it exists.
+#Region "Start color"
+        ' Only pull the MenuItem Image Margin Gradient Start Color element from XML if it exists.
         If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/StartColor[1]", themeNamespaceManager) IsNot Nothing Then
             Try
-                colorMenuItemBackColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/BackColor[1]", themeNamespaceManager).InnerText)
+                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/StartColor[1]", themeNamespaceManager).InnerText)
                 debugmodeStuff.updateDebugLabels()
                 ' If the element isn't a valid HTML color, just replace it with the default.
             Catch ex As Exception
-                colorMenuItemBackColor = Color.FromKnownColor(KnownColor.Window)
+                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("FCFCFC")
             End Try
         Else
             ' If the element doesn't exist, overwrite it with the Default theme's value.
-            colorMenuItemBackColor = Color.FromKnownColor(KnownColor.Window)
+            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("FCFCFC")
+        End If
+#End Region
+#Region "End color"
+        ' Only pull the MenuItem Image Margin Gradient Start Color element from XML if it exists.
+        If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/EndColor[1]", themeNamespaceManager) IsNot Nothing Then
+            Try
+                colorMenuItemImageMarginGradientEndColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/EndColor[1]", themeNamespaceManager).InnerText)
+                debugmodeStuff.updateDebugLabels()
+                ' If the element isn't a valid HTML color, just replace it with the default.
+            Catch ex As Exception
+                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("F1F1F1")
+            End Try
+        Else
+            ' If the element doesn't exist, overwrite it with the Default theme's value.
+            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("F1F1F1")
         End If
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -1010,8 +1010,12 @@ Public Class uxlProToolstripRenderer
     ' http://www.vbforums.com/showthread.php?539578-Custom-VisualStudio2008-style-MenuStrip-and-ToolStrip-Renderer&p=3333808&viewfull=1#post3333808
     Protected Overrides Sub OnRenderImageMargin(e As ToolStripRenderEventArgs)
         MyBase.OnRenderImageMargin(e)
+        ' Colors and brushes for menuitem background color.
         Dim DropDownItemBackColor As Color = Me.DropdownBackColor
         Dim dropdownBrush As New SolidBrush(DropdownBackColor)
+        ' Colors and brushes for image margin gradiant.
+        Dim ImageMarginGradientBrush As New LinearGradientBrush(e.AffectedBounds, Me.ImageMarginGradientStartColor,
+                                                                Me.ImageMarginGradientEndColor, LinearGradientMode.Horizontal)
         ' Make the menuitem background set to the theme's color.
         Dim itembgcolor As New Rectangle(0, 0, e.ToolStrip.Width, e.ToolStrip.Height)
         ' Fill the background of the menuitem.

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -1005,8 +1005,7 @@ Public Class uxlProToolstripRenderer
     End Sub
 
     ' Change the color for the menubar dropdowns.
-    ' Based on the code from the "gray itembackground"
-    ' area here:
+    ' Based on the code "Step 3" here:
     ' http://www.vbforums.com/showthread.php?539578-Custom-VisualStudio2008-style-MenuStrip-and-ToolStrip-Renderer&p=3333808&viewfull=1#post3333808
     Protected Overrides Sub OnRenderImageMargin(e As ToolStripRenderEventArgs)
         MyBase.OnRenderImageMargin(e)

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -404,7 +404,6 @@ Public Class UXLLauncher_ThemeEngine
         If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/BackColor[1]", themeNamespaceManager) IsNot Nothing Then
             Try
                 colorMenuItemBackColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/BackColor[1]", themeNamespaceManager).InnerText)
-                colorMenubarBackColor = colorMenuItemBackColor
                 debugmodeStuff.updateDebugLabels()
                 ' If the element isn't a valid HTML color, just replace it with the default.
             Catch ex As Exception
@@ -413,6 +412,22 @@ Public Class UXLLauncher_ThemeEngine
         Else
             ' If the element doesn't exist, overwrite it with the Default theme's value.
             colorMenuItemBackColor = Color.FromKnownColor(KnownColor.Window)
+        End If
+#End Region
+
+#Region "MenuBar BackColor"
+        ' Only pull the MenuItem BackColor element from XML if it exists.
+        If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuBar/BackColor[1]", themeNamespaceManager) IsNot Nothing Then
+            Try
+                colorMenubarBackColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuBar/BackColor[1]", themeNamespaceManager).InnerText)
+                debugmodeStuff.updateDebugLabels()
+                ' If the element isn't a valid HTML color, just replace it with the default.
+            Catch ex As Exception
+                colorMenubarBackColor = Color.FromKnownColor(KnownColor.Control)
+            End Try
+        Else
+            ' If the element doesn't exist, overwrite it with the Default theme's value.
+            colorMenubarBackColor = Color.FromKnownColor(KnownColor.Control)
         End If
 #End Region
 
@@ -644,8 +659,9 @@ Public Class UXLLauncher_ThemeEngine
 #Region "Set colors for menubar entries."
 
         ' Set color for menubar.
-        aaformMainWindow.UXLToolstripRenderer.BackColor = colorMenuItemBackColor
+        aaformMainWindow.UXLToolstripRenderer.BackColor = colorMenubarBackColor
         aaformMainWindow.UXLToolstripRenderer.ForeColor = colorMenuItemForeColor
+        aaformMainWindow.UXLToolstripRenderer.DropdownBackColor = colorMenuItemBackColor
         aaformMainWindow.UXLToolstripRenderer.TextHighlightColor = Color.FromKnownColor(KnownColor.ControlText)
 
 #End Region
@@ -876,6 +892,8 @@ Public Class uxlProToolstripRenderer
     Inherits ToolStripProfessionalRenderer
 
     Private _BackColor As Color
+    ' "_DropdownBackColor" determines the colors in the menubar dropdown.
+    Private _DropdownBackColor As Color
     Private _ForeColor As Color
     Private _TextHighlightColor As Color
 
@@ -886,6 +904,16 @@ Public Class uxlProToolstripRenderer
         End Get
         Set(ByVal value As Color)
             _BackColor = value
+        End Set
+    End Property
+
+    ' Get and set the backcolor for menubar dropdown items.
+    Public Property DropdownBackColor As Color
+        Get
+            Return _DropdownBackColor
+        End Get
+        Set(ByVal value As Color)
+            _DropdownBackColor = value
         End Set
     End Property
 
@@ -913,13 +941,25 @@ Public Class uxlProToolstripRenderer
     Protected Overrides Sub OnRenderToolStripBackground(ByVal e As ToolStripRenderEventArgs)
         MyBase.OnRenderToolStripBackground(e)
         Dim lightColor As Color = Me.BackColor
-        Using b As New LinearGradientBrush(e.AffectedBounds, lightColor, lightColor, LinearGradientMode.Vertical)
+        Using b As New SolidBrush(lightColor)
             e.Graphics.FillRectangle(b, e.AffectedBounds)
         End Using
     End Sub
 
+    ' Change the color for the menubar dropdowns.
+    ' Based on the code from the "gray itembackground"
+    ' area here:
+    ' http://www.vbforums.com/showthread.php?539578-Custom-VisualStudio2008-style-MenuStrip-and-ToolStrip-Renderer&p=3333808&viewfull=1#post3333808
+    Protected Overrides Sub OnRenderImageMargin(e As ToolStripRenderEventArgs)
+        MyBase.OnRenderImageMargin(e)
+        Dim color As Color = Me.DropdownBackColor
+        Dim b As New SolidBrush(color)
+        Dim itembgcolor As New Rectangle(0, 0, e.ToolStrip.Width, e.ToolStrip.Height)
+        e.Graphics.FillRectangle(b, itembgcolor)
+    End Sub
+
     ' Change the colors for the menubar text.
-    Protected Overrides Sub OnRenderItemText(e As ToolStripItemTextRenderEventArgs)
+    Protected Overrides Sub OnRenderItemText(ByVal e As ToolStripItemTextRenderEventArgs)
         If e.Item.Selected = True Then
             e.TextColor = _TextHighlightColor
         Else

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -102,6 +102,9 @@ Public Class UXLLauncher_ThemeEngine
         ' Menubar entry colors:
         Dim colorMenuItemBackColor As Color
         Dim colorMenuItemForeColor As Color
+        ' Menubar item margin colors:
+        Dim colorMenuItemImageMarginGradientStartColor As Color
+        Dim colorMenuItemImageMarginGradientEndColor As Color
         ' Statusbar label colors:
         Dim colorStatusLabelBackColor As Color
         Dim colorStatusLabelForeColor As Color
@@ -413,6 +416,24 @@ Public Class UXLLauncher_ThemeEngine
             ' If the element doesn't exist, overwrite it with the Default theme's value.
             colorMenuItemBackColor = Color.FromKnownColor(KnownColor.Window)
         End If
+#End Region
+
+#Region "MenuItem Image margin background gradient"
+#Region "Color 1 (first color)"
+        ' Only pull the MenuItem BackColor element from XML if it exists.
+        If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/ImageMarginGradient/StartColor[1]", themeNamespaceManager) IsNot Nothing Then
+            Try
+                colorMenuItemBackColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/MenuItem/BackColor[1]", themeNamespaceManager).InnerText)
+                debugmodeStuff.updateDebugLabels()
+                ' If the element isn't a valid HTML color, just replace it with the default.
+            Catch ex As Exception
+                colorMenuItemBackColor = Color.FromKnownColor(KnownColor.Window)
+            End Try
+        Else
+            ' If the element doesn't exist, overwrite it with the Default theme's value.
+            colorMenuItemBackColor = Color.FromKnownColor(KnownColor.Window)
+        End If
+#End Region
 #End Region
 
 #Region "MenuBar BackColor"

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -427,11 +427,11 @@ Public Class UXLLauncher_ThemeEngine
                 debugmodeStuff.updateDebugLabels()
                 ' If the element isn't a valid HTML color, just replace it with the default.
             Catch ex As Exception
-                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("FCFCFC")
+                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("0xFCFCFC")
             End Try
         Else
             ' If the element doesn't exist, overwrite it with the Default theme's value.
-            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("FCFCFC")
+            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("0xFCFCFC")
         End If
 #End Region
 #Region "End color"
@@ -442,11 +442,11 @@ Public Class UXLLauncher_ThemeEngine
                 debugmodeStuff.updateDebugLabels()
                 ' If the element isn't a valid HTML color, just replace it with the default.
             Catch ex As Exception
-                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("F1F1F1")
+                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("0xF1F1F1")
             End Try
         Else
             ' If the element doesn't exist, overwrite it with the Default theme's value.
-            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("F1F1F1")
+            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("0xF1F1F1")
         End If
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -442,11 +442,11 @@ Public Class UXLLauncher_ThemeEngine
                 debugmodeStuff.updateDebugLabels()
                 ' If the element isn't a valid HTML color, just replace it with the default.
             Catch ex As Exception
-                colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("0xF1F1F1")
+                colorMenuItemImageMarginGradientEndColor = ColorTranslator.FromHtml("0xF1F1F1")
             End Try
         Else
             ' If the element doesn't exist, overwrite it with the Default theme's value.
-            colorMenuItemImageMarginGradientStartColor = ColorTranslator.FromHtml("0xF1F1F1")
+            colorMenuItemImageMarginGradientEndColor = ColorTranslator.FromHtml("0xF1F1F1")
         End If
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -930,6 +930,8 @@ Public Class uxlProToolstripRenderer
     Private _BackColor As Color
     ' "_DropdownBackColor" determines the colors in the menubar dropdown.
     Private _DropdownBackColor As Color
+    Private _ImageMarginGradientStartColor As Color
+    Private _ImageMarginGradientEndColor As Color
     Private _ForeColor As Color
     Private _TextHighlightColor As Color
 
@@ -950,6 +952,26 @@ Public Class uxlProToolstripRenderer
         End Get
         Set(ByVal value As Color)
             _DropdownBackColor = value
+        End Set
+    End Property
+
+    ' Get and set the start color for the gradients in menuitem image margins.
+    Public Property ImageMarginGradientStartColor As Color
+        Get
+            Return _ImageMarginGradientStartColor
+        End Get
+        Set(ByVal value As Color)
+            _ImageMarginGradientStartColor = value
+        End Set
+    End Property
+
+    ' Get and set the end color for the gradients in menuitem image margins.
+    Public Property ImageMarginGradientEndColor As Color
+        Get
+            Return _ImageMarginGradientEndColor
+        End Get
+        Set(ByVal value As Color)
+            _ImageMarginGradientEndColor = value
         End Set
     End Property
 
@@ -990,7 +1012,9 @@ Public Class uxlProToolstripRenderer
         MyBase.OnRenderImageMargin(e)
         Dim color As Color = Me.DropdownBackColor
         Dim b As New SolidBrush(color)
+        ' Make the menuitem background set to the theme's color.
         Dim itembgcolor As New Rectangle(0, 0, e.ToolStrip.Width, e.ToolStrip.Height)
+        ' Fill the background of the menuitem.
         e.Graphics.FillRectangle(b, itembgcolor)
     End Sub
 

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -1010,12 +1010,12 @@ Public Class uxlProToolstripRenderer
     ' http://www.vbforums.com/showthread.php?539578-Custom-VisualStudio2008-style-MenuStrip-and-ToolStrip-Renderer&p=3333808&viewfull=1#post3333808
     Protected Overrides Sub OnRenderImageMargin(e As ToolStripRenderEventArgs)
         MyBase.OnRenderImageMargin(e)
-        Dim color As Color = Me.DropdownBackColor
-        Dim b As New SolidBrush(color)
+        Dim DropDownItemBackColor As Color = Me.DropdownBackColor
+        Dim dropdownBrush As New SolidBrush(DropdownBackColor)
         ' Make the menuitem background set to the theme's color.
         Dim itembgcolor As New Rectangle(0, 0, e.ToolStrip.Width, e.ToolStrip.Height)
         ' Fill the background of the menuitem.
-        e.Graphics.FillRectangle(b, itembgcolor)
+        e.Graphics.FillRectangle(dropdownBrush, itembgcolor)
     End Sub
 
     ' Change the colors for the menubar text.


### PR DESCRIPTION
A long time ago, UXL Launcher's Theme Engine sorta supported custom menuitem back colors, but now it's improved to the point that you can specify your own colors for not only the dropdown items, but also the image margin gradients! I couldn't have done it without these instructions listed here: http://www.vbforums.com/showthread.php?539578-Custom-VisualStudio2008-style-MenuStrip-and-ToolStrip-Renderer&p=3333808&viewfull=1#post3333808

I'll post a few comparisons later. These include a screenshot showing that I managed to get the Default theme to look the same as how the menus in UXL Launcher 3.0 look (so that the only downside of using the theme engine now is that it might use a few more resources) and one of the TestTheme showing that it's possible to have other colors for the menuitems and the menubar backcolor.

~~Another change in this pull request is that now, menubar backcolors use the actual color specified in the theme file instead of a slightly lighter color. Theme designers may need to change their "MenuBar" colors in their theme files.~~ Actually, this may already be in the Master branch.