### PR TITLE
Add "File>New" submenu for creating new documents.

### DIFF
--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -202,7 +202,7 @@ Partial Class aaformMainWindow
         Me.menuitemNewOutlookEmail.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewOutlookEmail.Name = "menuitemNewOutlookEmail"
         Me.menuitemNewOutlookEmail.Size = New System.Drawing.Size(266, 30)
-        Me.menuitemNewOutlookEmail.Text = "Microsoft Outlook email"
+        Me.menuitemNewOutlookEmail.Text = "Microsoft Outlook e&mail"
         '
         'menuitemNewOutlookContact
         '
@@ -210,7 +210,7 @@ Partial Class aaformMainWindow
         Me.menuitemNewOutlookContact.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewOutlookContact.Name = "menuitemNewOutlookContact"
         Me.menuitemNewOutlookContact.Size = New System.Drawing.Size(266, 30)
-        Me.menuitemNewOutlookContact.Text = "Microsoft Outlook contact"
+        Me.menuitemNewOutlookContact.Text = "Microsoft Outlook &contact"
         '
         'zSeparatorNewMenuProfessionalApps
         '

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -26,6 +26,15 @@ Partial Class aaformMainWindow
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(aaformMainWindow))
         Me.menubarMainWindow = New System.Windows.Forms.MenuStrip()
         Me.menubarFileMenu = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menubarNewFileSubmenu = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewWordDoc = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewExcelWorkbook = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewPPTPresentation = New System.Windows.Forms.ToolStripMenuItem()
+        Me.zSeparatorOutlookArea = New System.Windows.Forms.ToolStripSeparator()
+        Me.menuitemNewOutlookEmail = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewOutlookContact = New System.Windows.Forms.ToolStripMenuItem()
+        Me.zSeparatorNewMenuProfessionalApps = New System.Windows.Forms.ToolStripSeparator()
+        Me.menuitemNewPublisherPublication = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarOpenButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.zToolStripSeparatorFileMenu = New System.Windows.Forms.ToolStripSeparator()
         Me.menubarExitButton = New System.Windows.Forms.ToolStripMenuItem()
@@ -110,15 +119,6 @@ Partial Class aaformMainWindow
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
         Me.openfiledialogOpenDocument = New System.Windows.Forms.OpenFileDialog()
-        Me.menubarNewFileSubmenu = New System.Windows.Forms.ToolStripMenuItem()
-        Me.menuitemNewWordDoc = New System.Windows.Forms.ToolStripMenuItem()
-        Me.menuitemNewExcelWorkbook = New System.Windows.Forms.ToolStripMenuItem()
-        Me.menuitemNewPPTPresentation = New System.Windows.Forms.ToolStripMenuItem()
-        Me.menuitemNewOutlookEmail = New System.Windows.Forms.ToolStripMenuItem()
-        Me.menuitemNewOutlookContact = New System.Windows.Forms.ToolStripMenuItem()
-        Me.menuitemNewPublisherPublication = New System.Windows.Forms.ToolStripMenuItem()
-        Me.zSeparatorNewMenuProfessionalApps = New System.Windows.Forms.ToolStripSeparator()
-        Me.zSeparatorOutlookArea = New System.Windows.Forms.ToolStripSeparator()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -159,6 +159,71 @@ Partial Class aaformMainWindow
         Me.menubarFileMenu.Name = "menubarFileMenu"
         Me.menubarFileMenu.Size = New System.Drawing.Size(37, 19)
         Me.menubarFileMenu.Text = "&File"
