### PR TITLE
Add "File>Open..." as a way to open files in their default app.

### DIFF
--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -926,7 +926,7 @@ Partial Class aaformMainWindow
         '
         'openfiledialogOpenDocument
         '
-        Me.openfiledialogOpenDocument.FileName = "OpenFileDialog1"
+        Me.openfiledialogOpenDocument.Title = "Open"
         '
         'aaformMainWindow
         '

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -927,6 +927,7 @@ Partial Class aaformMainWindow
         'openfiledialogOpenDocument
         '
         Me.openfiledialogOpenDocument.Filter = resources.GetString("openfiledialogOpenDocument.Filter")
+        Me.openfiledialogOpenDocument.RestoreDirectory = True
         Me.openfiledialogOpenDocument.Title = "Open"
         '
         'aaformMainWindow

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -109,6 +109,7 @@ Partial Class aaformMainWindow
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
         Me.menubarOpenButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.zToolStripSeparatorFileMenu = New System.Windows.Forms.ToolStripSeparator()
+        Me.openfiledialogOpenDocument = New System.Windows.Forms.OpenFileDialog()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -923,6 +924,10 @@ Partial Class aaformMainWindow
         Me.zToolStripSeparatorFileMenu.Name = "zToolStripSeparatorFileMenu"
         Me.zToolStripSeparatorFileMenu.Size = New System.Drawing.Size(152, 6)
         '
+        'openfiledialogOpenDocument
+        '
+        Me.openfiledialogOpenDocument.FileName = "OpenFileDialog1"
+        '
         'aaformMainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -1052,4 +1057,5 @@ Partial Class aaformMainWindow
     Friend WithEvents debugLabelXmlThemeFileVersion As Label
     Friend WithEvents menubarOpenButton As ToolStripMenuItem
     Friend WithEvents zToolStripSeparatorFileMenu As ToolStripSeparator
+    Friend WithEvents openfiledialogOpenDocument As OpenFileDialog
 End Class

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -107,6 +107,8 @@ Partial Class aaformMainWindow
         Me.buttonRunClipOrganizer = New System.Windows.Forms.Button()
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
+        Me.menubarOpenButton = New System.Windows.Forms.ToolStripMenuItem()
+        Me.zToolStripSeparatorFileMenu = New System.Windows.Forms.ToolStripSeparator()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -143,7 +145,7 @@ Partial Class aaformMainWindow
         '
         'menubarFileMenu
         '
-        Me.menubarFileMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarExitButton})
+        Me.menubarFileMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarOpenButton, Me.zToolStripSeparatorFileMenu, Me.menubarExitButton})
         Me.menubarFileMenu.Name = "menubarFileMenu"
         Me.menubarFileMenu.Size = New System.Drawing.Size(37, 19)
         Me.menubarFileMenu.Text = "&File"
@@ -152,7 +154,7 @@ Partial Class aaformMainWindow
         '
         Me.menubarExitButton.Name = "menubarExitButton"
         Me.menubarExitButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Alt Or System.Windows.Forms.Keys.F4), System.Windows.Forms.Keys)
-        Me.menubarExitButton.Size = New System.Drawing.Size(134, 22)
+        Me.menubarExitButton.Size = New System.Drawing.Size(155, 22)
         Me.menubarExitButton.Text = "E&xit"
         '
         'menubarViewMenu
@@ -909,6 +911,18 @@ Partial Class aaformMainWindow
         Me.notifyiconTaskbarLaunchers.Text = "UXL Launcher Quickmenu"
         Me.notifyiconTaskbarLaunchers.Visible = True
         '
+        'menubarOpenButton
+        '
+        Me.menubarOpenButton.Name = "menubarOpenButton"
+        Me.menubarOpenButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
+        Me.menubarOpenButton.Size = New System.Drawing.Size(155, 22)
+        Me.menubarOpenButton.Text = "Open..."
+        '
+        'zToolStripSeparatorFileMenu
+        '
+        Me.zToolStripSeparatorFileMenu.Name = "zToolStripSeparatorFileMenu"
+        Me.zToolStripSeparatorFileMenu.Size = New System.Drawing.Size(152, 6)
+        '
         'aaformMainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -1036,4 +1050,6 @@ Partial Class aaformMainWindow
     Friend WithEvents debugLabelXmlThemeUseThemeEngineVersion As Label
     Friend WithEvents notifyiconShowApp As ToolStripMenuItem
     Friend WithEvents debugLabelXmlThemeFileVersion As Label
