### PR TITLE
Improve "Test settings" feature.

### DIFF
--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -422,17 +422,21 @@ Public Class aaformOptionsWindow
             ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96
             If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "SETLANG.EXE") Then
                 ' If the file for Office Language Preferences was found, tell the user.
-                MessageBox.Show("Office Language Preferences has been found in the configured location." &
+                MessageBox.Show(Me, "Office Language Preferences has been found in the configured location." &
                                 " You shouldn't have to change your Office-related settings further unless you encounter problems or upgrade Office.",
                                 "Test settings", MessageBoxButtons.OK, MessageBoxIcon.Information)
             Else
                 ' If it's not found, let the user know and give them the option to open
                 ' the Options window to change their settings if they want to.
-                Dim msgResultDidntFindOfficeLangPrefs As Integer = MessageBox.Show("We couldn't find Office Language Preferences in the configured location." & vbCrLf &
+                Dim msgResultDidntFindOfficeLangPrefs As Integer = MessageBox.Show(Me, "We couldn't find Office Language Preferences in the configured location." & vbCrLf &
                                                                                    "Would you like to open the Options window to change your settings?",
                                                                                    "Test settings", MessageBoxButtons.YesNo, MessageBoxIcon.Stop)
                 ' If the user clicks "Yes", open the Options window.
-
+                If msgResultDidntFindOfficeLangPrefs = DialogResult.Yes Then
+                    Dim forceOptionsWindowTab As New aaformOptionsWindow
+                    forceOptionsWindowTab.tabcontrolOptionsWindow.SelectTab(0)
+                    forceOptionsWindowTab.ShowDialog(aaformMainWindow)
+                End If
             End If
         End If
     End Sub

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -406,19 +406,23 @@ Public Class aaformOptionsWindow
         ' suggested: <http://stackoverflow.com/a/2256926>
 
         Dim msgResult As Integer = MessageBox.Show("Would you like to test your UXL Launcher settings?" &
-                        " This will save your settings and attempt to launch the Office Language Options app." & vbCrLf &
+                        " This will save your settings and attempt to find the Office Language Preferences app" & vbCrLf &
+                        "in the location configured based on your settings." & vbCrLf &
                         "" & vbCrLf &
-                        "If you choose to test your settings and no message appears, assume that it worked. " &
+                        "If you choose to test your settings and the file is found, a description of the file will appear. " &
                         "However, you might need to adjust your settings if you see a message saying that we couldn't find the file." & vbCrLf &
-                        "" & vbCrLf &
-                        "Close the Office Language Preferences window if it appears." & vbCrLf &
                         "" & vbCrLf &
                         "The Options window will close after your settings are saved.",
                         "Test settings", MessageBoxButtons.YesNo)
         If msgResult = DialogResult.Yes Then
             buttonSaveSettings.PerformClick()
             Me.Hide()
-            LaunchApp.LaunchOfficeLangPrefs()
+            ' Now, try to see if SETLANG.EXE is located in the configured directory.
+            ' If it is found, show the user a few of the file's properties.
+            ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96
+            If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "\SETLANG.EXE") Then
+                MessageBox.Show("Found it!")
+            End If
         End If
     End Sub
 #End Region

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -422,7 +422,9 @@ Public Class aaformOptionsWindow
             ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96
             If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "SETLANG.EXE") Then
                 ' If the file for Office Language Preferences was found, tell the user.
-                MessageBox.Show("Office Language Preferences has been found in the configured location. You shouldn't have to change your Office-related settings further unless you encounter problems or upgrade Office.")
+                MessageBox.Show("Office Language Preferences has been found in the configured location." &
+                                " You shouldn't have to change your Office-related settings further unless you encounter problems or upgrade Office.",
+                                "Test settings", MessageBoxButtons.OK, MessageBoxIcon.Information)
             Else
                 MessageBox.Show("Didn't find it...")
             End If

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -428,7 +428,11 @@ Public Class aaformOptionsWindow
             Else
                 ' If it's not found, let the user know and give them the option to open
                 ' the Options window to change their settings if they want to.