+        '
+        'menubarNewFileSubmenu
+        '
+        Me.menubarNewFileSubmenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menuitemNewWordDoc, Me.menuitemNewExcelWorkbook, Me.menuitemNewPPTPresentation, Me.zSeparatorOutlookArea, Me.menuitemNewOutlookEmail, Me.menuitemNewOutlookContact, Me.zSeparatorNewMenuProfessionalApps, Me.menuitemNewPublisherPublication})
+        Me.menubarNewFileSubmenu.Name = "menubarNewFileSubmenu"
+        Me.menubarNewFileSubmenu.Size = New System.Drawing.Size(155, 22)
+        Me.menubarNewFileSubmenu.Text = "&New"
+        '
+        'menuitemNewWordDoc
+        '
+        Me.menuitemNewWordDoc.Image = Global.UXL_Launcher.My.Resources.Resources.small_Word
+        Me.menuitemNewWordDoc.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
+        Me.menuitemNewWordDoc.Name = "menuitemNewWordDoc"
+        Me.menuitemNewWordDoc.Size = New System.Drawing.Size(266, 30)
+        Me.menuitemNewWordDoc.Text = "Microsoft &Word document"
+        '
+        'menuitemNewExcelWorkbook
+        '
+        Me.menuitemNewExcelWorkbook.Image = Global.UXL_Launcher.My.Resources.Resources.small_Excel
+        Me.menuitemNewExcelWorkbook.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
+        Me.menuitemNewExcelWorkbook.Name = "menuitemNewExcelWorkbook"
+        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(266, 30)
+        Me.menuitemNewExcelWorkbook.Text = "Microsoft &Excel workbook"
+        '
+        'menuitemNewPPTPresentation
+        '
+        Me.menuitemNewPPTPresentation.Image = Global.UXL_Launcher.My.Resources.Resources.small_Powerpoint
+        Me.menuitemNewPPTPresentation.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
+        Me.menuitemNewPPTPresentation.Name = "menuitemNewPPTPresentation"
+        Me.menuitemNewPPTPresentation.Size = New System.Drawing.Size(266, 30)
+        Me.menuitemNewPPTPresentation.Text = "Microsoft &PowerPoint presentation"
+        '
+        'zSeparatorOutlookArea
+        '
+        Me.zSeparatorOutlookArea.Name = "zSeparatorOutlookArea"
+        Me.zSeparatorOutlookArea.Size = New System.Drawing.Size(263, 6)
+        '
+        'menuitemNewOutlookEmail
+        '
+        Me.menuitemNewOutlookEmail.Image = Global.UXL_Launcher.My.Resources.Resources.small_Outlook
+        Me.menuitemNewOutlookEmail.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
+        Me.menuitemNewOutlookEmail.Name = "menuitemNewOutlookEmail"
+        Me.menuitemNewOutlookEmail.Size = New System.Drawing.Size(266, 30)
+        Me.menuitemNewOutlookEmail.Text = "Microsoft Outlook email"
+        '
+        'menuitemNewOutlookContact
+        '
+        Me.menuitemNewOutlookContact.Image = Global.UXL_Launcher.My.Resources.Resources.small_Outlook
+        Me.menuitemNewOutlookContact.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
+        Me.menuitemNewOutlookContact.Name = "menuitemNewOutlookContact"
+        Me.menuitemNewOutlookContact.Size = New System.Drawing.Size(266, 30)
+        Me.menuitemNewOutlookContact.Text = "Microsoft Outlook contact"
+        '
+        'zSeparatorNewMenuProfessionalApps
+        '
+        Me.zSeparatorNewMenuProfessionalApps.Name = "zSeparatorNewMenuProfessionalApps"
+        Me.zSeparatorNewMenuProfessionalApps.Size = New System.Drawing.Size(263, 6)
+        '
+        'menuitemNewPublisherPublication
+        '
+        Me.menuitemNewPublisherPublication.Image = Global.UXL_Launcher.My.Resources.Resources.small_Publisher
+        Me.menuitemNewPublisherPublication.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
+        Me.menuitemNewPublisherPublication.Name = "menuitemNewPublisherPublication"
+        Me.menuitemNewPublisherPublication.Size = New System.Drawing.Size(266, 30)
+        Me.menuitemNewPublisherPublication.Text = "Microsoft P&ublisher publication"
         '
         'menubarOpenButton
         '
@@ -938,59 +1003,6 @@ Partial Class aaformMainWindow
         Me.openfiledialogOpenDocument.Filter = resources.GetString("openfiledialogOpenDocument.Filter")
         Me.openfiledialogOpenDocument.RestoreDirectory = True
         Me.openfiledialogOpenDocument.Title = "Open"