+    Friend WithEvents menubarOpenButton As ToolStripMenuItem
+    Friend WithEvents zToolStripSeparatorFileMenu As ToolStripSeparator
 End Class

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -156,7 +156,7 @@ Partial Class aaformMainWindow
         Me.menubarOpenButton.Name = "menubarOpenButton"
         Me.menubarOpenButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
         Me.menubarOpenButton.Size = New System.Drawing.Size(155, 22)
-        Me.menubarOpenButton.Text = "Open..."
+        Me.menubarOpenButton.Text = "&Open..."
         '
         'zToolStripSeparatorFileMenu
         '

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -26,6 +26,8 @@ Partial Class aaformMainWindow
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(aaformMainWindow))
         Me.menubarMainWindow = New System.Windows.Forms.MenuStrip()
         Me.menubarFileMenu = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menubarOpenButton = New System.Windows.Forms.ToolStripMenuItem()
+        Me.zToolStripSeparatorFileMenu = New System.Windows.Forms.ToolStripSeparator()
         Me.menubarExitButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarViewMenu = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarAlwaysOnTopButton = New System.Windows.Forms.ToolStripMenuItem()
@@ -107,8 +109,6 @@ Partial Class aaformMainWindow
         Me.buttonRunClipOrganizer = New System.Windows.Forms.Button()
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
-        Me.menubarOpenButton = New System.Windows.Forms.ToolStripMenuItem()
-        Me.zToolStripSeparatorFileMenu = New System.Windows.Forms.ToolStripSeparator()
         Me.openfiledialogOpenDocument = New System.Windows.Forms.OpenFileDialog()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
@@ -150,6 +150,18 @@ Partial Class aaformMainWindow
         Me.menubarFileMenu.Name = "menubarFileMenu"
         Me.menubarFileMenu.Size = New System.Drawing.Size(37, 19)
         Me.menubarFileMenu.Text = "&File"
+        '
+        'menubarOpenButton
+        '
+        Me.menubarOpenButton.Name = "menubarOpenButton"
+        Me.menubarOpenButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
+        Me.menubarOpenButton.Size = New System.Drawing.Size(155, 22)
+        Me.menubarOpenButton.Text = "Open..."
+        '
+        'zToolStripSeparatorFileMenu
+        '
+        Me.zToolStripSeparatorFileMenu.Name = "zToolStripSeparatorFileMenu"
+        Me.zToolStripSeparatorFileMenu.Size = New System.Drawing.Size(152, 6)
         '
         'menubarExitButton
         '
@@ -912,20 +924,9 @@ Partial Class aaformMainWindow
         Me.notifyiconTaskbarLaunchers.Text = "UXL Launcher Quickmenu"
         Me.notifyiconTaskbarLaunchers.Visible = True
         '
-        'menubarOpenButton
-        '
-        Me.menubarOpenButton.Name = "menubarOpenButton"
-        Me.menubarOpenButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
-        Me.menubarOpenButton.Size = New System.Drawing.Size(155, 22)
-        Me.menubarOpenButton.Text = "Open..."
-        '
-        'zToolStripSeparatorFileMenu
-        '
-        Me.zToolStripSeparatorFileMenu.Name = "zToolStripSeparatorFileMenu"
-        Me.zToolStripSeparatorFileMenu.Size = New System.Drawing.Size(152, 6)
-        '
         'openfiledialogOpenDocument
         '
+        Me.openfiledialogOpenDocument.Filter = resources.GetString("openfiledialogOpenDocument.Filter")
         Me.openfiledialogOpenDocument.Title = "Open"
         '
         'aaformMainWindow

--- a/UXL-Launcher/MainWindow.resx
+++ b/UXL-Launcher/MainWindow.resx
@@ -174,6 +174,9 @@ Options window, whichever comes first.</value>
   <metadata name="openfiledialogOpenDocument.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>741, 17</value>
   </metadata>
+  <data name="openfiledialogOpenDocument.Filter" xml:space="preserve">
+    <value>Common Microsoft Office Formats (*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.mdb;*accdb;*.pub)|*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.mdb;*accdb;*.pub|Common Microsoft Word Formats (*.doc;*.docx)|*.doc;*.docx|Common Microsoft Excel Formats (*.xls;*.xlsx)|*.xls;*.xlsx|Common Microsoft PowerPoint Formats (*.ppt;*.pptx)|*.ppt;*.pptx|Common Microsoft Access Formats (*.mdb;*.accdb)|*.mdb;*.accdb|Common Microsoft Publisher Formats (*.pub)|*.pub|All File Formats (*.*)|*.*</value>
+  </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAgAEBAQAAEABAAoAQAAhgAAABAQAAABAAgAaAUAAK4BAAAYGAAAAQAIAMgGAAAWBwAAICAQAAEA