-                MessageBox.Show("Didn't find it...")
+                Dim msgResultDidntFindOfficeLangPrefs As Integer = MessageBox.Show("We couldn't find Office Language Preferences in the configured location." & vbCrLf &
+                                                                                   "Would you like to open the Options window to change your settings?",
+                                                                                   "Test settings", MessageBoxButtons.YesNo, MessageBoxIcon.Stop)
+                ' If the user clicks "Yes", open the Options window.
+
             End If
         End If
     End Sub

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -428,8 +428,8 @@ Public Class aaformOptionsWindow
             Else
                 ' If it's not found, let the user know and give them the option to open
                 ' the Options window to change their settings if they want to.
-                Dim msgResultDidntFindOfficeLangPrefs As Integer = MessageBox.Show(Me, "We couldn't find Office Language Preferences in the configured location." & vbCrLf &
-                                                                                   "Would you like to open the Options window to change your settings?",
+                Dim msgResultDidntFindOfficeLangPrefs As Integer = MessageBox.Show(Me, "We couldn't find Office Language Preferences in the configured location." &
+                                                                                   " Would you like to open the Options window to change your settings?",
                                                                                    "Test settings", MessageBoxButtons.YesNo, MessageBoxIcon.Stop)
                 ' If the user clicks "Yes", open the Options window.
                 If msgResultDidntFindOfficeLangPrefs = DialogResult.Yes Then

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -406,8 +406,8 @@ Public Class aaformOptionsWindow
         ' suggested: <http://stackoverflow.com/a/2256926>
 
         Dim msgResult As Integer = MessageBox.Show("Would you like to test your UXL Launcher settings?" &
-                        " This will save your settings and attempt to find the Office Language Preferences app" & vbCrLf &
-                        "in the location configured based on your settings." & vbCrLf &
+                        " This will save your settings and attempt to find the Office Language Preferences app" &
+                        " in the location configured based on your settings." & vbCrLf &
                         "" & vbCrLf &
                         "If you choose to test your settings and the file is found, a message saying this will appear and you shouldn't have to change your settings. " &
                         "However, you might need to adjust your settings if you see a message saying that we couldn't find the file." & vbCrLf &

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -416,7 +416,7 @@ Public Class aaformOptionsWindow
                         "Test settings", MessageBoxButtons.YesNo)
         If msgResult = DialogResult.Yes Then
             buttonSaveSettings.PerformClick()
-            Me.Hide()
+            Me.Hide() ' This Me.Hide() might not be necessary anymore since the Options window gets closed after saving settings, but I don't know. This line will be removed if it's definately not required.
             ' Now, try to see if SETLANG.EXE is located in the configured directory.
             ' If it is found, show the user a few of the file's properties.
             ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -421,7 +421,11 @@ Public Class aaformOptionsWindow
             ' If it is found, show the user a few of the file's properties.
             ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96
             If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "\SETLANG.EXE") Then
+                ' If the file for Office Language Preferences was found, tell the user
+                ' and display some file info about it.
                 MessageBox.Show("Found it!")
+            Else
+                MessageBox.Show("Didn't find it...")
             End If
         End If
     End Sub

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -420,7 +420,7 @@ Public Class aaformOptionsWindow
             ' Now, try to see if SETLANG.EXE is located in the configured directory.
             ' If it is found, show the user a few of the file's properties.
             ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96
-            If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "\SETLANG.EXE") Then
+            If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "SETLANG.EXE") Then
                 ' If the file for Office Language Preferences was found, tell the user
                 ' and display some file info about it.
                 MessageBox.Show("Found it!")

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -426,6 +426,8 @@ Public Class aaformOptionsWindow
                                 " You shouldn't have to change your Office-related settings further unless you encounter problems or upgrade Office.",
                                 "Test settings", MessageBoxButtons.OK, MessageBoxIcon.Information)
             Else
+                ' If it's not found, let the user know and give them the option to open
+                ' the Options window to change their settings if they want to.
                 MessageBox.Show("Didn't find it...")
             End If
         End If

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -431,7 +431,7 @@ Public Class aaformOptionsWindow
                 Dim msgResultDidntFindOfficeLangPrefs As Integer = MessageBox.Show(Me, "We couldn't find Office Language Preferences in the configured location." &
                                                                                    " Would you like to open the Options window to change your settings?",
                                                                                    "Test settings", MessageBoxButtons.YesNo, MessageBoxIcon.Stop)