-        '
-        'menubarNewFileSubmenu
-        '
-        Me.menubarNewFileSubmenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menuitemNewWordDoc, Me.menuitemNewExcelWorkbook, Me.menuitemNewPPTPresentation, Me.zSeparatorOutlookArea, Me.menuitemNewOutlookEmail, Me.menuitemNewOutlookContact, Me.zSeparatorNewMenuProfessionalApps, Me.menuitemNewPublisherPublication})
-        Me.menubarNewFileSubmenu.Name = "menubarNewFileSubmenu"
-        Me.menubarNewFileSubmenu.Size = New System.Drawing.Size(155, 22)
-        Me.menubarNewFileSubmenu.Text = "&New"
-        '
-        'menuitemNewWordDoc
-        '
-        Me.menuitemNewWordDoc.Name = "menuitemNewWordDoc"
-        Me.menuitemNewWordDoc.Size = New System.Drawing.Size(258, 22)
-        Me.menuitemNewWordDoc.Text = "Microsoft &Word document"
-        '
-        'menuitemNewExcelWorkbook
-        '
-        Me.menuitemNewExcelWorkbook.Name = "menuitemNewExcelWorkbook"
-        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(258, 22)
-        Me.menuitemNewExcelWorkbook.Text = "Microsoft &Excel workbook"
-        '
-        'menuitemNewPPTPresentation
-        '
-        Me.menuitemNewPPTPresentation.Name = "menuitemNewPPTPresentation"
-        Me.menuitemNewPPTPresentation.Size = New System.Drawing.Size(258, 22)
-        Me.menuitemNewPPTPresentation.Text = "Microsoft &PowerPoint presentation"
-        '
-        'menuitemNewOutlookEmail
-        '
-        Me.menuitemNewOutlookEmail.Name = "menuitemNewOutlookEmail"
-        Me.menuitemNewOutlookEmail.Size = New System.Drawing.Size(258, 22)
-        Me.menuitemNewOutlookEmail.Text = "Microsoft Outlook email"
-        '
-        'menuitemNewOutlookContact
-        '
-        Me.menuitemNewOutlookContact.Name = "menuitemNewOutlookContact"
-        Me.menuitemNewOutlookContact.Size = New System.Drawing.Size(258, 22)
-        Me.menuitemNewOutlookContact.Text = "Microsoft Outlook contact"
-        '
-        'menuitemNewPublisherPublication
-        '
-        Me.menuitemNewPublisherPublication.Name = "menuitemNewPublisherPublication"
-        Me.menuitemNewPublisherPublication.Size = New System.Drawing.Size(258, 22)
-        Me.menuitemNewPublisherPublication.Text = "Microsoft P&ublisher publication"
-        '
-        'zSeparatorNewMenuProfessionalApps
-        '
-        Me.zSeparatorNewMenuProfessionalApps.Name = "zSeparatorNewMenuProfessionalApps"
-        Me.zSeparatorNewMenuProfessionalApps.Size = New System.Drawing.Size(255, 6)
-        '
-        'zSeparatorOutlookArea
-        '
-        Me.zSeparatorOutlookArea.Name = "zSeparatorOutlookArea"
-        Me.zSeparatorOutlookArea.Size = New System.Drawing.Size(255, 6)
         '
         'aaformMainWindow
         '

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -110,6 +110,15 @@ Partial Class aaformMainWindow
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
         Me.openfiledialogOpenDocument = New System.Windows.Forms.OpenFileDialog()
+        Me.menubarNewFileSubmenu = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewWordDoc = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewExcelWorkbook = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewPPTPresentation = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewOutlookEmail = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewOutlookContact = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemNewPublisherPublication = New System.Windows.Forms.ToolStripMenuItem()
+        Me.zSeparatorNewMenuProfessionalApps = New System.Windows.Forms.ToolStripSeparator()
+        Me.zSeparatorOutlookArea = New System.Windows.Forms.ToolStripSeparator()
         Me.menubarMainWindow.SuspendLayout()
         Me.contextmenuNotifyicon.SuspendLayout()
         Me.statusbarMainWindow.SuspendLayout()
@@ -146,7 +155,7 @@ Partial Class aaformMainWindow
         '
         'menubarFileMenu
         '
-        Me.menubarFileMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarOpenButton, Me.zToolStripSeparatorFileMenu, Me.menubarExitButton})
+        Me.menubarFileMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarNewFileSubmenu, Me.menubarOpenButton, Me.zToolStripSeparatorFileMenu, Me.menubarExitButton})
         Me.menubarFileMenu.Name = "menubarFileMenu"
         Me.menubarFileMenu.Size = New System.Drawing.Size(37, 19)
         Me.menubarFileMenu.Text = "&File"
@@ -930,6 +939,59 @@ Partial Class aaformMainWindow
         Me.openfiledialogOpenDocument.RestoreDirectory = True
         Me.openfiledialogOpenDocument.Title = "Open"
         '