--- a/UXL-Launcher/MainWindow.resx
+++ b/UXL-Launcher/MainWindow.resx
@@ -175,7 +175,7 @@ Options window, whichever comes first.</value>
     <value>741, 17</value>
   </metadata>
   <data name="openfiledialogOpenDocument.Filter" xml:space="preserve">
-    <value>Common Microsoft Office Formats (*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.mdb;*accdb;*.pub)|*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.mdb;*accdb;*.pub|Common Microsoft Word Formats (*.doc;*.docx)|*.doc;*.docx|Common Microsoft Excel Formats (*.xls;*.xlsx)|*.xls;*.xlsx|Common Microsoft PowerPoint Formats (*.ppt;*.pptx)|*.ppt;*.pptx|Common Microsoft Access Formats (*.mdb;*.accdb)|*.mdb;*.accdb|Common Microsoft Publisher Formats (*.pub)|*.pub|All File Formats (*.*)|*.*</value>
+    <value>Common Microsoft Office Formats (*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.mdb;*.accdb;*.pub)|*.doc;*.docx;*.xls;*.xlsx;*.ppt;*.pptx;*.mdb;*.accdb;*.pub|Common Microsoft Word Formats (*.doc;*.docx)|*.doc;*.docx|Common Microsoft Excel Formats (*.xls;*.xlsx)|*.xls;*.xlsx|Common Microsoft PowerPoint Formats (*.ppt;*.pptx)|*.ppt;*.pptx|Common Microsoft Access Formats (*.mdb;*.accdb)|*.mdb;*.accdb|Common Microsoft Publisher Formats (*.pub)|*.pub|All File Formats (*.*)|*.*</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/UXL-Launcher/MainWindow.resx
+++ b/UXL-Launcher/MainWindow.resx
@@ -171,6 +171,9 @@ Options window, whichever comes first.</value>
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 </value>
   </data>
+  <metadata name="openfiledialogOpenDocument.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>741, 17</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAgAEBAQAAEABAAoAQAAhgAAABAQAAABAAgAaAUAAK4BAAAYGAAAAQAIAMgGAAAWBwAAICAQAAEA

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -238,12 +238,9 @@ Public Class aaformMainWindow
         ' Show the "Open..." dialog and open the file if the user
         ' wants to.
         If openfiledialogOpenDocument.ShowDialog = DialogResult.OK Then
-            ' If the user clicks the "OK" button, try to open the file.
-            Try
-                Process.Start(openfiledialogOpenDocument.FileName)
-            Catch ex As Exception
-
-            End Try
+            ' If the user clicks the "OK" button, open the file.
+            ' Note that this can also open EXE files and run them.
+            Process.Start(openfiledialogOpenDocument.FileName)
         End If
     End Sub
 #End Region

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -227,11 +227,19 @@ Public Class aaformMainWindow
 
 #Region "Menubar code, including menubar buttons."
 
+#Region "File menu"
     Private Sub menubarExitButton_Click(sender As Object, e As EventArgs) Handles menubarExitButton.Click
         ' End the execution of the app.
         Me.Close()
 
     End Sub
+
+    Private Sub menubarOpenButton_Click(sender As Object, e As EventArgs) Handles menubarOpenButton.Click
+        ' Show the "Open..." dialog and open the file if the user
+        ' wants to.
+        openfiledialogOpenDocument.ShowDialog()
+    End Sub
+#End Region
 
     Private Sub menubarOptionsButton_Click(sender As Object, e As EventArgs) Handles menubarOptionsButton.Click
         ' Open the Options window. Credit goes to this SO answer: <http://stackoverflow.com/a/2513186>
@@ -507,10 +515,6 @@ Public Class aaformMainWindow
                 Debug.Print(UXLLauncher_ThemeEngine.userTheme.OuterXml)
             End If
         End If
-    End Sub
-
-    Private Sub menubarOpenButton_Click(sender As Object, e As EventArgs) Handles menubarOpenButton.Click
-        openfiledialogOpenDocument.ShowDialog()
     End Sub
 #End Region
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -237,7 +237,14 @@ Public Class aaformMainWindow
     Private Sub menubarOpenButton_Click(sender As Object, e As EventArgs) Handles menubarOpenButton.Click
         ' Show the "Open..." dialog and open the file if the user
         ' wants to.
-        openfiledialogOpenDocument.ShowDialog()
+        If openfiledialogOpenDocument.ShowDialog = DialogResult.OK Then
+            ' If the user clicks the "OK" button, try to open the file.
+            Try
+                Process.Start(openfiledialogOpenDocument.FileName)
+            Catch ex As Exception
+
+            End Try
+        End If
     End Sub
 #End Region
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -236,7 +236,8 @@ Public Class aaformMainWindow
 
     Private Sub menubarOpenButton_Click(sender As Object, e As EventArgs) Handles menubarOpenButton.Click
         ' Show the "Open..." dialog and open the file if the user