-                ' If the user clicks "Yes", open the Options window.
+                ' If the user clicks "Yes", open the Options window. Credit goes to this SO answer: <http://stackoverflow.com/a/2513186>
                 If msgResultDidntFindOfficeLangPrefs = DialogResult.Yes Then
                     Dim forceOptionsWindowTab As New aaformOptionsWindow
                     forceOptionsWindowTab.tabcontrolOptionsWindow.SelectTab(0)

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -409,7 +409,7 @@ Public Class aaformOptionsWindow
                         " This will save your settings and attempt to find the Office Language Preferences app" & vbCrLf &
                         "in the location configured based on your settings." & vbCrLf &
                         "" & vbCrLf &
-                        "If you choose to test your settings and the file is found, a description of the file will appear. " &
+                        "If you choose to test your settings and the file is found, a message saying this will appear and you shouldn't have to change your settings. " &
                         "However, you might need to adjust your settings if you see a message saying that we couldn't find the file." & vbCrLf &
                         "" & vbCrLf &
                         "The Options window will close after your settings are saved.",
@@ -421,9 +421,8 @@ Public Class aaformOptionsWindow
             ' If it is found, show the user a few of the file's properties.
             ' See also this issue: https://github.com/DrewNaylor/UXL-Launcher/issues/96
             If My.Computer.FileSystem.FileExists(OfficeLocater.fullLauncherCodeString & "SETLANG.EXE") Then
-                ' If the file for Office Language Preferences was found, tell the user
-                ' and display some file info about it.
-                MessageBox.Show("Found it!")
+                ' If the file for Office Language Preferences was found, tell the user.
+                MessageBox.Show("Office Language Preferences has been found in the configured location. You shouldn't have to change your Office-related settings further unless you encounter problems or upgrade Office.")
             Else
                 MessageBox.Show("Didn't find it...")
             End If

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -43,6 +43,7 @@ Public Class isolated_error_handler
 
             ' If the user chooses to open the Options window, open the Options window to the General tab.
             If msgResult = DialogResult.Yes Then
+                ' Open the Options window. Credit goes to this SO answer: <http://stackoverflow.com/a/2513186>
                 Dim forceOptionsWindowTab As New aaformOptionsWindow
                 forceOptionsWindowTab.tabcontrolOptionsWindow.SelectTab(0)
                 forceOptionsWindowTab.ShowDialog(aaformMainWindow)

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -35,7 +35,7 @@ Public Class isolated_error_handler
         Catch ex As System.ComponentModel.Win32Exception
             ' If Microsoft Access isn't found in the folder the user chose in the Options window, ask them if they want to
             ' go to the Options window to change it.
-            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & launcherErrorHandler_ExeFriendlyName & " in the location specified in the Options window." &
+            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & launcherErrorHandler_ExeFriendlyName & " in the configured location." &
             " Would you like to open the Options window to change your settings?" & vbCrLf &
                 "" & vbCrLf &
                 "Full error message: " & ex.Message, "Couldn't find file",


### PR DESCRIPTION
This pull request improves the "Test settings" feature in the Options window. Fixes #96.

- Now, instead of attempting to launch the Office Language Preferences app and relying on the exception handler for app launching to catch when it isn't found, we just try to see if the file is found in the configured location. 
  - If it can't be found, we provide a way to open the Options window again and tell the user it couldn't be found. 
  - If it can be found, we tell the user that it was found and that the user shouldn't have to change their Office-related settings unless they have problems or upgrade Office.

- Wording is now much more concise for both the "Test settings" messageboxes and the message when apps can't be found in general.

- A bug was discovered and, for Version 3.2, fixed. 
  - This bug was #128 and resulted in the messageboxes that say whether or not Office Language Preferences could be found being placed behind the main window when "Always On Top" is enabled. 
  - This bug might be fixed in a Version 3.1.1 bugfix update if there's at least one more easy bugfix within the next week or so in 3.2, but I don't know.

- Comments updated.