+        'menubarNewFileSubmenu
+        '
+        Me.menubarNewFileSubmenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menuitemNewWordDoc, Me.menuitemNewExcelWorkbook, Me.menuitemNewPPTPresentation, Me.zSeparatorOutlookArea, Me.menuitemNewOutlookEmail, Me.menuitemNewOutlookContact, Me.zSeparatorNewMenuProfessionalApps, Me.menuitemNewPublisherPublication})
+        Me.menubarNewFileSubmenu.Name = "menubarNewFileSubmenu"
+        Me.menubarNewFileSubmenu.Size = New System.Drawing.Size(155, 22)
+        Me.menubarNewFileSubmenu.Text = "&New"
+        '
+        'menuitemNewWordDoc
+        '
+        Me.menuitemNewWordDoc.Name = "menuitemNewWordDoc"
+        Me.menuitemNewWordDoc.Size = New System.Drawing.Size(258, 22)
+        Me.menuitemNewWordDoc.Text = "Microsoft &Word document"
+        '
+        'menuitemNewExcelWorkbook
+        '
+        Me.menuitemNewExcelWorkbook.Name = "menuitemNewExcelWorkbook"
+        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(258, 22)
+        Me.menuitemNewExcelWorkbook.Text = "Microsoft &Excel workbook"
+        '
+        'menuitemNewPPTPresentation
+        '
+        Me.menuitemNewPPTPresentation.Name = "menuitemNewPPTPresentation"
+        Me.menuitemNewPPTPresentation.Size = New System.Drawing.Size(258, 22)
+        Me.menuitemNewPPTPresentation.Text = "Microsoft &PowerPoint presentation"
+        '
+        'menuitemNewOutlookEmail
+        '
+        Me.menuitemNewOutlookEmail.Name = "menuitemNewOutlookEmail"
+        Me.menuitemNewOutlookEmail.Size = New System.Drawing.Size(258, 22)
+        Me.menuitemNewOutlookEmail.Text = "Microsoft Outlook email"
+        '
+        'menuitemNewOutlookContact
+        '
+        Me.menuitemNewOutlookContact.Name = "menuitemNewOutlookContact"
+        Me.menuitemNewOutlookContact.Size = New System.Drawing.Size(258, 22)
+        Me.menuitemNewOutlookContact.Text = "Microsoft Outlook contact"
+        '
+        'menuitemNewPublisherPublication
+        '
+        Me.menuitemNewPublisherPublication.Name = "menuitemNewPublisherPublication"
+        Me.menuitemNewPublisherPublication.Size = New System.Drawing.Size(258, 22)
+        Me.menuitemNewPublisherPublication.Text = "Microsoft P&ublisher publication"
+        '
+        'zSeparatorNewMenuProfessionalApps
+        '
+        Me.zSeparatorNewMenuProfessionalApps.Name = "zSeparatorNewMenuProfessionalApps"
+        Me.zSeparatorNewMenuProfessionalApps.Size = New System.Drawing.Size(255, 6)
+        '
+        'zSeparatorOutlookArea
+        '
+        Me.zSeparatorOutlookArea.Name = "zSeparatorOutlookArea"
+        Me.zSeparatorOutlookArea.Size = New System.Drawing.Size(255, 6)
+        '
         'aaformMainWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -1060,4 +1122,13 @@ Partial Class aaformMainWindow
     Friend WithEvents menubarOpenButton As ToolStripMenuItem
     Friend WithEvents zToolStripSeparatorFileMenu As ToolStripSeparator
     Friend WithEvents openfiledialogOpenDocument As OpenFileDialog
+    Friend WithEvents menubarNewFileSubmenu As ToolStripMenuItem
+    Friend WithEvents menuitemNewWordDoc As ToolStripMenuItem
+    Friend WithEvents menuitemNewExcelWorkbook As ToolStripMenuItem
+    Friend WithEvents menuitemNewPPTPresentation As ToolStripMenuItem
+    Friend WithEvents menuitemNewOutlookEmail As ToolStripMenuItem
+    Friend WithEvents menuitemNewOutlookContact As ToolStripMenuItem
+    Friend WithEvents zSeparatorOutlookArea As ToolStripSeparator
+    Friend WithEvents zSeparatorNewMenuProfessionalApps As ToolStripSeparator
+    Friend WithEvents menuitemNewPublisherPublication As ToolStripMenuItem
 End Class

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -180,8 +180,9 @@ Partial Class aaformMainWindow
         Me.menuitemNewExcelWorkbook.Image = Global.UXL_Launcher.My.Resources.Resources.small_Excel
         Me.menuitemNewExcelWorkbook.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewExcelWorkbook.Name = "menuitemNewExcelWorkbook"
-        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(266, 30)
-        Me.menuitemNewExcelWorkbook.Text = "Microsoft &Excel workbook"
+        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(294, 30)
+        Me.menuitemNewExcelWorkbook.Text = "Microsoft &Excel workbook (macro sheet)"
+        Me.menuitemNewExcelWorkbook.ToolTipText = resources.GetString("menuitemNewExcelWorkbook.ToolTipText")
         '
         'menuitemNewPPTPresentation
         '