-        ' wants to.
+        ' wants to. Process.Start opens the file in the default app
+        ' for that file type.
         If openfiledialogOpenDocument.ShowDialog = DialogResult.OK Then
             ' If the user clicks the "OK" button, open the file.
             ' Note that this can also open EXE files and run them.

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -508,6 +508,10 @@ Public Class aaformMainWindow
             End If
         End If
     End Sub
+
+    Private Sub menubarOpenButton_Click(sender As Object, e As EventArgs) Handles menubarOpenButton.Click
+        openfiledialogOpenDocument.ShowDialog()
+    End Sub
 #End Region
 
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -41,6 +41,7 @@ Partial Class aaformOptionsWindow
         Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
         Me.groupboxCPUType = New System.Windows.Forms.GroupBox()
+        Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
         Me.radiobuttonCPUIsQBit = New System.Windows.Forms.RadioButton()
         Me.radiobuttonCPUIs64Bit = New System.Windows.Forms.RadioButton()
         Me.radiobuttonCPUIs32Bit = New System.Windows.Forms.RadioButton()
@@ -66,7 +67,6 @@ Partial Class aaformOptionsWindow
         Me.tooltipO365InstallMethod = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipSystemInfo = New System.Windows.Forms.ToolTip(Me.components)
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
-        Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -296,6 +296,17 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType.TabIndex = 0
         Me.groupboxCPUType.TabStop = False
         Me.groupboxCPUType.Text = "What edition of Windows do you run?"
+        '
+        'labelRecommendedWindowsEdition
+        '
+        Me.labelRecommendedWindowsEdition.AutoSize = True
+        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(93, 93)
+        Me.labelRecommendedWindowsEdition.Name = "labelRecommendedWindowsEdition"
+        Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(291, 52)
+        Me.labelRecommendedWindowsEdition.TabIndex = 5
+        Me.labelRecommendedWindowsEdition.Text = "16-bit Windows is the recommended option for you, but if" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "using Office 2013, you " &
+    "may need to select ""32-bit Windows""" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "due to the 32-bit version installing to ""Pr" &
+    "ogram Files""" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "even on 64-bit Windows."
         '
         'radiobuttonCPUIsQBit
         '
@@ -549,17 +560,6 @@ Partial Class aaformOptionsWindow
         '
         Me.openfiledialogBrowseCustomThemeFile.Filter = "XML Files (*.xml)|*.xml|Text Files (*.txt)|*.txt|All Files (*.*)|*.*"
         Me.openfiledialogBrowseCustomThemeFile.Title = "Browse for a custom theme"
-        '
-        'labelRecommendedWindowsEdition
-        '
-        Me.labelRecommendedWindowsEdition.AutoSize = True
-        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(93, 93)
-        Me.labelRecommendedWindowsEdition.Name = "labelRecommendedWindowsEdition"
-        Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(291, 52)
-        Me.labelRecommendedWindowsEdition.TabIndex = 5
-        Me.labelRecommendedWindowsEdition.Text = "16-bit Windows is the recommended option for you, but if" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "using Office 2013, you " &
-    "may need to select ""32-bit Windows""" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "due to the 32-bit version installing to ""Pr" &
-    "ogram Files""" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "even on 64-bit Windows."
         '
         'aaformOptionsWindow
         '

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>277, 21</value>
+    <value>22, 23</value>
   </metadata>
   <data name="checkboxO365InstallMethod.ToolTip" xml:space="preserve">
     <value>Check this box if you use a retail copy of Office or one from Office 365, or are otherwise having trouble
@@ -132,9 +132,9 @@ from older versions of Office. This is due to a technology called 'Click-to-Run'
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
   </data>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>469, 21</value>
+    <value>214, 23</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>617, 21</value>
+    <value>362, 23</value>
   </metadata>
 </root>


### PR DESCRIPTION
With this pull request, the user can now open files in the default app associated with that file.

Some filters are provided. These include the following:
- Common Office formats (doc, docx, xls, xlsx, ppt, pptx, mdb, accdb, pub)
- Common Microsoft Word formats (doc, docx)
- Common Microsoft Excel formats (xls, xlsx)
- Common Microsoft PowerPoint formats (ppt, pptx)
- Common Microsoft Access formats (mdb, accdb)
- Common Microsoft Publisher formats (pub)
- And an option to show all file formats (*.*).

Due to using "Process.Start" to open the files (so that they open in their default program), EXE files can be run with this "File>Open..." dialog.