--- a/UXL-Launcher/MainWindow.resx
+++ b/UXL-Launcher/MainWindow.resx
@@ -120,6 +120,15 @@
   <metadata name="menubarMainWindow.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="menuitemNewExcelWorkbook.ToolTipText" xml:space="preserve">
+    <value>Microsoft doesn't provide a command to just create a new
+Excel workbook other than one that also adds a macro sheet
+to the new workbook.
+
+Because that command is used here, you'll see a macro sheet
+at the bottom, but you can just add a regular sheet and delete
+the macro one.</value>
+  </data>
   <data name="menubarRevertThemeButton.ToolTipText" xml:space="preserve">
     <value>Change the theme back to Default for this session only.
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -254,6 +254,18 @@ Public Class aaformMainWindow
         LaunchApp.NewWordDoc
     End Sub
 #End Region
+#Region "Microsoft Excel workbook"
+    Private Sub menuitemNewExcelWorkbook_Click(sender As Object, e As EventArgs) Handles menuitemNewExcelWorkbook.Click
+        ' When the user clicks this button, run Excel to create a new workbook.
+        LaunchApp.NewExcelWorkbook()
+    End Sub
+#End Region
+#Region "Microsoft PowerPoint presentation"
+    Private Sub menuitemNewPPTPresentation_Click(sender As Object, e As EventArgs) Handles menuitemNewPPTPresentation.Click
+        ' When the user clicks this button, run PowerPoint to create a new presentation.
+        LaunchApp.NewPPTPresentation()
+    End Sub
+#End Region
 
 #End Region
 #End Region

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -251,7 +251,7 @@ Public Class aaformMainWindow
     ' Create new Word document.
     Private Sub menuitemNewWordDoc_Click(sender As Object, e As EventArgs) Handles menuitemNewWordDoc.Click
         ' When the user clicks this button, run Word to create a new document.
-        LaunchApp.NewWordDoc
+        LaunchApp.NewWordDoc()
     End Sub
 #End Region
 #Region "Microsoft Excel workbook"
@@ -270,6 +270,12 @@ Public Class aaformMainWindow
     Private Sub menuitemNewOutlookEmail_Click(sender As Object, e As EventArgs) Handles menuitemNewOutlookEmail.Click
         ' When the user clicks this button, run Outlook to create a new email.
         LaunchApp.NewOutlookEmail()
+    End Sub
+#End Region
+#Region "Microsoft Outlook contact"
+    Private Sub menuitemNewOutlookContact_Click(sender As Object, e As EventArgs) Handles menuitemNewOutlookContact.Click
+        ' When the user clicks this button, run Outlook to create a new contact.
+        LaunchApp.NewOutlookContact
     End Sub
 #End Region
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -244,6 +244,18 @@ Public Class aaformMainWindow
             Process.Start(openfiledialogOpenDocument.FileName)
         End If
     End Sub
+
+#Region "New submenu"
+
+#Region "Microsoft Word document"
+    ' Create new Word document.
+    Private Sub menuitemNewWordDoc_Click(sender As Object, e As EventArgs) Handles menuitemNewWordDoc.Click
+        ' When the user clicks this button, run Word to create a new document.
+        LaunchApp.NewWordDoc
+    End Sub
+#End Region
+
+#End Region
 #End Region
 
     Private Sub menubarOptionsButton_Click(sender As Object, e As EventArgs) Handles menubarOptionsButton.Click

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -275,7 +275,7 @@ Public Class aaformMainWindow
 #Region "Microsoft Outlook contact"
     Private Sub menuitemNewOutlookContact_Click(sender As Object, e As EventArgs) Handles menuitemNewOutlookContact.Click
         ' When the user clicks this button, run Outlook to create a new contact.
-        LaunchApp.NewOutlookContact
+        LaunchApp.NewOutlookContact()
     End Sub
 #End Region
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -278,6 +278,12 @@ Public Class aaformMainWindow
         LaunchApp.NewOutlookContact()
     End Sub
 #End Region
+#Region "Microsoft Publisher publication"
+    Private Sub menuitemNewPublisherPublication_Click(sender As Object, e As EventArgs) Handles menuitemNewPublisherPublication.Click
+        ' When the user clicks this button, run Publisher to create a new publication.
+        LaunchApp.NewPublisherPublication()
+    End Sub
+#End Region
 
 #End Region
 #End Region

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -266,6 +266,12 @@ Public Class aaformMainWindow
         LaunchApp.NewPPTPresentation()
     End Sub
 #End Region
+#Region "Microsoft Outlook email"
+    Private Sub menuitemNewOutlookEmail_Click(sender As Object, e As EventArgs) Handles menuitemNewOutlookEmail.Click
+        ' When the user clicks this button, run Outlook to create a new email.
+        LaunchApp.NewOutlookEmail()
+    End Sub
+#End Region
 
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -145,5 +145,11 @@ Public Class LaunchApp
         isolated_error_handler.newFileErrorHandler("OUTLOOK.EXE", "/c ipm.contact", "Microsoft Outlook")
     End Sub
 #End Region
+#Region "Publisher"
+    Public Shared Sub NewPublisherPublication()
+        ' Create a new Outlook contact.
+        isolated_error_handler.newFileErrorHandler("MSPUB.EXE", "/b", "Microsoft Publisher")
+    End Sub
+#End Region
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -139,5 +139,11 @@ Public Class LaunchApp
         isolated_error_handler.newFileErrorHandler("OUTLOOK.EXE", "/c ipm.note", "Microsoft Outlook")
     End Sub
 #End Region
+#Region "Outlook - New Contact"
+    Public Shared Sub NewOutlookContact()
+        ' Create a new Outlook email.
+        isolated_error_handler.newFileErrorHandler("OUTLOOK.EXE", "/c ipm.contact", "Microsoft Outlook")
+    End Sub
+#End Region
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -133,5 +133,11 @@ Public Class LaunchApp
         isolated_error_handler.newFileErrorHandler("POWERPNT.EXE", "/b", "Microsoft PowerPoint")
     End Sub
 #End Region
+#Region "Outlook - New Email"
+    Public Shared Sub NewOutlookEmail()
+        ' Create a new Outlook email.
+        isolated_error_handler.newFileErrorHandler("OUTLOOK.EXE", "/c ipm.note", "Microsoft Outlook")
+    End Sub
+#End Region
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -121,5 +121,17 @@ Public Class LaunchApp
         isolated_error_handler.newFileErrorHandler("WINWORD.EXE", "/w", "Microsoft Word")
     End Sub
 #End Region
+#Region "Excel"
+    Public Shared Sub NewExcelWorkbook()
+        ' Create a new Excel workbook.
+        isolated_error_handler.newFileErrorHandler("EXCEL.EXE", "/m", "Microsoft Excel")
+    End Sub
+#End Region
+#Region "PowerPoint"
+    Public Shared Sub NewPPTPresentation()
+        ' Create a new PowerPoint presentation.
+        isolated_error_handler.newFileErrorHandler("POWERPNT.EXE", "/b", "Microsoft PowerPoint")
+    End Sub
+#End Region
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -118,7 +118,7 @@ Public Class LaunchApp
 #Region "Word"
     Public Shared Sub NewWordDoc()
         ' Create a new Word document.
-        isolated_error_handler.newFileErrorHandler("winword.exe /w", "New word doc")
+        isolated_error_handler.newFileErrorHandler("winword.exe", "/w", "Word")
     End Sub
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -118,7 +118,7 @@ Public Class LaunchApp
 #Region "Word"
     Public Shared Sub NewWordDoc()
         ' Create a new Word document.
-        isolated_error_handler.newFileErrorHandler("winword.exe", "/w", "Word")
+        isolated_error_handler.newFileErrorHandler("WINWORD.EXE", "/w", "Microsoft Word")
     End Sub
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -113,4 +113,13 @@ Public Class LaunchApp
     End Sub
 #End Region
 #End Region
+
+#Region "New files area"
+#Region "Word"
+    Public Shared Sub NewWordDoc()
+        ' Create a new Word document.
+        isolated_error_handler.launcherErrorHandler("winword.exe /w", "New word doc")
+    End Sub
+#End Region
+#End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -141,7 +141,7 @@ Public Class LaunchApp
 #End Region
 #Region "Outlook - New Contact"
     Public Shared Sub NewOutlookContact()
-        ' Create a new Outlook email.
+        ' Create a new Outlook contact.
         isolated_error_handler.newFileErrorHandler("OUTLOOK.EXE", "/c ipm.contact", "Microsoft Outlook")
     End Sub
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -147,7 +147,7 @@ Public Class LaunchApp
 #End Region
 #Region "Publisher"
     Public Shared Sub NewPublisherPublication()
-        ' Create a new Outlook contact.
+        ' Create a new Publisher publication.
         isolated_error_handler.newFileErrorHandler("MSPUB.EXE", "/b", "Microsoft Publisher")
     End Sub
 #End Region

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -118,7 +118,7 @@ Public Class LaunchApp
 #Region "Word"
     Public Shared Sub NewWordDoc()
         ' Create a new Word document.
-        isolated_error_handler.launcherErrorHandler("winword.exe /w", "New word doc")
+        isolated_error_handler.newFileErrorHandler("winword.exe /w", "New word doc")
     End Sub
 #End Region
 #End Region

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -76,7 +76,9 @@ Public Class isolated_error_handler
         Dim procNewFile As ProcessStartInfo
         ' Now, get the file to launch.
         procNewFile.FileName = OfficeLocater.fullLauncherCodeString & exeToLaunch
-
+        ' Assign start arguments.
+        procNewFile.Arguments = launchArguments
+        ' 
     End Sub
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -34,8 +34,8 @@ Public Class isolated_error_handler
         Try
             Process.Start(OfficeLocater.fullLauncherCodeString & launcherErrorHandler_ExeName)
         Catch ex As System.ComponentModel.Win32Exception
-            ' If Microsoft Access isn't found in the folder the user chose in the Options window, ask them if they want to
-            ' go to the Options window to change it.
+            ' If the program the user wants to launch isn't found in the folder the user chose
+            ' in the Options window, ask them if they want to go to the Options window to change it.
             Dim msgResult As Integer = MessageBox.Show("We couldn't find " & launcherErrorHandler_ExeFriendlyName & " in the configured location." &
             " Would you like to open the Options window to change your settings?" & vbCrLf &
                 "" & vbCrLf &
@@ -79,7 +79,10 @@ Public Class isolated_error_handler
         ' Assign start arguments.
         procNewFile.Arguments = launchArguments
         ' Try to start the program.
-        Process.Start(procNewFile)
+        Try
+            Process.Start(procNewFile)
+        Catch ex As System.ComponentModel.Win32Exception
+        End Try
     End Sub
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -69,7 +69,14 @@ Public Class isolated_error_handler
 
 #Region "New file error handler code."
     Public Shared Sub newFileErrorHandler(Optional exeToLaunch As String = "EXE To Launch", Optional launchArguments As String = "Launch Arguments", Optional exeFriendlyName As String = "EXE Friendly Name")
-        ' First, create a process 
+        ' First, create a ProcessStartInfo thing.
+        ' Based on code from HideSettingsPages.
+        ' https://github.com/DrewNaylor/HideSettingsPages
+
+        Dim procNewFile As ProcessStartInfo
+        ' Now, get the file to launch.
+        procNewFile.FileName = OfficeLocater.fullLauncherCodeString & exeToLaunch
+
     End Sub
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -89,9 +89,7 @@ Public Class isolated_error_handler
                 "" & vbCrLf &
                 "Full error message: " & ex.Message & vbCrLf &
                 vbCrLf &
-                "Configured location: " & OfficeLocater.fullLauncherCodeString & vbCrLf &
-                vbCrLf &
-                "Command-line argument(s) used: " & launchArguments, "Couldn't find " & exeFriendlyName, MessageBoxButtons.YesNo, MessageBoxIcon.Error)
+                "Configured location: " & OfficeLocater.fullLauncherCodeString, "Couldn't find " & exeFriendlyName, MessageBoxButtons.YesNo, MessageBoxIcon.Error)
 
             ' If the user chooses to open the Options window, open the Options window to the General tab.
             If msgResult = DialogResult.Yes Then

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -29,6 +29,7 @@
 
 
 Public Class isolated_error_handler
+#Region "Regular app launching error handler code."
     Public Shared Sub launcherErrorHandler(Optional launcherErrorHandler_ExeName As String = "ExeToLaunch.exe", Optional launcherErrorHandler_ExeFriendlyName As String = "Application Name Here")
         Try
             Process.Start(OfficeLocater.fullLauncherCodeString & launcherErrorHandler_ExeName)
@@ -64,4 +65,9 @@ Public Class isolated_error_handler
             End If
         End Try
     End Sub
+#End Region
+
+#Region "New file error handler code."
+
+#End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -68,6 +68,8 @@ Public Class isolated_error_handler
 #End Region
 
 #Region "New file error handler code."
-
+    Public Shared Sub newFileErrorHandler(exeToLaunch As String, launchArguments As String, exeFriendlyName As String)
+        Throw New NotImplementedException()
+    End Sub
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -68,8 +68,8 @@ Public Class isolated_error_handler
 #End Region
 
 #Region "New file error handler code."
-    Public Shared Sub newFileErrorHandler(exeToLaunch As String, launchArguments As String, exeFriendlyName As String)
-        Throw New NotImplementedException()
+    Public Shared Sub newFileErrorHandler(Optional exeToLaunch As String = "EXE To Launch", Optional launchArguments As String = "Launch Arguments", Optional exeFriendlyName As String = "EXE Friendly Name")
+        ' First, create a process 
     End Sub
 #End Region
 End Class

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -82,6 +82,36 @@ Public Class isolated_error_handler
         Try
             Process.Start(procNewFile)
         Catch ex As System.ComponentModel.Win32Exception
+            ' If the program the user wants to launch isn't found in the folder the user chose
+            ' in the Options window, ask them if they want to go to the Options window to change it.
+            Dim msgResult As Integer = MessageBox.Show("We couldn't find " & exeFriendlyName & " in the configured location." &
+            " Would you like to open the Options window to change your settings?" & vbCrLf &
+                "" & vbCrLf &
+                "Full error message: " & ex.Message & vbCrLf &
+                vbCrLf &
+                "Configured location: " & OfficeLocater.fullLauncherCodeString & vbCrLf &
+                vbCrLf &
+                "Command-line argument(s) used: " & launchArguments, "Couldn't find " & exeFriendlyName, MessageBoxButtons.YesNo, MessageBoxIcon.Error)
+
+            ' If the user chooses to open the Options window, open the Options window to the General tab.
+            If msgResult = DialogResult.Yes Then
+                ' Open the Options window. Credit goes to this SO answer: <http://stackoverflow.com/a/2513186>
+                Dim forceOptionsWindowTab As New aaformOptionsWindow
+                forceOptionsWindowTab.tabcontrolOptionsWindow.SelectTab(0)
+                forceOptionsWindowTab.ShowDialog(aaformMainWindow)
+            End If
+        Catch ex As Exception
+            ' If another error shows up, then we can't handle it yet and ask the user if they want to file a
+            ' bug report.
+            Dim msgResult As Integer = MessageBox.Show("An error occurred that we can't handle yet. Would you like to file a bug report online?" & vbCrLf & "Before clicking ""Yes,"" please write down what you were doing" & vbCrLf & "when the error occurred along with the text below" &
+                " and use that to fill out the bug report." & vbCrLf &
+                "" & vbCrLf &
+                "Error message: " & vbCrLf & ex.Message & vbCrLf & "Error type:" & vbCrLf & ex.GetType.ToString, "I just don't know what went wrong!",
+            MessageBoxButtons.YesNo, MessageBoxIcon.Error)
+            ' If the user chooses to file a bug report online, go to the GitHub Issues "New Issue."
+            If msgResult = DialogResult.Yes Then
+                Process.Start("https://github.com/DrewNaylor/UXL-Launcher/issues/new")
+            End If
         End Try
     End Sub
 #End Region

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -68,17 +68,18 @@ Public Class isolated_error_handler
 #End Region
 
 #Region "New file error handler code."
-    Public Shared Sub newFileErrorHandler(Optional exeToLaunch As String = "EXE To Launch", Optional launchArguments As String = "Launch Arguments", Optional exeFriendlyName As String = "EXE Friendly Name")
+    Public Shared Sub newFileErrorHandler(Optional exeToLaunch As String = "exeToLaunch.exe", Optional launchArguments As String = "Launch Arguments", Optional exeFriendlyName As String = "EXE Friendly Name")
         ' First, create a ProcessStartInfo thing.
         ' Based on code from HideSettingsPages.
         ' https://github.com/DrewNaylor/HideSettingsPages
 
-        Dim procNewFile As ProcessStartInfo
+        Dim procNewFile As New ProcessStartInfo
         ' Now, get the file to launch.
         procNewFile.FileName = OfficeLocater.fullLauncherCodeString & exeToLaunch
         ' Assign start arguments.
         procNewFile.Arguments = launchArguments
-        ' 
+        ' Try to start the program.
+        Process.Start(procNewFile)
     End Sub
 #End Region
 End Class


### PR DESCRIPTION
With this pull request, the user can now create new files in some Office programs from the `File>New` submenu.

Each entry has an icon based on the application it launches. The icons are sourced from the small icons used in the Quickmenu.

Available options include:

- Microsoft Word document
- Microsoft Excel worksheet (macro sheet)
- Microsoft PowerPoint presentation
- (separator)
- Microsoft Outlook email
- Microsoft Outlook contact
- (separator)
- Microsoft Publisher publication

Microsoft Access database creation and Microsoft OneNote-related tasks are not available yet.

- For Access, it's because I can't figure out an easy way to create a new database by using command-line args instead of complicated workarounds.
- For OneNote, it's because I feel that most users would rather use the OneNote interface to create new pages, sections, and notebooks.

The "(macro sheet)" in the Excel entry is because of this:

"Microsoft doesn't provide a command to just create a new Excel workbook other than one that also adds a macro sheet to the new workbook.

Because that command is used here, you'll see a macro sheet at the bottom, but you can just add a regular sheet and delete the macro one."