### PR TITLE
Move debug labels to their own window.

### DIFF
--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -36,12 +36,14 @@ Partial Class aaformDebugLabels
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.debugButtonDefaultThemeSetter = New System.Windows.Forms.Button()
         Me.debugButtonTestThemeSetter = New System.Windows.Forms.Button()
+        Me.Panel1 = New System.Windows.Forms.Panel()
+        Me.Panel1.SuspendLayout()
         Me.SuspendLayout()
         '
         'debugLabelXmlThemeFileVersion
         '
         Me.debugLabelXmlThemeFileVersion.AutoSize = True
-        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(11, 170)
+        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(12, 175)
         Me.debugLabelXmlThemeFileVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
         Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(220, 17)
@@ -51,7 +53,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeUseThemeEngineVersion
         '
         Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(11, 186)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(12, 191)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
         Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(311, 17)
@@ -61,7 +63,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeAuthor
         '
         Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(11, 153)
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(12, 158)
         Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
         Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(192, 17)
@@ -71,7 +73,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeTitle
         '
         Me.debugLabelXmlThemeTitle.AutoSize = True
-        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(11, 121)
+        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(12, 126)
         Me.debugLabelXmlThemeTitle.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeTitle.Name = "debugLabelXmlThemeTitle"
         Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(177, 17)
@@ -81,7 +83,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeDescription
         '
         Me.debugLabelXmlThemeDescription.AutoSize = True
-        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(11, 137)
+        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(12, 142)
         Me.debugLabelXmlThemeDescription.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeDescription.Name = "debugLabelXmlThemeDescription"
         Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(221, 17)
@@ -91,7 +93,7 @@ Partial Class aaformDebugLabels
         'debugLabelForUserHasOfficeThreeSixFive
         '
         Me.debugLabelForUserHasOfficeThreeSixFive.AutoSize = True
-        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(11, 89)
+        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(12, 94)
         Me.debugLabelForUserHasOfficeThreeSixFive.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelForUserHasOfficeThreeSixFive.Name = "debugLabelForUserHasOfficeThreeSixFive"
         Me.debugLabelForUserHasOfficeThreeSixFive.Size = New System.Drawing.Size(278, 17)
@@ -101,7 +103,7 @@ Partial Class aaformDebugLabels
         'debugLabelForofficeDriveLocation
         '
         Me.debugLabelForofficeDriveLocation.AutoSize = True
-        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(11, 9)
+        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(12, 14)
         Me.debugLabelForofficeDriveLocation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeDriveLocation.Name = "debugLabelForofficeDriveLocation"
         Me.debugLabelForofficeDriveLocation.Size = New System.Drawing.Size(225, 17)
@@ -111,7 +113,7 @@ Partial Class aaformDebugLabels
         'debugLabelForuserOfficeVersion
         '
         Me.debugLabelForuserOfficeVersion.AutoSize = True
-        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(11, 72)
+        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(12, 77)
         Me.debugLabelForuserOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForuserOfficeVersion.Name = "debugLabelForuserOfficeVersion"
         Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(217, 17)
@@ -121,7 +123,7 @@ Partial Class aaformDebugLabels
         'debugLabelForofficeInstallMethodString
         '
         Me.debugLabelForofficeInstallMethodString.AutoSize = True
-        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(11, 40)
+        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(12, 45)
         Me.debugLabelForofficeInstallMethodString.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeInstallMethodString.Name = "debugLabelForofficeInstallMethodString"
         Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(221, 34)
@@ -131,7 +133,7 @@ Partial Class aaformDebugLabels
         'debugLabelForcpuTypeString
         '
         Me.debugLabelForcpuTypeString.AutoSize = True
-        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(11, 23)
+        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(12, 28)
         Me.debugLabelForcpuTypeString.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelForcpuTypeString.Name = "debugLabelForcpuTypeString"
         Me.debugLabelForcpuTypeString.Size = New System.Drawing.Size(196, 17)
@@ -140,7 +142,7 @@ Partial Class aaformDebugLabels
         '
         'debugTextboxForFullLauncherCodeString
         '
-        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(11, 214)
+        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(12, 219)
         Me.debugTextboxForFullLauncherCodeString.Margin = New System.Windows.Forms.Padding(2)
         Me.debugTextboxForFullLauncherCodeString.Multiline = True
         Me.debugTextboxForFullLauncherCodeString.Name = "debugTextboxForFullLauncherCodeString"
@@ -151,7 +153,7 @@ Partial Class aaformDebugLabels
         'debugLabelForAlwaysOnTop
         '
         Me.debugLabelForAlwaysOnTop.AutoSize = True
-        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(19, 290)
+        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(20, 295)
         Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
         Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(222, 34)
@@ -160,7 +162,7 @@ Partial Class aaformDebugLabels
         '
         'debugButtonDefaultThemeSetter
         '
-        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(370, 262)
+        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(371, 267)
         Me.debugButtonDefaultThemeSetter.Margin = New System.Windows.Forms.Padding(4)
         Me.debugButtonDefaultThemeSetter.Name = "debugButtonDefaultThemeSetter"
         Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(94, 72)
@@ -170,7 +172,7 @@ Partial Class aaformDebugLabels
         '
         'debugButtonTestThemeSetter
         '
-        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(269, 262)
+        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(270, 267)
         Me.debugButtonTestThemeSetter.Margin = New System.Windows.Forms.Padding(4)
         Me.debugButtonTestThemeSetter.Name = "debugButtonTestThemeSetter"
         Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(94, 72)
@@ -178,29 +180,39 @@ Partial Class aaformDebugLabels
         Me.debugButtonTestThemeSetter.Text = "Apply Chosen Theme"
         Me.debugButtonTestThemeSetter.UseVisualStyleBackColor = True
         '
+        'Panel1
+        '
+        Me.Panel1.Controls.Add(Me.debugLabelForofficeDriveLocation)
+        Me.Panel1.Controls.Add(Me.debugButtonDefaultThemeSetter)
+        Me.Panel1.Controls.Add(Me.debugLabelForcpuTypeString)
+        Me.Panel1.Controls.Add(Me.debugButtonTestThemeSetter)
+        Me.Panel1.Controls.Add(Me.debugLabelForofficeInstallMethodString)
+        Me.Panel1.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
+        Me.Panel1.Controls.Add(Me.debugLabelForuserOfficeVersion)
+        Me.Panel1.Controls.Add(Me.debugLabelForAlwaysOnTop)
+        Me.Panel1.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
+        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeFileVersion)
+        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeDescription)
+        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
+        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeTitle)
+        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeAuthor)
+        Me.Panel1.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.Panel1.Location = New System.Drawing.Point(0, 0)
+        Me.Panel1.Name = "Panel1"
+        Me.Panel1.Size = New System.Drawing.Size(477, 360)
+        Me.Panel1.TabIndex = 42
+        '
         'aaformDebugLabels
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(477, 360)
-        Me.Controls.Add(Me.debugButtonDefaultThemeSetter)
-        Me.Controls.Add(Me.debugButtonTestThemeSetter)
-        Me.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
-        Me.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.Controls.Add(Me.debugLabelXmlThemeFileVersion)
-        Me.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
-        Me.Controls.Add(Me.debugLabelXmlThemeAuthor)
-        Me.Controls.Add(Me.debugLabelXmlThemeTitle)
-        Me.Controls.Add(Me.debugLabelXmlThemeDescription)
-        Me.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
-        Me.Controls.Add(Me.debugLabelForofficeDriveLocation)
-        Me.Controls.Add(Me.debugLabelForuserOfficeVersion)
-        Me.Controls.Add(Me.debugLabelForofficeInstallMethodString)
-        Me.Controls.Add(Me.debugLabelForcpuTypeString)
+        Me.Controls.Add(Me.Panel1)
         Me.Name = "aaformDebugLabels"
         Me.Text = "aaformDebugLabels"
+        Me.Panel1.ResumeLayout(False)
+        Me.Panel1.PerformLayout()
         Me.ResumeLayout(False)
-        Me.PerformLayout()
 
     End Sub
 
@@ -218,4 +230,5 @@ Partial Class aaformDebugLabels
     Friend WithEvents debugLabelForAlwaysOnTop As Label
     Friend WithEvents debugButtonDefaultThemeSetter As Button
     Friend WithEvents debugButtonTestThemeSetter As Button
+    Friend WithEvents Panel1 As Panel
 End Class

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -1,0 +1,221 @@
+﻿<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class aaformDebugLabels
+    Inherits System.Windows.Forms.Form
+
+    'Form overrides dispose to clean up the component list.
+    <System.Diagnostics.DebuggerNonUserCode()> _
+    Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    'Required by the Windows Form Designer
+    Private components As System.ComponentModel.IContainer
+
+    'NOTE: The following procedure is required by the Windows Form Designer
+    'It can be modified using the Windows Form Designer.  
+    'Do not modify it using the code editor.
+    <System.Diagnostics.DebuggerStepThrough()> _
+    Private Sub InitializeComponent()
+        Me.debugLabelXmlThemeFileVersion = New System.Windows.Forms.Label()
+        Me.debugLabelXmlThemeUseThemeEngineVersion = New System.Windows.Forms.Label()
+        Me.debugLabelXmlThemeAuthor = New System.Windows.Forms.Label()
+        Me.debugLabelXmlThemeTitle = New System.Windows.Forms.Label()
+        Me.debugLabelXmlThemeDescription = New System.Windows.Forms.Label()
+        Me.debugLabelForUserHasOfficeThreeSixFive = New System.Windows.Forms.Label()
+        Me.debugLabelForofficeDriveLocation = New System.Windows.Forms.Label()
+        Me.debugLabelForuserOfficeVersion = New System.Windows.Forms.Label()
+        Me.debugLabelForofficeInstallMethodString = New System.Windows.Forms.Label()
+        Me.debugLabelForcpuTypeString = New System.Windows.Forms.Label()
+        Me.debugTextboxForFullLauncherCodeString = New System.Windows.Forms.TextBox()
+        Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
+        Me.debugButtonDefaultThemeSetter = New System.Windows.Forms.Button()
+        Me.debugButtonTestThemeSetter = New System.Windows.Forms.Button()
+        Me.SuspendLayout()
+        '
+        'debugLabelXmlThemeFileVersion
+        '
+        Me.debugLabelXmlThemeFileVersion.AutoSize = True
+        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(11, 170)
+        Me.debugLabelXmlThemeFileVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
+        Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(220, 17)
+        Me.debugLabelXmlThemeFileVersion.TabIndex = 37
+        Me.debugLabelXmlThemeFileVersion.Text = "debugLabelXmlThemeFileVersion"
+        '
+        'debugLabelXmlThemeUseThemeEngineVersion
+        '
+        Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(11, 186)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(311, 17)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.TabIndex = 36
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Text = "debugLabelXmlThemeUseThemeEngineVersion"
+        '
+        'debugLabelXmlThemeAuthor
+        '
+        Me.debugLabelXmlThemeAuthor.AutoSize = True
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(11, 153)
+        Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
+        Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(192, 17)
+        Me.debugLabelXmlThemeAuthor.TabIndex = 35
+        Me.debugLabelXmlThemeAuthor.Text = "debugLabelXmlThemeAuthor"
+        '
+        'debugLabelXmlThemeTitle
+        '
+        Me.debugLabelXmlThemeTitle.AutoSize = True
+        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(11, 121)
+        Me.debugLabelXmlThemeTitle.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeTitle.Name = "debugLabelXmlThemeTitle"
+        Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(177, 17)
+        Me.debugLabelXmlThemeTitle.TabIndex = 34
+        Me.debugLabelXmlThemeTitle.Text = "debugLabelXmlThemeTitle"
+        '
+        'debugLabelXmlThemeDescription
+        '
+        Me.debugLabelXmlThemeDescription.AutoSize = True
+        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(11, 137)
+        Me.debugLabelXmlThemeDescription.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeDescription.Name = "debugLabelXmlThemeDescription"
+        Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(221, 17)
+        Me.debugLabelXmlThemeDescription.TabIndex = 33
+        Me.debugLabelXmlThemeDescription.Text = "debugLabelXmlThemeDescription"
+        '
+        'debugLabelForUserHasOfficeThreeSixFive
+        '
+        Me.debugLabelForUserHasOfficeThreeSixFive.AutoSize = True
+        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(11, 89)
+        Me.debugLabelForUserHasOfficeThreeSixFive.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelForUserHasOfficeThreeSixFive.Name = "debugLabelForUserHasOfficeThreeSixFive"
+        Me.debugLabelForUserHasOfficeThreeSixFive.Size = New System.Drawing.Size(278, 17)
+        Me.debugLabelForUserHasOfficeThreeSixFive.TabIndex = 32
+        Me.debugLabelForUserHasOfficeThreeSixFive.Text = "debugLabelForUserHasOfficeThreeSixFive"
+        '
+        'debugLabelForofficeDriveLocation
+        '
+        Me.debugLabelForofficeDriveLocation.AutoSize = True
+        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(11, 9)
+        Me.debugLabelForofficeDriveLocation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.debugLabelForofficeDriveLocation.Name = "debugLabelForofficeDriveLocation"
+        Me.debugLabelForofficeDriveLocation.Size = New System.Drawing.Size(225, 17)
+        Me.debugLabelForofficeDriveLocation.TabIndex = 31
+        Me.debugLabelForofficeDriveLocation.Text = "debugLabelForofficeDriveLocation"
+        '
+        'debugLabelForuserOfficeVersion
+        '
+        Me.debugLabelForuserOfficeVersion.AutoSize = True
+        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(11, 72)
+        Me.debugLabelForuserOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.debugLabelForuserOfficeVersion.Name = "debugLabelForuserOfficeVersion"
+        Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(217, 17)
+        Me.debugLabelForuserOfficeVersion.TabIndex = 30
+        Me.debugLabelForuserOfficeVersion.Text = "debugLabelForuserOfficeVersion"
+        '
+        'debugLabelForofficeInstallMethodString
+        '
+        Me.debugLabelForofficeInstallMethodString.AutoSize = True
+        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(11, 40)
+        Me.debugLabelForofficeInstallMethodString.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.debugLabelForofficeInstallMethodString.Name = "debugLabelForofficeInstallMethodString"
+        Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(221, 34)
+        Me.debugLabelForofficeInstallMethodString.TabIndex = 29
+        Me.debugLabelForofficeInstallMethodString.Text = "debugLabelForofficeInstallMethod" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "String"
+        '
+        'debugLabelForcpuTypeString
+        '
+        Me.debugLabelForcpuTypeString.AutoSize = True
+        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(11, 23)
+        Me.debugLabelForcpuTypeString.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelForcpuTypeString.Name = "debugLabelForcpuTypeString"
+        Me.debugLabelForcpuTypeString.Size = New System.Drawing.Size(196, 17)
+        Me.debugLabelForcpuTypeString.TabIndex = 28
+        Me.debugLabelForcpuTypeString.Text = "debugLabelForcpuTypeString"
+        '
+        'debugTextboxForFullLauncherCodeString
+        '
+        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(11, 214)
+        Me.debugTextboxForFullLauncherCodeString.Margin = New System.Windows.Forms.Padding(2)
+        Me.debugTextboxForFullLauncherCodeString.Multiline = True
+        Me.debugTextboxForFullLauncherCodeString.Name = "debugTextboxForFullLauncherCodeString"
+        Me.debugTextboxForFullLauncherCodeString.Size = New System.Drawing.Size(239, 63)
+        Me.debugTextboxForFullLauncherCodeString.TabIndex = 39
+        Me.debugTextboxForFullLauncherCodeString.Text = "debugTextboxForFullLauncherCodeString"
+        '
+        'debugLabelForAlwaysOnTop
+        '
+        Me.debugLabelForAlwaysOnTop.AutoSize = True
+        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(19, 290)
+        Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
+        Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(222, 34)
+        Me.debugLabelForAlwaysOnTop.TabIndex = 38
+        Me.debugLabelForAlwaysOnTop.Text = "This debug label shows the status" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "of the Always On Top feature."
+        '
+        'debugButtonDefaultThemeSetter
+        '
+        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(370, 262)
+        Me.debugButtonDefaultThemeSetter.Margin = New System.Windows.Forms.Padding(4)
+        Me.debugButtonDefaultThemeSetter.Name = "debugButtonDefaultThemeSetter"
+        Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(94, 72)
+        Me.debugButtonDefaultThemeSetter.TabIndex = 41
+        Me.debugButtonDefaultThemeSetter.Text = "Apply Default Theme"
+        Me.debugButtonDefaultThemeSetter.UseVisualStyleBackColor = True
+        '
+        'debugButtonTestThemeSetter
+        '
+        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(269, 262)
+        Me.debugButtonTestThemeSetter.Margin = New System.Windows.Forms.Padding(4)
+        Me.debugButtonTestThemeSetter.Name = "debugButtonTestThemeSetter"
+        Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(94, 72)
+        Me.debugButtonTestThemeSetter.TabIndex = 40
+        Me.debugButtonTestThemeSetter.Text = "Apply Chosen Theme"
+        Me.debugButtonTestThemeSetter.UseVisualStyleBackColor = True
+        '
+        'aaformDebugLabels
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(477, 360)
+        Me.Controls.Add(Me.debugButtonDefaultThemeSetter)
+        Me.Controls.Add(Me.debugButtonTestThemeSetter)
+        Me.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
+        Me.Controls.Add(Me.debugLabelForAlwaysOnTop)
+        Me.Controls.Add(Me.debugLabelXmlThemeFileVersion)
+        Me.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
+        Me.Controls.Add(Me.debugLabelXmlThemeAuthor)
+        Me.Controls.Add(Me.debugLabelXmlThemeTitle)
+        Me.Controls.Add(Me.debugLabelXmlThemeDescription)
+        Me.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
+        Me.Controls.Add(Me.debugLabelForofficeDriveLocation)
+        Me.Controls.Add(Me.debugLabelForuserOfficeVersion)
+        Me.Controls.Add(Me.debugLabelForofficeInstallMethodString)
+        Me.Controls.Add(Me.debugLabelForcpuTypeString)
+        Me.Name = "aaformDebugLabels"
+        Me.Text = "aaformDebugLabels"
+        Me.ResumeLayout(False)
+        Me.PerformLayout()
+
+    End Sub
+
+    Friend WithEvents debugLabelXmlThemeFileVersion As Label
+    Friend WithEvents debugLabelXmlThemeUseThemeEngineVersion As Label
+    Friend WithEvents debugLabelXmlThemeAuthor As Label
+    Friend WithEvents debugLabelXmlThemeTitle As Label
+    Friend WithEvents debugLabelXmlThemeDescription As Label
+    Friend WithEvents debugLabelForUserHasOfficeThreeSixFive As Label
+    Friend WithEvents debugLabelForofficeDriveLocation As Label
+    Friend WithEvents debugLabelForuserOfficeVersion As Label
+    Friend WithEvents debugLabelForofficeInstallMethodString As Label
+    Friend WithEvents debugLabelForcpuTypeString As Label
+    Friend WithEvents debugTextboxForFullLauncherCodeString As TextBox
+    Friend WithEvents debugLabelForAlwaysOnTop As Label
+    Friend WithEvents debugButtonDefaultThemeSetter As Button
+    Friend WithEvents debugButtonTestThemeSetter As Button
+End Class

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -36,14 +36,20 @@ Partial Class aaformDebugLabels
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.debugButtonDefaultThemeSetter = New System.Windows.Forms.Button()
         Me.debugButtonTestThemeSetter = New System.Windows.Forms.Button()
+        Me.groupboxOfficeDetails = New System.Windows.Forms.GroupBox()
+        Me.groupboxThemeInfo = New System.Windows.Forms.GroupBox()
+        Me.groupboxOther = New System.Windows.Forms.GroupBox()
         Me.panelLabelsTab = New System.Windows.Forms.Panel()
+        Me.groupboxOfficeDetails.SuspendLayout()
+        Me.groupboxThemeInfo.SuspendLayout()
+        Me.groupboxOther.SuspendLayout()
         Me.panelLabelsTab.SuspendLayout()
         Me.SuspendLayout()
         '
         'debugLabelXmlThemeFileVersion
         '
         Me.debugLabelXmlThemeFileVersion.AutoSize = True
-        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(12, 236)
+        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(5, 67)
         Me.debugLabelXmlThemeFileVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
         Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(220, 17)
@@ -53,7 +59,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeUseThemeEngineVersion
         '
         Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(12, 252)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(5, 83)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
         Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(311, 17)
@@ -63,7 +69,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeAuthor
         '
         Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(12, 219)
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(5, 50)
         Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
         Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(192, 17)
@@ -73,7 +79,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeTitle
         '
         Me.debugLabelXmlThemeTitle.AutoSize = True
-        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(12, 187)
+        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(5, 17)
         Me.debugLabelXmlThemeTitle.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeTitle.Name = "debugLabelXmlThemeTitle"
         Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(177, 17)
@@ -83,7 +89,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeDescription
         '
         Me.debugLabelXmlThemeDescription.AutoSize = True
-        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(12, 203)
+        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(5, 34)
         Me.debugLabelXmlThemeDescription.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeDescription.Name = "debugLabelXmlThemeDescription"
         Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(221, 17)
@@ -93,7 +99,7 @@ Partial Class aaformDebugLabels
         'debugLabelForUserHasOfficeThreeSixFive
         '
         Me.debugLabelForUserHasOfficeThreeSixFive.AutoSize = True
-        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(12, 94)
+        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(5, 98)
         Me.debugLabelForUserHasOfficeThreeSixFive.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelForUserHasOfficeThreeSixFive.Name = "debugLabelForUserHasOfficeThreeSixFive"
         Me.debugLabelForUserHasOfficeThreeSixFive.Size = New System.Drawing.Size(278, 17)
@@ -103,7 +109,7 @@ Partial Class aaformDebugLabels
         'debugLabelForofficeDriveLocation
         '
         Me.debugLabelForofficeDriveLocation.AutoSize = True
-        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(12, 14)
+        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(5, 18)
         Me.debugLabelForofficeDriveLocation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeDriveLocation.Name = "debugLabelForofficeDriveLocation"
         Me.debugLabelForofficeDriveLocation.Size = New System.Drawing.Size(225, 17)
@@ -113,7 +119,7 @@ Partial Class aaformDebugLabels
         'debugLabelForuserOfficeVersion
         '
         Me.debugLabelForuserOfficeVersion.AutoSize = True
-        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(12, 77)
+        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(5, 81)
         Me.debugLabelForuserOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForuserOfficeVersion.Name = "debugLabelForuserOfficeVersion"
         Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(217, 17)
@@ -123,7 +129,7 @@ Partial Class aaformDebugLabels
         'debugLabelForofficeInstallMethodString
         '
         Me.debugLabelForofficeInstallMethodString.AutoSize = True
-        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(12, 45)
+        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(5, 49)
         Me.debugLabelForofficeInstallMethodString.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeInstallMethodString.Name = "debugLabelForofficeInstallMethodString"
         Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(221, 34)
@@ -133,7 +139,7 @@ Partial Class aaformDebugLabels
         'debugLabelForcpuTypeString
         '
         Me.debugLabelForcpuTypeString.AutoSize = True
-        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(12, 28)
+        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(5, 32)
         Me.debugLabelForcpuTypeString.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelForcpuTypeString.Name = "debugLabelForcpuTypeString"
         Me.debugLabelForcpuTypeString.Size = New System.Drawing.Size(196, 17)
@@ -142,7 +148,7 @@ Partial Class aaformDebugLabels
         '
         'debugTextboxForFullLauncherCodeString
         '
-        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(15, 119)
+        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(8, 123)
         Me.debugTextboxForFullLauncherCodeString.Margin = New System.Windows.Forms.Padding(2)
         Me.debugTextboxForFullLauncherCodeString.Multiline = True
         Me.debugTextboxForFullLauncherCodeString.Name = "debugTextboxForFullLauncherCodeString"
@@ -153,7 +159,7 @@ Partial Class aaformDebugLabels
         'debugLabelForAlwaysOnTop
         '
         Me.debugLabelForAlwaysOnTop.AutoSize = True
-        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(12, 305)
+        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(5, 18)
         Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
         Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(222, 34)
@@ -162,7 +168,7 @@ Partial Class aaformDebugLabels
         '
         'debugButtonDefaultThemeSetter
         '
-        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(371, 267)
+        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(111, 105)
         Me.debugButtonDefaultThemeSetter.Margin = New System.Windows.Forms.Padding(4)
         Me.debugButtonDefaultThemeSetter.Name = "debugButtonDefaultThemeSetter"
         Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(94, 72)
@@ -172,7 +178,7 @@ Partial Class aaformDebugLabels
         '
         'debugButtonTestThemeSetter
         '
-        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(270, 267)
+        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(10, 105)
         Me.debugButtonTestThemeSetter.Margin = New System.Windows.Forms.Padding(4)
         Me.debugButtonTestThemeSetter.Name = "debugButtonTestThemeSetter"
         Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(94, 72)
@@ -180,38 +186,80 @@ Partial Class aaformDebugLabels
         Me.debugButtonTestThemeSetter.Text = "Apply Chosen Theme"
         Me.debugButtonTestThemeSetter.UseVisualStyleBackColor = True
         '
+        'groupboxOfficeDetails
+        '
+        Me.groupboxOfficeDetails.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForofficeDriveLocation)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForuserOfficeVersion)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForcpuTypeString)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForofficeInstallMethodString)
+        Me.groupboxOfficeDetails.Location = New System.Drawing.Point(3, 3)
+        Me.groupboxOfficeDetails.Name = "groupboxOfficeDetails"
+        Me.groupboxOfficeDetails.Size = New System.Drawing.Size(427, 193)
+        Me.groupboxOfficeDetails.TabIndex = 42
+        Me.groupboxOfficeDetails.TabStop = False
+        Me.groupboxOfficeDetails.Text = "Configured Location Details"
+        '
+        'groupboxThemeInfo
+        '
+        Me.groupboxThemeInfo.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeTitle)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeAuthor)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugButtonDefaultThemeSetter)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugButtonTestThemeSetter)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeDescription)
+        Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeFileVersion)
+        Me.groupboxThemeInfo.Location = New System.Drawing.Point(3, 202)
+        Me.groupboxThemeInfo.Name = "groupboxThemeInfo"
+        Me.groupboxThemeInfo.Size = New System.Drawing.Size(427, 182)
+        Me.groupboxThemeInfo.TabIndex = 43
+        Me.groupboxThemeInfo.TabStop = False
+        Me.groupboxThemeInfo.Text = "Theme Details"
+        '
+        'groupboxOther
+        '
+        Me.groupboxOther.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.groupboxOther.Controls.Add(Me.debugLabelForAlwaysOnTop)
+        Me.groupboxOther.Location = New System.Drawing.Point(3, 390)
+        Me.groupboxOther.Name = "groupboxOther"
+        Me.groupboxOther.Size = New System.Drawing.Size(427, 156)
+        Me.groupboxOther.TabIndex = 44
+        Me.groupboxOther.TabStop = False
+        Me.groupboxOther.Text = "Other Details"
+        '
         'panelLabelsTab
         '
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelForofficeDriveLocation)
-        Me.panelLabelsTab.Controls.Add(Me.debugButtonDefaultThemeSetter)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelForcpuTypeString)
-        Me.panelLabelsTab.Controls.Add(Me.debugButtonTestThemeSetter)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelForofficeInstallMethodString)
-        Me.panelLabelsTab.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelForuserOfficeVersion)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeFileVersion)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeDescription)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeTitle)
-        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeAuthor)
+        Me.panelLabelsTab.Controls.Add(Me.groupboxOther)
+        Me.panelLabelsTab.Controls.Add(Me.groupboxThemeInfo)
+        Me.panelLabelsTab.Controls.Add(Me.groupboxOfficeDetails)
         Me.panelLabelsTab.Dock = System.Windows.Forms.DockStyle.Fill
         Me.panelLabelsTab.Location = New System.Drawing.Point(0, 0)
         Me.panelLabelsTab.Name = "panelLabelsTab"
-        Me.panelLabelsTab.Size = New System.Drawing.Size(477, 360)
+        Me.panelLabelsTab.Size = New System.Drawing.Size(433, 549)
         Me.panelLabelsTab.TabIndex = 42
         '
         'aaformDebugLabels
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(477, 360)
+        Me.ClientSize = New System.Drawing.Size(433, 549)
         Me.Controls.Add(Me.panelLabelsTab)
         Me.Name = "aaformDebugLabels"
         Me.Text = "aaformDebugLabels"
+        Me.groupboxOfficeDetails.ResumeLayout(False)
+        Me.groupboxOfficeDetails.PerformLayout()
+        Me.groupboxThemeInfo.ResumeLayout(False)
+        Me.groupboxThemeInfo.PerformLayout()
+        Me.groupboxOther.ResumeLayout(False)
+        Me.groupboxOther.PerformLayout()
         Me.panelLabelsTab.ResumeLayout(False)
-        Me.panelLabelsTab.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -230,5 +278,8 @@ Partial Class aaformDebugLabels
     Friend WithEvents debugLabelForAlwaysOnTop As Label
     Friend WithEvents debugButtonDefaultThemeSetter As Button
     Friend WithEvents debugButtonTestThemeSetter As Button
+    Friend WithEvents groupboxThemeInfo As GroupBox
+    Friend WithEvents groupboxOfficeDetails As GroupBox
+    Friend WithEvents groupboxOther As GroupBox
     Friend WithEvents panelLabelsTab As Panel
 End Class

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -36,8 +36,8 @@ Partial Class aaformDebugLabels
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.debugButtonDefaultThemeSetter = New System.Windows.Forms.Button()
         Me.debugButtonTestThemeSetter = New System.Windows.Forms.Button()
-        Me.Panel1 = New System.Windows.Forms.Panel()
-        Me.Panel1.SuspendLayout()
+        Me.panelLabelsTab = New System.Windows.Forms.Panel()
+        Me.panelLabelsTab.SuspendLayout()
         Me.SuspendLayout()
         '
         'debugLabelXmlThemeFileVersion
@@ -180,38 +180,38 @@ Partial Class aaformDebugLabels
         Me.debugButtonTestThemeSetter.Text = "Apply Chosen Theme"
         Me.debugButtonTestThemeSetter.UseVisualStyleBackColor = True
         '
-        'Panel1
+        'panelLabelsTab
         '
-        Me.Panel1.Controls.Add(Me.debugLabelForofficeDriveLocation)
-        Me.Panel1.Controls.Add(Me.debugButtonDefaultThemeSetter)
-        Me.Panel1.Controls.Add(Me.debugLabelForcpuTypeString)
-        Me.Panel1.Controls.Add(Me.debugButtonTestThemeSetter)
-        Me.Panel1.Controls.Add(Me.debugLabelForofficeInstallMethodString)
-        Me.Panel1.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
-        Me.Panel1.Controls.Add(Me.debugLabelForuserOfficeVersion)
-        Me.Panel1.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.Panel1.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
-        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeFileVersion)
-        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeDescription)
-        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
-        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeTitle)
-        Me.Panel1.Controls.Add(Me.debugLabelXmlThemeAuthor)
-        Me.Panel1.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.Panel1.Location = New System.Drawing.Point(0, 0)
-        Me.Panel1.Name = "Panel1"
-        Me.Panel1.Size = New System.Drawing.Size(477, 360)
-        Me.Panel1.TabIndex = 42
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelForofficeDriveLocation)
+        Me.panelLabelsTab.Controls.Add(Me.debugButtonDefaultThemeSetter)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelForcpuTypeString)
+        Me.panelLabelsTab.Controls.Add(Me.debugButtonTestThemeSetter)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelForofficeInstallMethodString)
+        Me.panelLabelsTab.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelForuserOfficeVersion)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelForAlwaysOnTop)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeFileVersion)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeDescription)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeTitle)
+        Me.panelLabelsTab.Controls.Add(Me.debugLabelXmlThemeAuthor)
+        Me.panelLabelsTab.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.panelLabelsTab.Location = New System.Drawing.Point(0, 0)
+        Me.panelLabelsTab.Name = "panelLabelsTab"
+        Me.panelLabelsTab.Size = New System.Drawing.Size(477, 360)
+        Me.panelLabelsTab.TabIndex = 42
         '
         'aaformDebugLabels
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
         Me.ClientSize = New System.Drawing.Size(477, 360)
-        Me.Controls.Add(Me.Panel1)
+        Me.Controls.Add(Me.panelLabelsTab)
         Me.Name = "aaformDebugLabels"
         Me.Text = "aaformDebugLabels"
-        Me.Panel1.ResumeLayout(False)
-        Me.Panel1.PerformLayout()
+        Me.panelLabelsTab.ResumeLayout(False)
+        Me.panelLabelsTab.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -230,5 +230,5 @@ Partial Class aaformDebugLabels
     Friend WithEvents debugLabelForAlwaysOnTop As Label
     Friend WithEvents debugButtonDefaultThemeSetter As Button
     Friend WithEvents debugButtonTestThemeSetter As Button
-    Friend WithEvents Panel1 As Panel
+    Friend WithEvents panelLabelsTab As Panel
 End Class

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -38,11 +38,11 @@ Partial Class aaformDebugLabels
         Me.debugButtonTestThemeSetter = New System.Windows.Forms.Button()
         Me.groupboxOfficeDetails = New System.Windows.Forms.GroupBox()
         Me.groupboxThemeInfo = New System.Windows.Forms.GroupBox()
-        Me.groupboxOther = New System.Windows.Forms.GroupBox()
+        Me.groupboxAlwaysOnTop = New System.Windows.Forms.GroupBox()
         Me.panelLabelsTab = New System.Windows.Forms.Panel()
         Me.groupboxOfficeDetails.SuspendLayout()
         Me.groupboxThemeInfo.SuspendLayout()
-        Me.groupboxOther.SuspendLayout()
+        Me.groupboxAlwaysOnTop.SuspendLayout()
         Me.panelLabelsTab.SuspendLayout()
         Me.SuspendLayout()
         '
@@ -216,27 +216,27 @@ Partial Class aaformDebugLabels
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeFileVersion)
         Me.groupboxThemeInfo.Location = New System.Drawing.Point(3, 202)
         Me.groupboxThemeInfo.Name = "groupboxThemeInfo"
-        Me.groupboxThemeInfo.Size = New System.Drawing.Size(427, 182)
+        Me.groupboxThemeInfo.Size = New System.Drawing.Size(427, 189)
         Me.groupboxThemeInfo.TabIndex = 43
         Me.groupboxThemeInfo.TabStop = False
         Me.groupboxThemeInfo.Text = "Theme Details"
         '
-        'groupboxOther
+        'groupboxAlwaysOnTop
         '
-        Me.groupboxOther.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+        Me.groupboxAlwaysOnTop.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
             Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.groupboxOther.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.groupboxOther.Location = New System.Drawing.Point(3, 390)
-        Me.groupboxOther.Name = "groupboxOther"
-        Me.groupboxOther.Size = New System.Drawing.Size(427, 156)
-        Me.groupboxOther.TabIndex = 44
-        Me.groupboxOther.TabStop = False
-        Me.groupboxOther.Text = "Other Details"
+        Me.groupboxAlwaysOnTop.Controls.Add(Me.debugLabelForAlwaysOnTop)
+        Me.groupboxAlwaysOnTop.Location = New System.Drawing.Point(3, 397)
+        Me.groupboxAlwaysOnTop.Name = "groupboxAlwaysOnTop"
+        Me.groupboxAlwaysOnTop.Size = New System.Drawing.Size(427, 149)
+        Me.groupboxAlwaysOnTop.TabIndex = 44
+        Me.groupboxAlwaysOnTop.TabStop = False
+        Me.groupboxAlwaysOnTop.Text = "Always On Top Details"
         '
         'panelLabelsTab
         '
-        Me.panelLabelsTab.Controls.Add(Me.groupboxOther)
+        Me.panelLabelsTab.Controls.Add(Me.groupboxAlwaysOnTop)
         Me.panelLabelsTab.Controls.Add(Me.groupboxThemeInfo)
         Me.panelLabelsTab.Controls.Add(Me.groupboxOfficeDetails)
         Me.panelLabelsTab.Dock = System.Windows.Forms.DockStyle.Fill
@@ -257,8 +257,8 @@ Partial Class aaformDebugLabels
         Me.groupboxOfficeDetails.PerformLayout()
         Me.groupboxThemeInfo.ResumeLayout(False)
         Me.groupboxThemeInfo.PerformLayout()
-        Me.groupboxOther.ResumeLayout(False)
-        Me.groupboxOther.PerformLayout()
+        Me.groupboxAlwaysOnTop.ResumeLayout(False)
+        Me.groupboxAlwaysOnTop.PerformLayout()
         Me.panelLabelsTab.ResumeLayout(False)
         Me.ResumeLayout(False)
 
@@ -280,6 +280,6 @@ Partial Class aaformDebugLabels
     Friend WithEvents debugButtonTestThemeSetter As Button
     Friend WithEvents groupboxThemeInfo As GroupBox
     Friend WithEvents groupboxOfficeDetails As GroupBox
-    Friend WithEvents groupboxOther As GroupBox
+    Friend WithEvents groupboxAlwaysOnTop As GroupBox
     Friend WithEvents panelLabelsTab As Panel
 End Class

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -49,7 +49,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeFileVersion
         '
         Me.debugLabelXmlThemeFileVersion.AutoSize = True
-        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(5, 67)
+        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(5, 68)
         Me.debugLabelXmlThemeFileVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
         Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(220, 17)
@@ -59,7 +59,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeUseThemeEngineVersion
         '
         Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(5, 83)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(5, 85)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
         Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(311, 17)
@@ -69,7 +69,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeAuthor
         '
         Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(5, 50)
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(5, 51)
         Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
         Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(192, 17)
@@ -168,7 +168,7 @@ Partial Class aaformDebugLabels
         '
         'debugButtonDefaultThemeSetter
         '
-        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(111, 105)
+        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(112, 116)
         Me.debugButtonDefaultThemeSetter.Margin = New System.Windows.Forms.Padding(4)
         Me.debugButtonDefaultThemeSetter.Name = "debugButtonDefaultThemeSetter"
         Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(94, 72)
@@ -178,7 +178,7 @@ Partial Class aaformDebugLabels
         '
         'debugButtonTestThemeSetter
         '
-        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(10, 105)
+        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(10, 116)
         Me.debugButtonTestThemeSetter.Margin = New System.Windows.Forms.Padding(4)
         Me.debugButtonTestThemeSetter.Name = "debugButtonTestThemeSetter"
         Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(94, 72)
@@ -205,7 +205,8 @@ Partial Class aaformDebugLabels
         '
         'groupboxThemeInfo
         '
-        Me.groupboxThemeInfo.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+        Me.groupboxThemeInfo.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+            Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeTitle)
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeAuthor)
@@ -214,22 +215,21 @@ Partial Class aaformDebugLabels
         Me.groupboxThemeInfo.Controls.Add(Me.debugButtonTestThemeSetter)
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeDescription)
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeFileVersion)
-        Me.groupboxThemeInfo.Location = New System.Drawing.Point(3, 202)
+        Me.groupboxThemeInfo.Location = New System.Drawing.Point(3, 348)
         Me.groupboxThemeInfo.Name = "groupboxThemeInfo"
-        Me.groupboxThemeInfo.Size = New System.Drawing.Size(427, 189)
+        Me.groupboxThemeInfo.Size = New System.Drawing.Size(427, 198)
         Me.groupboxThemeInfo.TabIndex = 43
         Me.groupboxThemeInfo.TabStop = False
         Me.groupboxThemeInfo.Text = "Theme Details"
         '
         'groupboxAlwaysOnTop
         '
-        Me.groupboxAlwaysOnTop.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
-            Or System.Windows.Forms.AnchorStyles.Left) _
+        Me.groupboxAlwaysOnTop.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.groupboxAlwaysOnTop.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.groupboxAlwaysOnTop.Location = New System.Drawing.Point(3, 397)
+        Me.groupboxAlwaysOnTop.Location = New System.Drawing.Point(3, 202)
         Me.groupboxAlwaysOnTop.Name = "groupboxAlwaysOnTop"
-        Me.groupboxAlwaysOnTop.Size = New System.Drawing.Size(427, 149)
+        Me.groupboxAlwaysOnTop.Size = New System.Drawing.Size(427, 140)
         Me.groupboxAlwaysOnTop.TabIndex = 44
         Me.groupboxAlwaysOnTop.TabStop = False
         Me.groupboxAlwaysOnTop.Text = "Always On Top Details"

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -204,8 +204,8 @@ Partial Class aaformDebugLabels
         '
         'aaformDebugLabels
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(8.0!, 16.0!)
-        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
         Me.ClientSize = New System.Drawing.Size(477, 360)
         Me.Controls.Add(Me.panelLabelsTab)
         Me.Name = "aaformDebugLabels"

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -43,7 +43,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeFileVersion
         '
         Me.debugLabelXmlThemeFileVersion.AutoSize = True
-        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(12, 175)
+        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(12, 236)
         Me.debugLabelXmlThemeFileVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
         Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(220, 17)
@@ -53,7 +53,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeUseThemeEngineVersion
         '
         Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(12, 191)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(12, 252)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
         Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(311, 17)
@@ -63,7 +63,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeAuthor
         '
         Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(12, 158)
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(12, 219)
         Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
         Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(192, 17)
@@ -73,7 +73,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeTitle
         '
         Me.debugLabelXmlThemeTitle.AutoSize = True
-        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(12, 126)
+        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(12, 187)
         Me.debugLabelXmlThemeTitle.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeTitle.Name = "debugLabelXmlThemeTitle"
         Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(177, 17)
@@ -83,7 +83,7 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeDescription
         '
         Me.debugLabelXmlThemeDescription.AutoSize = True
-        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(12, 142)
+        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(12, 203)
         Me.debugLabelXmlThemeDescription.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
         Me.debugLabelXmlThemeDescription.Name = "debugLabelXmlThemeDescription"
         Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(221, 17)
@@ -142,7 +142,7 @@ Partial Class aaformDebugLabels
         '
         'debugTextboxForFullLauncherCodeString
         '
-        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(12, 219)
+        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(15, 119)
         Me.debugTextboxForFullLauncherCodeString.Margin = New System.Windows.Forms.Padding(2)
         Me.debugTextboxForFullLauncherCodeString.Multiline = True
         Me.debugTextboxForFullLauncherCodeString.Name = "debugTextboxForFullLauncherCodeString"
@@ -153,7 +153,7 @@ Partial Class aaformDebugLabels
         'debugLabelForAlwaysOnTop
         '
         Me.debugLabelForAlwaysOnTop.AutoSize = True
-        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(20, 295)
+        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(12, 305)
         Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
         Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(222, 34)

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -252,7 +252,7 @@ Partial Class aaformDebugLabels
         Me.ClientSize = New System.Drawing.Size(433, 549)
         Me.Controls.Add(Me.panelLabelsTab)
         Me.Name = "aaformDebugLabels"
-        Me.Text = "aaformDebugLabels"
+        Me.Text = "Debug Info"
         Me.groupboxOfficeDetails.ResumeLayout(False)
         Me.groupboxOfficeDetails.PerformLayout()
         Me.groupboxThemeInfo.ResumeLayout(False)

--- a/UXL-Launcher/DebugLabelsWindow.resx
+++ b/UXL-Launcher/DebugLabelsWindow.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -1,4 +1,33 @@
-﻿Public Class aaformDebugLabels
+﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
+'Copyright (C) 2013-2020 Drew Naylor
+'Microsoft Office and all related words are copyright
+'and trademark Microsoft Corporation. More details in the About window.
+'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor
+'and does not endorse this software.
+'Any other companies mentioned own their respective copyrights/trademarks.
+'(Note that the copyright years include the years left out by the hyphen.)
+'
+'This file is part of UXL Launcher
+'(Program is also known as "Unified eXecutable Launcher." Not to be confused with
+'other software titled "[Kindle] Unified Application Launcher",
+'"UX Launcher" [an Android launcher], or "Ulauncher" [a Linux app launcher].)
+'
+'UXL Launcher is free software: you can redistribute it and/or modify
+'it under the terms of the GNU General Public License as published by
+'the Free Software Foundation, either version 3 of the License, or
+'(at your option) any later version.
+'
+'UXL Launcher is distributed in the hope that it will be useful,
+'but WITHOUT ANY WARRANTY; without even the implied warranty of
+'MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+'GNU General Public License for more details.
+'
+'You should have received a copy of the GNU General Public License
+'along with UXL Launcher.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+Public Class aaformDebugLabels
     Private Sub aaformDebugLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
     End Sub

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -1,0 +1,30 @@
+﻿Public Class aaformDebugLabels
+    Private Sub aaformDebugLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+
+    End Sub
+
+    Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonTestThemeSetter.Click
+        ' Attempt to apply the theme the user chose.
+        If My.Settings.enableThemeEngine = True Then
+            aaformMainWindow.themeChooser()
+        End If
+    End Sub
+
+    Private Sub debugButtonDefaultThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonDefaultThemeSetter.Click
+        ' Attempt to apply the default theme.
+        If My.Settings.enableThemeEngine = True Then
+            UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.DefaultTheme_XML)
+            aaformMainWindow.themeApplier()
+            ' First make sure theme engine output is enabled.
+            If My.Settings.debugmodeShowThemeEngineOutput = True Then
+                Debug.WriteLine("userTheme:")
+                ' Due to changes to the theme engine, I had to change
+                ' how the theme engine outputs the user's theme file
+                ' and it doesn't look as good as it used to, but this
+                ' should be fine. "OuterXml" property from here:
+                ' https://msdn.microsoft.com/en-us/library/system.xml.xmlnode.outerxml.aspx
+                Debug.Print(UXLLauncher_ThemeEngine.userTheme.OuterXml)
+            End If
+        End If
+    End Sub
+End Class

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -32,24 +32,30 @@ Public Class aaformDebugLabels
         ' Make sure the debug labels are up to date and don't have the
         ' default text after closing and re-opening the window.
         debugmodeStuff.updateDebugLabels()
+        ' Show/hide areas as needed.
+        debugmodeStuff.showDebugLabels()
         ' If the theme engine is enabled, re-apply the current theme to the debug
         ' window so it's more consistent and doesn't use the Default theme after
         ' closing and re-opening it.
-        If My.Settings.enableThemeEngine = True Then
+        If aaformOptionsWindow.boolIsThemeEngineEnabled = True Then
             UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(Me, aaformMainWindow.UXLToolstripRenderer)
         End If
     End Sub
 
     Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonTestThemeSetter.Click
-        ' Attempt to apply the theme the user chose.
-        If My.Settings.enableThemeEngine = True Then
+        ' Attempt to apply the theme the user chose if the theme engine is enabled.
+        ' Make sure the theme engine was enabled at application start
+        ' so that the theme will be applied properly.
+        If aaformOptionsWindow.boolIsThemeEngineEnabled = True AndAlso My.Settings.enableThemeEngine = True Then
             aaformMainWindow.themeChooser()
         End If
     End Sub
 
     Private Sub debugButtonDefaultThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonDefaultThemeSetter.Click
-        ' Attempt to apply the default theme.
-        If My.Settings.enableThemeEngine = True Then
+        ' Attempt to apply the default theme if the theme engine is enabled.
+        ' Make sure the theme engine was enabled at application start
+        ' so that the theme will be applied properly.
+        If aaformOptionsWindow.boolIsThemeEngineEnabled = True AndAlso My.Settings.enableThemeEngine = True Then
             UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.DefaultTheme_XML)
             aaformMainWindow.themeApplier()
             ' First make sure theme engine output is enabled.

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -30,6 +30,7 @@
 Public Class aaformDebugLabels
     Private Sub aaformDebugLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         debugmodeStuff.updateDebugLabels()
+        UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(Me, aaformMainWindow.UXLToolstripRenderer)
     End Sub
 
     Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonTestThemeSetter.Click

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -29,7 +29,7 @@
 
 Public Class aaformDebugLabels
     Private Sub aaformDebugLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-
+        debugmodeStuff.updateDebugLabels()
     End Sub
 
     Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonTestThemeSetter.Click

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -29,7 +29,12 @@
 
 Public Class aaformDebugLabels
     Private Sub aaformDebugLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        ' Make sure the debug labels are up to date and don't have the
+        ' default text after closing and re-opening the window.
         debugmodeStuff.updateDebugLabels()
+        ' If the theme engine is enabled, re-apply the current theme to the debug
+        ' window so it's more consistent and doesn't use the Default theme after
+        ' closing and re-opening it.
         If My.Settings.enableThemeEngine = True Then
             UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(Me, aaformMainWindow.UXLToolstripRenderer)
         End If

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -30,7 +30,9 @@
 Public Class aaformDebugLabels
     Private Sub aaformDebugLabels_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         debugmodeStuff.updateDebugLabels()
-        UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(Me, aaformMainWindow.UXLToolstripRenderer)
+        If My.Settings.enableThemeEngine = True Then
+            UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(Me, aaformMainWindow.UXLToolstripRenderer)
+        End If
     End Sub
 
     Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonTestThemeSetter.Click

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -341,8 +341,8 @@ Partial Class aaformMainWindow
         'menuitemShowDebugWindow
         '
         Me.menuitemShowDebugWindow.Name = "menuitemShowDebugWindow"
-        Me.menuitemShowDebugWindow.Size = New System.Drawing.Size(223, 26)
-        Me.menuitemShowDebugWindow.Text = "Show debug &window"
+        Me.menuitemShowDebugWindow.Size = New System.Drawing.Size(224, 26)
+        Me.menuitemShowDebugWindow.Text = "Debug info &window..."
         '
         'contextmenuNotifyicon
         '

--- a/UXL-Launcher/MainWindow.Designer.vb
+++ b/UXL-Launcher/MainWindow.Designer.vb
@@ -52,6 +52,8 @@ Partial Class aaformMainWindow
         Me.menubarAuthorsButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarLicenseButton = New System.Windows.Forms.ToolStripMenuItem()
         Me.menubarAboutButton = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menubarDebugMenu = New System.Windows.Forms.ToolStripMenuItem()
+        Me.menuitemShowDebugWindow = New System.Windows.Forms.ToolStripMenuItem()
         Me.contextmenuNotifyicon = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.notifyiconWord = New System.Windows.Forms.ToolStripMenuItem()
         Me.notifyiconExcel = New System.Windows.Forms.ToolStripMenuItem()
@@ -75,9 +77,7 @@ Partial Class aaformMainWindow
         Me.statusbarLabelWelcomeText = New System.Windows.Forms.ToolStripStatusLabel()
         Me.flowLayoutPanel = New System.Windows.Forms.FlowLayoutPanel()
         Me.groupboxStandardApps = New System.Windows.Forms.GroupBox()
-        Me.debugButtonDefaultThemeSetter = New System.Windows.Forms.Button()
         Me.buttonRunOneNote = New System.Windows.Forms.Button()
-        Me.debugButtonTestThemeSetter = New System.Windows.Forms.Button()
         Me.buttonRunOutlook = New System.Windows.Forms.Button()
         Me.buttonRunPowerPoint = New System.Windows.Forms.Button()
         Me.buttonRunExcel = New System.Windows.Forms.Button()
@@ -88,16 +88,6 @@ Partial Class aaformMainWindow
         Me.pictureExcelIcon = New System.Windows.Forms.PictureBox()
         Me.pictureWordIcon = New System.Windows.Forms.PictureBox()
         Me.groupboxProApps = New System.Windows.Forms.GroupBox()
-        Me.debugLabelXmlThemeFileVersion = New System.Windows.Forms.Label()
-        Me.debugLabelXmlThemeUseThemeEngineVersion = New System.Windows.Forms.Label()
-        Me.debugLabelXmlThemeAuthor = New System.Windows.Forms.Label()
-        Me.debugLabelXmlThemeTitle = New System.Windows.Forms.Label()
-        Me.debugLabelXmlThemeDescription = New System.Windows.Forms.Label()
-        Me.debugLabelForUserHasOfficeThreeSixFive = New System.Windows.Forms.Label()
-        Me.debugLabelForofficeDriveLocation = New System.Windows.Forms.Label()
-        Me.debugLabelForuserOfficeVersion = New System.Windows.Forms.Label()
-        Me.debugLabelForofficeInstallMethodString = New System.Windows.Forms.Label()
-        Me.debugLabelForcpuTypeString = New System.Windows.Forms.Label()
         Me.buttonRunSharePointWkSp = New System.Windows.Forms.Button()
         Me.buttonRunAccess = New System.Windows.Forms.Button()
         Me.buttonRunInfoPath = New System.Windows.Forms.Button()
@@ -107,7 +97,6 @@ Partial Class aaformMainWindow
         Me.pictureInfoPathIcon = New System.Windows.Forms.PictureBox()
         Me.pictureSharepointIcon = New System.Windows.Forms.PictureBox()
         Me.groupboxExtraApps = New System.Windows.Forms.GroupBox()
-        Me.debugTextboxForFullLauncherCodeString = New System.Windows.Forms.TextBox()
         Me.buttonRunOneNoteQuickLaunch = New System.Windows.Forms.Button()
         Me.pictureQueryIcon = New System.Windows.Forms.PictureBox()
         Me.buttonRunQuery = New System.Windows.Forms.Button()
@@ -116,7 +105,6 @@ Partial Class aaformMainWindow
         Me.picturePictureManagerIcon = New System.Windows.Forms.PictureBox()
         Me.pictureClipOrganizerIcon = New System.Windows.Forms.PictureBox()
         Me.buttonRunClipOrganizer = New System.Windows.Forms.Button()
-        Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.notifyiconTaskbarLaunchers = New System.Windows.Forms.NotifyIcon(Me.components)
         Me.openfiledialogOpenDocument = New System.Windows.Forms.OpenFileDialog()
         Me.menubarMainWindow.SuspendLayout()
@@ -146,10 +134,11 @@ Partial Class aaformMainWindow
         Me.menubarMainWindow.AutoSize = False
         Me.menubarMainWindow.BackColor = System.Drawing.SystemColors.Control
         Me.menubarMainWindow.ImageScalingSize = New System.Drawing.Size(32, 32)
-        Me.menubarMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarFileMenu, Me.menubarViewMenu, Me.menubarToolsMenu, Me.menubarHelpMenu})
+        Me.menubarMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarFileMenu, Me.menubarViewMenu, Me.menubarToolsMenu, Me.menubarHelpMenu, Me.menubarDebugMenu})
         Me.menubarMainWindow.Location = New System.Drawing.Point(0, 0)
         Me.menubarMainWindow.Name = "menubarMainWindow"
-        Me.menubarMainWindow.Size = New System.Drawing.Size(640, 23)
+        Me.menubarMainWindow.Padding = New System.Windows.Forms.Padding(8, 2, 0, 2)
+        Me.menubarMainWindow.Size = New System.Drawing.Size(800, 29)
         Me.menubarMainWindow.TabIndex = 0
         Me.menubarMainWindow.Text = "MenuStrip1"
         '
@@ -157,14 +146,14 @@ Partial Class aaformMainWindow
         '
         Me.menubarFileMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarNewFileSubmenu, Me.menubarOpenButton, Me.zToolStripSeparatorFileMenu, Me.menubarExitButton})
         Me.menubarFileMenu.Name = "menubarFileMenu"
-        Me.menubarFileMenu.Size = New System.Drawing.Size(37, 19)
+        Me.menubarFileMenu.Size = New System.Drawing.Size(44, 25)
         Me.menubarFileMenu.Text = "&File"
         '
         'menubarNewFileSubmenu
         '
         Me.menubarNewFileSubmenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menuitemNewWordDoc, Me.menuitemNewExcelWorkbook, Me.menuitemNewPPTPresentation, Me.zSeparatorOutlookArea, Me.menuitemNewOutlookEmail, Me.menuitemNewOutlookContact, Me.zSeparatorNewMenuProfessionalApps, Me.menuitemNewPublisherPublication})
         Me.menubarNewFileSubmenu.Name = "menubarNewFileSubmenu"
-        Me.menubarNewFileSubmenu.Size = New System.Drawing.Size(155, 22)
+        Me.menubarNewFileSubmenu.Size = New System.Drawing.Size(182, 26)
         Me.menubarNewFileSubmenu.Text = "&New"
         '
         'menuitemNewWordDoc
@@ -173,7 +162,7 @@ Partial Class aaformMainWindow
         Me.menuitemNewWordDoc.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewWordDoc.Name = "menuitemNewWordDoc"
         Me.menuitemNewWordDoc.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.N), System.Windows.Forms.Keys)
-        Me.menuitemNewWordDoc.Size = New System.Drawing.Size(295, 30)
+        Me.menuitemNewWordDoc.Size = New System.Drawing.Size(354, 30)
         Me.menuitemNewWordDoc.Text = "Microsoft &Word document"
         '
         'menuitemNewExcelWorkbook
@@ -181,7 +170,7 @@ Partial Class aaformMainWindow
         Me.menuitemNewExcelWorkbook.Image = Global.UXL_Launcher.My.Resources.Resources.small_Excel
         Me.menuitemNewExcelWorkbook.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewExcelWorkbook.Name = "menuitemNewExcelWorkbook"
-        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(295, 30)
+        Me.menuitemNewExcelWorkbook.Size = New System.Drawing.Size(354, 30)
         Me.menuitemNewExcelWorkbook.Text = "Microsoft &Excel workbook (macro sheet)"
         Me.menuitemNewExcelWorkbook.ToolTipText = resources.GetString("menuitemNewExcelWorkbook.ToolTipText")
         '
@@ -190,20 +179,20 @@ Partial Class aaformMainWindow
         Me.menuitemNewPPTPresentation.Image = Global.UXL_Launcher.My.Resources.Resources.small_Powerpoint
         Me.menuitemNewPPTPresentation.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewPPTPresentation.Name = "menuitemNewPPTPresentation"
-        Me.menuitemNewPPTPresentation.Size = New System.Drawing.Size(295, 30)
+        Me.menuitemNewPPTPresentation.Size = New System.Drawing.Size(354, 30)
         Me.menuitemNewPPTPresentation.Text = "Microsoft &PowerPoint presentation"
         '
         'zSeparatorOutlookArea
         '
         Me.zSeparatorOutlookArea.Name = "zSeparatorOutlookArea"
-        Me.zSeparatorOutlookArea.Size = New System.Drawing.Size(292, 6)
+        Me.zSeparatorOutlookArea.Size = New System.Drawing.Size(351, 6)
         '
         'menuitemNewOutlookEmail
         '
         Me.menuitemNewOutlookEmail.Image = Global.UXL_Launcher.My.Resources.Resources.small_Outlook
         Me.menuitemNewOutlookEmail.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewOutlookEmail.Name = "menuitemNewOutlookEmail"
-        Me.menuitemNewOutlookEmail.Size = New System.Drawing.Size(295, 30)
+        Me.menuitemNewOutlookEmail.Size = New System.Drawing.Size(354, 30)
         Me.menuitemNewOutlookEmail.Text = "Microsoft Outlook e&mail"
         '
         'menuitemNewOutlookContact
@@ -211,60 +200,60 @@ Partial Class aaformMainWindow
         Me.menuitemNewOutlookContact.Image = Global.UXL_Launcher.My.Resources.Resources.small_Outlook
         Me.menuitemNewOutlookContact.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewOutlookContact.Name = "menuitemNewOutlookContact"
-        Me.menuitemNewOutlookContact.Size = New System.Drawing.Size(295, 30)
+        Me.menuitemNewOutlookContact.Size = New System.Drawing.Size(354, 30)
         Me.menuitemNewOutlookContact.Text = "Microsoft Outlook &contact"
         '
         'zSeparatorNewMenuProfessionalApps
         '
         Me.zSeparatorNewMenuProfessionalApps.Name = "zSeparatorNewMenuProfessionalApps"
-        Me.zSeparatorNewMenuProfessionalApps.Size = New System.Drawing.Size(292, 6)
+        Me.zSeparatorNewMenuProfessionalApps.Size = New System.Drawing.Size(351, 6)
         '
         'menuitemNewPublisherPublication
         '
         Me.menuitemNewPublisherPublication.Image = Global.UXL_Launcher.My.Resources.Resources.small_Publisher
         Me.menuitemNewPublisherPublication.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menuitemNewPublisherPublication.Name = "menuitemNewPublisherPublication"
-        Me.menuitemNewPublisherPublication.Size = New System.Drawing.Size(295, 30)
+        Me.menuitemNewPublisherPublication.Size = New System.Drawing.Size(354, 30)
         Me.menuitemNewPublisherPublication.Text = "Microsoft P&ublisher publication"
         '
         'menubarOpenButton
         '
         Me.menubarOpenButton.Name = "menubarOpenButton"
         Me.menubarOpenButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.O), System.Windows.Forms.Keys)
-        Me.menubarOpenButton.Size = New System.Drawing.Size(155, 22)
+        Me.menubarOpenButton.Size = New System.Drawing.Size(182, 26)
         Me.menubarOpenButton.Text = "&Open..."
         '
         'zToolStripSeparatorFileMenu
         '
         Me.zToolStripSeparatorFileMenu.Name = "zToolStripSeparatorFileMenu"
-        Me.zToolStripSeparatorFileMenu.Size = New System.Drawing.Size(152, 6)
+        Me.zToolStripSeparatorFileMenu.Size = New System.Drawing.Size(179, 6)
         '
         'menubarExitButton
         '
         Me.menubarExitButton.Name = "menubarExitButton"
         Me.menubarExitButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Alt Or System.Windows.Forms.Keys.F4), System.Windows.Forms.Keys)
-        Me.menubarExitButton.Size = New System.Drawing.Size(155, 22)
+        Me.menubarExitButton.Size = New System.Drawing.Size(182, 26)
         Me.menubarExitButton.Text = "E&xit"
         '
         'menubarViewMenu
         '
         Me.menubarViewMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarAlwaysOnTopButton, Me.menubarHideWhenMinimizedButton, Me.menubarRevertThemeButton})
         Me.menubarViewMenu.Name = "menubarViewMenu"
-        Me.menubarViewMenu.Size = New System.Drawing.Size(44, 19)
+        Me.menubarViewMenu.Size = New System.Drawing.Size(53, 25)
         Me.menubarViewMenu.Text = "&View"
         '
         'menubarAlwaysOnTopButton
         '
         Me.menubarAlwaysOnTopButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarAlwaysOnTopButton.Name = "menubarAlwaysOnTopButton"
-        Me.menubarAlwaysOnTopButton.Size = New System.Drawing.Size(231, 22)
+        Me.menubarAlwaysOnTopButton.Size = New System.Drawing.Size(284, 26)
         Me.menubarAlwaysOnTopButton.Text = "&Always On Top"
         '
         'menubarHideWhenMinimizedButton
         '
         Me.menubarHideWhenMinimizedButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarHideWhenMinimizedButton.Name = "menubarHideWhenMinimizedButton"
-        Me.menubarHideWhenMinimizedButton.Size = New System.Drawing.Size(231, 22)
+        Me.menubarHideWhenMinimizedButton.Size = New System.Drawing.Size(284, 26)
         Me.menubarHideWhenMinimizedButton.Text = "&Hide When Minimized"
         '
         'menubarRevertThemeButton
@@ -272,7 +261,7 @@ Partial Class aaformMainWindow
         Me.menubarRevertThemeButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarRevertThemeButton.Name = "menubarRevertThemeButton"
         Me.menubarRevertThemeButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.R), System.Windows.Forms.Keys)
-        Me.menubarRevertThemeButton.Size = New System.Drawing.Size(231, 22)
+        Me.menubarRevertThemeButton.Size = New System.Drawing.Size(284, 26)
         Me.menubarRevertThemeButton.Text = "&Reload Default Theme"
         Me.menubarRevertThemeButton.ToolTipText = resources.GetString("menubarRevertThemeButton.ToolTipText")
         '
@@ -280,7 +269,7 @@ Partial Class aaformMainWindow
         '
         Me.menubarToolsMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarOfficeLangPrefsButton, Me.zseparatorToolsMenu1, Me.menubarOptionsButton})
         Me.menubarToolsMenu.Name = "menubarToolsMenu"
-        Me.menubarToolsMenu.Size = New System.Drawing.Size(46, 19)
+        Me.menubarToolsMenu.Size = New System.Drawing.Size(56, 25)
         Me.menubarToolsMenu.Text = "&Tools"
         '
         'menubarOfficeLangPrefsButton
@@ -289,58 +278,71 @@ Partial Class aaformMainWindow
         Me.menubarOfficeLangPrefsButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarOfficeLangPrefsButton.Name = "menubarOfficeLangPrefsButton"
         Me.menubarOfficeLangPrefsButton.Padding = New System.Windows.Forms.Padding(0)
-        Me.menubarOfficeLangPrefsButton.Size = New System.Drawing.Size(233, 28)
+        Me.menubarOfficeLangPrefsButton.Size = New System.Drawing.Size(277, 28)
         Me.menubarOfficeLangPrefsButton.Text = "O&ffice Language Preferences"
         '
         'zseparatorToolsMenu1
         '
         Me.zseparatorToolsMenu1.Name = "zseparatorToolsMenu1"
-        Me.zseparatorToolsMenu1.Size = New System.Drawing.Size(230, 6)
+        Me.zseparatorToolsMenu1.Size = New System.Drawing.Size(274, 6)
         '
         'menubarOptionsButton
         '
         Me.menubarOptionsButton.Image = Global.UXL_Launcher.My.Resources.Resources.uxl_icon_24x24
         Me.menubarOptionsButton.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.menubarOptionsButton.Name = "menubarOptionsButton"
-        Me.menubarOptionsButton.Size = New System.Drawing.Size(233, 30)
+        Me.menubarOptionsButton.Size = New System.Drawing.Size(277, 30)
         Me.menubarOptionsButton.Text = "&Options..."
         '
         'menubarHelpMenu
         '
         Me.menubarHelpMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menubarHelpTopicsButton, Me.zseparatorHelpMenu, Me.menubarAuthorsButton, Me.menubarLicenseButton, Me.menubarAboutButton})
         Me.menubarHelpMenu.Name = "menubarHelpMenu"
-        Me.menubarHelpMenu.Size = New System.Drawing.Size(44, 19)
+        Me.menubarHelpMenu.Size = New System.Drawing.Size(53, 25)
         Me.menubarHelpMenu.Text = "&Help"
         '
         'menubarHelpTopicsButton
         '
         Me.menubarHelpTopicsButton.Name = "menubarHelpTopicsButton"
         Me.menubarHelpTopicsButton.ShortcutKeys = CType((System.Windows.Forms.Keys.Control Or System.Windows.Forms.Keys.F1), System.Windows.Forms.Keys)
-        Me.menubarHelpTopicsButton.Size = New System.Drawing.Size(209, 22)
+        Me.menubarHelpTopicsButton.Size = New System.Drawing.Size(255, 26)
         Me.menubarHelpTopicsButton.Text = "&View Help Topics"
         '
         'zseparatorHelpMenu
         '
         Me.zseparatorHelpMenu.Name = "zseparatorHelpMenu"
-        Me.zseparatorHelpMenu.Size = New System.Drawing.Size(206, 6)
+        Me.zseparatorHelpMenu.Size = New System.Drawing.Size(252, 6)
         '
         'menubarAuthorsButton
         '
         Me.menubarAuthorsButton.Name = "menubarAuthorsButton"
-        Me.menubarAuthorsButton.Size = New System.Drawing.Size(209, 22)
+        Me.menubarAuthorsButton.Size = New System.Drawing.Size(255, 26)
         Me.menubarAuthorsButton.Text = "A&cknowledgements"
         '
         'menubarLicenseButton
         '
         Me.menubarLicenseButton.Name = "menubarLicenseButton"
-        Me.menubarLicenseButton.Size = New System.Drawing.Size(209, 22)
+        Me.menubarLicenseButton.Size = New System.Drawing.Size(255, 26)
         Me.menubarLicenseButton.Text = "&License"
         '
         'menubarAboutButton
         '
         Me.menubarAboutButton.Name = "menubarAboutButton"
-        Me.menubarAboutButton.Size = New System.Drawing.Size(209, 22)
+        Me.menubarAboutButton.Size = New System.Drawing.Size(255, 26)
         Me.menubarAboutButton.Text = "&About"
+        '
+        'menubarDebugMenu
+        '
+        Me.menubarDebugMenu.DropDownItems.AddRange(New System.Windows.Forms.ToolStripItem() {Me.menuitemShowDebugWindow})
+        Me.menubarDebugMenu.Name = "menubarDebugMenu"
+        Me.menubarDebugMenu.Size = New System.Drawing.Size(64, 25)
+        Me.menubarDebugMenu.Text = "&debug"
+        '
+        'menuitemShowDebugWindow
+        '
+        Me.menuitemShowDebugWindow.Name = "menuitemShowDebugWindow"
+        Me.menuitemShowDebugWindow.Size = New System.Drawing.Size(223, 26)
+        Me.menuitemShowDebugWindow.Text = "Show debug &window"
         '
         'contextmenuNotifyicon
         '
@@ -348,14 +350,14 @@ Partial Class aaformMainWindow
         Me.contextmenuNotifyicon.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.notifyiconWord, Me.notifyiconExcel, Me.notifyiconPowerpoint, Me.notifyiconOutlook, Me.notifyiconOnenote, Me.notifyiconSeparator1, Me.notifyiconAccess, Me.notifyiconPublisher, Me.notifyiconInfopath, Me.notifyiconSharepointWkSp, Me.notifyiconSeparator2, Me.notifyiconOfficeLang, Me.notifyiconUXLOptions, Me.notifyiconSeparator3, Me.notifyiconShowApp, Me.notifyiconExitApp})
         Me.contextmenuNotifyicon.Name = "contextmenuNotifyicon"
         Me.contextmenuNotifyicon.RenderMode = System.Windows.Forms.ToolStripRenderMode.Professional
-        Me.contextmenuNotifyicon.Size = New System.Drawing.Size(255, 412)
+        Me.contextmenuNotifyicon.Size = New System.Drawing.Size(300, 412)
         '
         'notifyiconWord
         '
         Me.notifyiconWord.Image = Global.UXL_Launcher.My.Resources.Resources.small_Word
         Me.notifyiconWord.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconWord.Name = "notifyiconWord"
-        Me.notifyiconWord.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconWord.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconWord.Text = "Microsoft Word"
         '
         'notifyiconExcel
@@ -363,7 +365,7 @@ Partial Class aaformMainWindow
         Me.notifyiconExcel.Image = Global.UXL_Launcher.My.Resources.Resources.small_Excel
         Me.notifyiconExcel.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconExcel.Name = "notifyiconExcel"
-        Me.notifyiconExcel.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconExcel.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconExcel.Text = "Microsoft Excel"
         '
         'notifyiconPowerpoint
@@ -371,7 +373,7 @@ Partial Class aaformMainWindow
         Me.notifyiconPowerpoint.Image = Global.UXL_Launcher.My.Resources.Resources.small_Powerpoint
         Me.notifyiconPowerpoint.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconPowerpoint.Name = "notifyiconPowerpoint"
-        Me.notifyiconPowerpoint.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconPowerpoint.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconPowerpoint.Text = "Microsoft PowerPoint"
         '
         'notifyiconOutlook
@@ -379,7 +381,7 @@ Partial Class aaformMainWindow
         Me.notifyiconOutlook.Image = Global.UXL_Launcher.My.Resources.Resources.small_Outlook
         Me.notifyiconOutlook.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconOutlook.Name = "notifyiconOutlook"
-        Me.notifyiconOutlook.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconOutlook.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconOutlook.Text = "Microsoft Outlook"
         '
         'notifyiconOnenote
@@ -387,20 +389,20 @@ Partial Class aaformMainWindow
         Me.notifyiconOnenote.Image = Global.UXL_Launcher.My.Resources.Resources.small_Onenote
         Me.notifyiconOnenote.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconOnenote.Name = "notifyiconOnenote"
-        Me.notifyiconOnenote.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconOnenote.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconOnenote.Text = "Microsoft OneNote"
         '
         'notifyiconSeparator1
         '
         Me.notifyiconSeparator1.Name = "notifyiconSeparator1"
-        Me.notifyiconSeparator1.Size = New System.Drawing.Size(251, 6)
+        Me.notifyiconSeparator1.Size = New System.Drawing.Size(296, 6)
         '
         'notifyiconAccess
         '
         Me.notifyiconAccess.Image = Global.UXL_Launcher.My.Resources.Resources.small_Access
         Me.notifyiconAccess.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconAccess.Name = "notifyiconAccess"
-        Me.notifyiconAccess.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconAccess.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconAccess.Text = "Microsoft Access"
         '
         'notifyiconPublisher
@@ -408,7 +410,7 @@ Partial Class aaformMainWindow
         Me.notifyiconPublisher.Image = Global.UXL_Launcher.My.Resources.Resources.small_Publisher
         Me.notifyiconPublisher.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconPublisher.Name = "notifyiconPublisher"
-        Me.notifyiconPublisher.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconPublisher.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconPublisher.Text = "Microsoft Publisher"
         '
         'notifyiconInfopath
@@ -416,7 +418,7 @@ Partial Class aaformMainWindow
         Me.notifyiconInfopath.Image = Global.UXL_Launcher.My.Resources.Resources.small_Infopath
         Me.notifyiconInfopath.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconInfopath.Name = "notifyiconInfopath"
-        Me.notifyiconInfopath.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconInfopath.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconInfopath.Text = "Microsoft InfoPath"
         '
         'notifyiconSharepointWkSp
@@ -424,20 +426,20 @@ Partial Class aaformMainWindow
         Me.notifyiconSharepointWkSp.Image = Global.UXL_Launcher.My.Resources.Resources.small_Sharepoint
         Me.notifyiconSharepointWkSp.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconSharepointWkSp.Name = "notifyiconSharepointWkSp"
-        Me.notifyiconSharepointWkSp.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconSharepointWkSp.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconSharepointWkSp.Text = "Microsoft SharePoint Workspace"
         '
         'notifyiconSeparator2
         '
         Me.notifyiconSeparator2.Name = "notifyiconSeparator2"
-        Me.notifyiconSeparator2.Size = New System.Drawing.Size(251, 6)
+        Me.notifyiconSeparator2.Size = New System.Drawing.Size(296, 6)
         '
         'notifyiconOfficeLang
         '
         Me.notifyiconOfficeLang.Image = Global.UXL_Launcher.My.Resources.Resources.small_Language_Settings
         Me.notifyiconOfficeLang.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconOfficeLang.Name = "notifyiconOfficeLang"
-        Me.notifyiconOfficeLang.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconOfficeLang.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconOfficeLang.Text = "Office Language Preferences"
         '
         'notifyiconUXLOptions
@@ -445,25 +447,25 @@ Partial Class aaformMainWindow
         Me.notifyiconUXLOptions.Image = Global.UXL_Launcher.My.Resources.Resources.uxl_icon_24x24
         Me.notifyiconUXLOptions.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconUXLOptions.Name = "notifyiconUXLOptions"
-        Me.notifyiconUXLOptions.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconUXLOptions.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconUXLOptions.Text = "Options..."
         '
         'notifyiconSeparator3
         '
         Me.notifyiconSeparator3.Name = "notifyiconSeparator3"
-        Me.notifyiconSeparator3.Size = New System.Drawing.Size(251, 6)
+        Me.notifyiconSeparator3.Size = New System.Drawing.Size(296, 6)
         '
         'notifyiconShowApp
         '
         Me.notifyiconShowApp.Name = "notifyiconShowApp"
-        Me.notifyiconShowApp.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconShowApp.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconShowApp.Text = "Show UXL Launcher"
         '
         'notifyiconExitApp
         '
         Me.notifyiconExitApp.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None
         Me.notifyiconExitApp.Name = "notifyiconExitApp"
-        Me.notifyiconExitApp.Size = New System.Drawing.Size(254, 30)
+        Me.notifyiconExitApp.Size = New System.Drawing.Size(299, 30)
         Me.notifyiconExitApp.Text = "Exit UXL Launcher"
         '
         'zotherstuffFileToolStripMenuItem
@@ -482,10 +484,10 @@ Partial Class aaformMainWindow
         '
         Me.statusbarMainWindow.ImageScalingSize = New System.Drawing.Size(32, 32)
         Me.statusbarMainWindow.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.statusbarLabelWelcomeText})
-        Me.statusbarMainWindow.Location = New System.Drawing.Point(0, 505)
+        Me.statusbarMainWindow.Location = New System.Drawing.Point(0, 634)
         Me.statusbarMainWindow.Name = "statusbarMainWindow"
-        Me.statusbarMainWindow.Padding = New System.Windows.Forms.Padding(0, 0, 7, 0)
-        Me.statusbarMainWindow.Size = New System.Drawing.Size(640, 22)
+        Me.statusbarMainWindow.Padding = New System.Windows.Forms.Padding(0, 0, 9, 0)
+        Me.statusbarMainWindow.Size = New System.Drawing.Size(800, 25)
         Me.statusbarMainWindow.SizingGrip = False
         Me.statusbarMainWindow.TabIndex = 1
         Me.statusbarMainWindow.Text = "StatusStrip1"
@@ -494,7 +496,7 @@ Partial Class aaformMainWindow
         '
         Me.statusbarLabelWelcomeText.BackColor = System.Drawing.Color.Transparent
         Me.statusbarLabelWelcomeText.Name = "statusbarLabelWelcomeText"
-        Me.statusbarLabelWelcomeText.Size = New System.Drawing.Size(623, 17)
+        Me.statusbarLabelWelcomeText.Size = New System.Drawing.Size(776, 20)
         Me.statusbarLabelWelcomeText.Text = "Welcome to UXL Launcher, the Unified eXecutable Launcher! Click the app names to " &
     "launch them and explore the UI."
         '
@@ -505,18 +507,16 @@ Partial Class aaformMainWindow
         Me.flowLayoutPanel.Controls.Add(Me.groupboxProApps)
         Me.flowLayoutPanel.Controls.Add(Me.groupboxExtraApps)
         Me.flowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.flowLayoutPanel.Location = New System.Drawing.Point(0, 23)
+        Me.flowLayoutPanel.Location = New System.Drawing.Point(0, 29)
         Me.flowLayoutPanel.Margin = New System.Windows.Forms.Padding(2)
         Me.flowLayoutPanel.Name = "flowLayoutPanel"
-        Me.flowLayoutPanel.Size = New System.Drawing.Size(640, 504)
+        Me.flowLayoutPanel.Size = New System.Drawing.Size(800, 630)
         Me.flowLayoutPanel.TabIndex = 2
         '
         'groupboxStandardApps
         '
         Me.groupboxStandardApps.BackColor = System.Drawing.Color.Transparent
-        Me.groupboxStandardApps.Controls.Add(Me.debugButtonDefaultThemeSetter)
         Me.groupboxStandardApps.Controls.Add(Me.buttonRunOneNote)
-        Me.groupboxStandardApps.Controls.Add(Me.debugButtonTestThemeSetter)
         Me.groupboxStandardApps.Controls.Add(Me.buttonRunOutlook)
         Me.groupboxStandardApps.Controls.Add(Me.buttonRunPowerPoint)
         Me.groupboxStandardApps.Controls.Add(Me.buttonRunExcel)
@@ -526,79 +526,61 @@ Partial Class aaformMainWindow
         Me.groupboxStandardApps.Controls.Add(Me.picturePowerpointIcon)
         Me.groupboxStandardApps.Controls.Add(Me.pictureExcelIcon)
         Me.groupboxStandardApps.Controls.Add(Me.pictureWordIcon)
-        Me.groupboxStandardApps.Location = New System.Drawing.Point(16, 2)
-        Me.groupboxStandardApps.Margin = New System.Windows.Forms.Padding(16, 2, 2, 2)
+        Me.groupboxStandardApps.Location = New System.Drawing.Point(20, 2)
+        Me.groupboxStandardApps.Margin = New System.Windows.Forms.Padding(20, 2, 2, 2)
         Me.groupboxStandardApps.Name = "groupboxStandardApps"
         Me.groupboxStandardApps.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxStandardApps.Size = New System.Drawing.Size(190, 478)
+        Me.groupboxStandardApps.Size = New System.Drawing.Size(238, 598)
         Me.groupboxStandardApps.TabIndex = 0
         Me.groupboxStandardApps.TabStop = False
         Me.groupboxStandardApps.Text = "Standard Apps"
         '
-        'debugButtonDefaultThemeSetter
-        '
-        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(100, 363)
-        Me.debugButtonDefaultThemeSetter.Name = "debugButtonDefaultThemeSetter"
-        Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(75, 58)
-        Me.debugButtonDefaultThemeSetter.TabIndex = 11
-        Me.debugButtonDefaultThemeSetter.Text = "Apply Default Theme"
-        Me.debugButtonDefaultThemeSetter.UseVisualStyleBackColor = True
-        '
         'buttonRunOneNote
         '
-        Me.buttonRunOneNote.Location = New System.Drawing.Point(63, 276)
+        Me.buttonRunOneNote.Location = New System.Drawing.Point(79, 345)
         Me.buttonRunOneNote.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunOneNote.Name = "buttonRunOneNote"
-        Me.buttonRunOneNote.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunOneNote.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunOneNote.TabIndex = 9
         Me.buttonRunOneNote.Text = "Microsoft OneNote"
         Me.buttonRunOneNote.UseVisualStyleBackColor = True
         '
-        'debugButtonTestThemeSetter
-        '
-        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(19, 363)
-        Me.debugButtonTestThemeSetter.Name = "debugButtonTestThemeSetter"
-        Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(75, 58)
-        Me.debugButtonTestThemeSetter.TabIndex = 10
-        Me.debugButtonTestThemeSetter.Text = "Apply Chosen Theme"
-        Me.debugButtonTestThemeSetter.UseVisualStyleBackColor = True
-        '
         'buttonRunOutlook
         '
-        Me.buttonRunOutlook.Location = New System.Drawing.Point(63, 212)
+        Me.buttonRunOutlook.Location = New System.Drawing.Point(79, 265)
         Me.buttonRunOutlook.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunOutlook.Name = "buttonRunOutlook"
-        Me.buttonRunOutlook.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunOutlook.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunOutlook.TabIndex = 8
         Me.buttonRunOutlook.Text = "Microsoft Outlook"
         Me.buttonRunOutlook.UseVisualStyleBackColor = True
         '
         'buttonRunPowerPoint
         '
-        Me.buttonRunPowerPoint.Location = New System.Drawing.Point(63, 148)
+        Me.buttonRunPowerPoint.Location = New System.Drawing.Point(79, 185)
         Me.buttonRunPowerPoint.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunPowerPoint.Name = "buttonRunPowerPoint"
-        Me.buttonRunPowerPoint.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunPowerPoint.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunPowerPoint.TabIndex = 7
         Me.buttonRunPowerPoint.Text = "Microsoft PowerPoint"
         Me.buttonRunPowerPoint.UseVisualStyleBackColor = True
         '
         'buttonRunExcel
         '
-        Me.buttonRunExcel.Location = New System.Drawing.Point(63, 84)
+        Me.buttonRunExcel.Location = New System.Drawing.Point(79, 105)
         Me.buttonRunExcel.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunExcel.Name = "buttonRunExcel"
-        Me.buttonRunExcel.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunExcel.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunExcel.TabIndex = 6
         Me.buttonRunExcel.Text = "Microsoft Excel"
         Me.buttonRunExcel.UseVisualStyleBackColor = True
         '
         'buttonRunWord
         '
-        Me.buttonRunWord.Location = New System.Drawing.Point(63, 20)
+        Me.buttonRunWord.Location = New System.Drawing.Point(79, 25)
         Me.buttonRunWord.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunWord.Name = "buttonRunWord"
-        Me.buttonRunWord.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunWord.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunWord.TabIndex = 5
         Me.buttonRunWord.Text = "Microsoft Word"
         Me.buttonRunWord.UseVisualStyleBackColor = True
@@ -606,10 +588,10 @@ Partial Class aaformMainWindow
         'pictureOneNoteIcon
         '
         Me.pictureOneNoteIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Onenote
-        Me.pictureOneNoteIcon.Location = New System.Drawing.Point(7, 276)
+        Me.pictureOneNoteIcon.Location = New System.Drawing.Point(9, 345)
         Me.pictureOneNoteIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureOneNoteIcon.Name = "pictureOneNoteIcon"
-        Me.pictureOneNoteIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureOneNoteIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureOneNoteIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureOneNoteIcon.TabIndex = 4
         Me.pictureOneNoteIcon.TabStop = False
@@ -617,10 +599,10 @@ Partial Class aaformMainWindow
         'pictureOutlookIcon
         '
         Me.pictureOutlookIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Outlook
-        Me.pictureOutlookIcon.Location = New System.Drawing.Point(7, 212)
+        Me.pictureOutlookIcon.Location = New System.Drawing.Point(9, 265)
         Me.pictureOutlookIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureOutlookIcon.Name = "pictureOutlookIcon"
-        Me.pictureOutlookIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureOutlookIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureOutlookIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureOutlookIcon.TabIndex = 3
         Me.pictureOutlookIcon.TabStop = False
@@ -628,10 +610,10 @@ Partial Class aaformMainWindow
         'picturePowerpointIcon
         '
         Me.picturePowerpointIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Powerpoint
-        Me.picturePowerpointIcon.Location = New System.Drawing.Point(7, 148)
+        Me.picturePowerpointIcon.Location = New System.Drawing.Point(9, 185)
         Me.picturePowerpointIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.picturePowerpointIcon.Name = "picturePowerpointIcon"
-        Me.picturePowerpointIcon.Size = New System.Drawing.Size(50, 50)
+        Me.picturePowerpointIcon.Size = New System.Drawing.Size(62, 62)
         Me.picturePowerpointIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.picturePowerpointIcon.TabIndex = 2
         Me.picturePowerpointIcon.TabStop = False
@@ -639,10 +621,10 @@ Partial Class aaformMainWindow
         'pictureExcelIcon
         '
         Me.pictureExcelIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Excel
-        Me.pictureExcelIcon.Location = New System.Drawing.Point(7, 84)
+        Me.pictureExcelIcon.Location = New System.Drawing.Point(9, 105)
         Me.pictureExcelIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureExcelIcon.Name = "pictureExcelIcon"
-        Me.pictureExcelIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureExcelIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureExcelIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureExcelIcon.TabIndex = 1
         Me.pictureExcelIcon.TabStop = False
@@ -650,10 +632,10 @@ Partial Class aaformMainWindow
         'pictureWordIcon
         '
         Me.pictureWordIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Word
-        Me.pictureWordIcon.Location = New System.Drawing.Point(7, 20)
+        Me.pictureWordIcon.Location = New System.Drawing.Point(9, 25)
         Me.pictureWordIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureWordIcon.Name = "pictureWordIcon"
-        Me.pictureWordIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureWordIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureWordIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureWordIcon.TabIndex = 0
         Me.pictureWordIcon.TabStop = False
@@ -661,16 +643,6 @@ Partial Class aaformMainWindow
         'groupboxProApps
         '
         Me.groupboxProApps.BackColor = System.Drawing.Color.Transparent
-        Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeFileVersion)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeUseThemeEngineVersion)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeAuthor)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeTitle)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelXmlThemeDescription)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelForofficeDriveLocation)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelForuserOfficeVersion)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelForofficeInstallMethodString)
-        Me.groupboxProApps.Controls.Add(Me.debugLabelForcpuTypeString)
         Me.groupboxProApps.Controls.Add(Me.buttonRunSharePointWkSp)
         Me.groupboxProApps.Controls.Add(Me.buttonRunAccess)
         Me.groupboxProApps.Controls.Add(Me.buttonRunInfoPath)
@@ -679,135 +651,41 @@ Partial Class aaformMainWindow
         Me.groupboxProApps.Controls.Add(Me.picturePublisherIcon)
         Me.groupboxProApps.Controls.Add(Me.pictureInfoPathIcon)
         Me.groupboxProApps.Controls.Add(Me.pictureSharepointIcon)
-        Me.groupboxProApps.Location = New System.Drawing.Point(224, 2)
-        Me.groupboxProApps.Margin = New System.Windows.Forms.Padding(16, 2, 2, 2)
+        Me.groupboxProApps.Location = New System.Drawing.Point(280, 2)
+        Me.groupboxProApps.Margin = New System.Windows.Forms.Padding(20, 2, 2, 2)
         Me.groupboxProApps.Name = "groupboxProApps"
         Me.groupboxProApps.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxProApps.Size = New System.Drawing.Size(190, 478)
+        Me.groupboxProApps.Size = New System.Drawing.Size(238, 598)
         Me.groupboxProApps.TabIndex = 1
         Me.groupboxProApps.TabStop = False
         Me.groupboxProApps.Text = "Professional Apps"
         '
-        'debugLabelXmlThemeFileVersion
-        '
-        Me.debugLabelXmlThemeFileVersion.AutoSize = True
-        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(4, 407)
-        Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
-        Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(164, 13)
-        Me.debugLabelXmlThemeFileVersion.TabIndex = 27
-        Me.debugLabelXmlThemeFileVersion.Text = "debugLabelXmlThemeFileVersion"
-        '
-        'debugLabelXmlThemeUseThemeEngineVersion
-        '
-        Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(4, 420)
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(233, 13)
-        Me.debugLabelXmlThemeUseThemeEngineVersion.TabIndex = 26
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Text = "debugLabelXmlThemeUseThemeEngineVersion"
-        '
-        'debugLabelXmlThemeAuthor
-        '
-        Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(4, 394)
-        Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
-        Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(144, 13)
-        Me.debugLabelXmlThemeAuthor.TabIndex = 25
-        Me.debugLabelXmlThemeAuthor.Text = "debugLabelXmlThemeAuthor"
-        '
-        'debugLabelXmlThemeTitle
-        '
-        Me.debugLabelXmlThemeTitle.AutoSize = True
-        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(4, 368)
-        Me.debugLabelXmlThemeTitle.Name = "debugLabelXmlThemeTitle"
-        Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(133, 13)
-        Me.debugLabelXmlThemeTitle.TabIndex = 24
-        Me.debugLabelXmlThemeTitle.Text = "debugLabelXmlThemeTitle"
-        '
-        'debugLabelXmlThemeDescription
-        '
-        Me.debugLabelXmlThemeDescription.AutoSize = True
-        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(4, 381)
-        Me.debugLabelXmlThemeDescription.Name = "debugLabelXmlThemeDescription"
-        Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(166, 13)
-        Me.debugLabelXmlThemeDescription.TabIndex = 23
-        Me.debugLabelXmlThemeDescription.Text = "debugLabelXmlThemeDescription"
-        '
-        'debugLabelForUserHasOfficeThreeSixFive
-        '
-        Me.debugLabelForUserHasOfficeThreeSixFive.AutoSize = True
-        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(4, 342)
-        Me.debugLabelForUserHasOfficeThreeSixFive.Name = "debugLabelForUserHasOfficeThreeSixFive"
-        Me.debugLabelForUserHasOfficeThreeSixFive.Size = New System.Drawing.Size(209, 13)
-        Me.debugLabelForUserHasOfficeThreeSixFive.TabIndex = 22
-        Me.debugLabelForUserHasOfficeThreeSixFive.Text = "debugLabelForUserHasOfficeThreeSixFive"
-        '
-        'debugLabelForofficeDriveLocation
-        '
-        Me.debugLabelForofficeDriveLocation.AutoSize = True
-        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(4, 278)
-        Me.debugLabelForofficeDriveLocation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.debugLabelForofficeDriveLocation.Name = "debugLabelForofficeDriveLocation"
-        Me.debugLabelForofficeDriveLocation.Size = New System.Drawing.Size(170, 13)
-        Me.debugLabelForofficeDriveLocation.TabIndex = 21
-        Me.debugLabelForofficeDriveLocation.Text = "debugLabelForofficeDriveLocation"
-        '
-        'debugLabelForuserOfficeVersion
-        '
-        Me.debugLabelForuserOfficeVersion.AutoSize = True
-        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(4, 329)
-        Me.debugLabelForuserOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.debugLabelForuserOfficeVersion.Name = "debugLabelForuserOfficeVersion"
-        Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(161, 13)
-        Me.debugLabelForuserOfficeVersion.TabIndex = 20
-        Me.debugLabelForuserOfficeVersion.Text = "debugLabelForuserOfficeVersion"
-        '
-        'debugLabelForofficeInstallMethodString
-        '
-        Me.debugLabelForofficeInstallMethodString.AutoSize = True
-        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(4, 303)
-        Me.debugLabelForofficeInstallMethodString.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.debugLabelForofficeInstallMethodString.Name = "debugLabelForofficeInstallMethodString"
-        Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(167, 26)
-        Me.debugLabelForofficeInstallMethodString.TabIndex = 19
-        Me.debugLabelForofficeInstallMethodString.Text = "debugLabelForofficeInstallMethod" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "String"
-        '
-        'debugLabelForcpuTypeString
-        '
-        Me.debugLabelForcpuTypeString.AutoSize = True
-        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(4, 290)
-        Me.debugLabelForcpuTypeString.Name = "debugLabelForcpuTypeString"
-        Me.debugLabelForcpuTypeString.Size = New System.Drawing.Size(147, 13)
-        Me.debugLabelForcpuTypeString.TabIndex = 18
-        Me.debugLabelForcpuTypeString.Text = "debugLabelForcpuTypeString"
-        '
         'buttonRunSharePointWkSp
         '
-        Me.buttonRunSharePointWkSp.Location = New System.Drawing.Point(63, 212)
+        Me.buttonRunSharePointWkSp.Location = New System.Drawing.Point(79, 265)
         Me.buttonRunSharePointWkSp.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunSharePointWkSp.Name = "buttonRunSharePointWkSp"
-        Me.buttonRunSharePointWkSp.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunSharePointWkSp.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunSharePointWkSp.TabIndex = 17
         Me.buttonRunSharePointWkSp.Text = "Microsoft SharePoint Workspace"
         Me.buttonRunSharePointWkSp.UseVisualStyleBackColor = True
         '
         'buttonRunAccess
         '
-        Me.buttonRunAccess.Location = New System.Drawing.Point(63, 20)
+        Me.buttonRunAccess.Location = New System.Drawing.Point(79, 25)
         Me.buttonRunAccess.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunAccess.Name = "buttonRunAccess"
-        Me.buttonRunAccess.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunAccess.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunAccess.TabIndex = 14
         Me.buttonRunAccess.Text = "Microsoft Access"
         Me.buttonRunAccess.UseVisualStyleBackColor = True
         '
         'buttonRunInfoPath
         '
-        Me.buttonRunInfoPath.Location = New System.Drawing.Point(63, 148)
+        Me.buttonRunInfoPath.Location = New System.Drawing.Point(79, 185)
         Me.buttonRunInfoPath.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunInfoPath.Name = "buttonRunInfoPath"
-        Me.buttonRunInfoPath.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunInfoPath.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunInfoPath.TabIndex = 16
         Me.buttonRunInfoPath.Text = "Microsoft InfoPath"
         Me.buttonRunInfoPath.UseVisualStyleBackColor = True
@@ -815,20 +693,20 @@ Partial Class aaformMainWindow
         'pictureAccessIcon
         '
         Me.pictureAccessIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Access
-        Me.pictureAccessIcon.Location = New System.Drawing.Point(7, 20)
+        Me.pictureAccessIcon.Location = New System.Drawing.Point(9, 25)
         Me.pictureAccessIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureAccessIcon.Name = "pictureAccessIcon"
-        Me.pictureAccessIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureAccessIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureAccessIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureAccessIcon.TabIndex = 10
         Me.pictureAccessIcon.TabStop = False
         '
         'buttonRunPublisher
         '
-        Me.buttonRunPublisher.Location = New System.Drawing.Point(63, 84)
+        Me.buttonRunPublisher.Location = New System.Drawing.Point(79, 105)
         Me.buttonRunPublisher.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunPublisher.Name = "buttonRunPublisher"
-        Me.buttonRunPublisher.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunPublisher.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunPublisher.TabIndex = 15
         Me.buttonRunPublisher.Text = "Microsoft Publisher"
         Me.buttonRunPublisher.UseVisualStyleBackColor = True
@@ -836,10 +714,10 @@ Partial Class aaformMainWindow
         'picturePublisherIcon
         '
         Me.picturePublisherIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Publisher
-        Me.picturePublisherIcon.Location = New System.Drawing.Point(7, 84)
+        Me.picturePublisherIcon.Location = New System.Drawing.Point(9, 105)
         Me.picturePublisherIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.picturePublisherIcon.Name = "picturePublisherIcon"
-        Me.picturePublisherIcon.Size = New System.Drawing.Size(50, 50)
+        Me.picturePublisherIcon.Size = New System.Drawing.Size(62, 62)
         Me.picturePublisherIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.picturePublisherIcon.TabIndex = 11
         Me.picturePublisherIcon.TabStop = False
@@ -847,10 +725,10 @@ Partial Class aaformMainWindow
         'pictureInfoPathIcon
         '
         Me.pictureInfoPathIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Infopath
-        Me.pictureInfoPathIcon.Location = New System.Drawing.Point(7, 148)
+        Me.pictureInfoPathIcon.Location = New System.Drawing.Point(9, 185)
         Me.pictureInfoPathIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureInfoPathIcon.Name = "pictureInfoPathIcon"
-        Me.pictureInfoPathIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureInfoPathIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureInfoPathIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureInfoPathIcon.TabIndex = 12
         Me.pictureInfoPathIcon.TabStop = False
@@ -858,10 +736,10 @@ Partial Class aaformMainWindow
         'pictureSharepointIcon
         '
         Me.pictureSharepointIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Sharepoint_Workspace
-        Me.pictureSharepointIcon.Location = New System.Drawing.Point(7, 212)
+        Me.pictureSharepointIcon.Location = New System.Drawing.Point(9, 265)
         Me.pictureSharepointIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureSharepointIcon.Name = "pictureSharepointIcon"
-        Me.pictureSharepointIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureSharepointIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureSharepointIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureSharepointIcon.TabIndex = 13
         Me.pictureSharepointIcon.TabStop = False
@@ -870,7 +748,6 @@ Partial Class aaformMainWindow
         '
         Me.groupboxExtraApps.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.groupboxExtraApps.BackColor = System.Drawing.Color.Transparent
-        Me.groupboxExtraApps.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
         Me.groupboxExtraApps.Controls.Add(Me.buttonRunOneNoteQuickLaunch)
         Me.groupboxExtraApps.Controls.Add(Me.pictureQueryIcon)
         Me.groupboxExtraApps.Controls.Add(Me.buttonRunQuery)
@@ -879,32 +756,21 @@ Partial Class aaformMainWindow
         Me.groupboxExtraApps.Controls.Add(Me.picturePictureManagerIcon)
         Me.groupboxExtraApps.Controls.Add(Me.pictureClipOrganizerIcon)
         Me.groupboxExtraApps.Controls.Add(Me.buttonRunClipOrganizer)
-        Me.groupboxExtraApps.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.groupboxExtraApps.Location = New System.Drawing.Point(432, 2)
-        Me.groupboxExtraApps.Margin = New System.Windows.Forms.Padding(16, 2, 2, 2)
+        Me.groupboxExtraApps.Location = New System.Drawing.Point(540, 2)
+        Me.groupboxExtraApps.Margin = New System.Windows.Forms.Padding(20, 2, 2, 2)
         Me.groupboxExtraApps.Name = "groupboxExtraApps"
         Me.groupboxExtraApps.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxExtraApps.Size = New System.Drawing.Size(190, 478)
+        Me.groupboxExtraApps.Size = New System.Drawing.Size(238, 598)
         Me.groupboxExtraApps.TabIndex = 2
         Me.groupboxExtraApps.TabStop = False
         Me.groupboxExtraApps.Text = "Extra Apps + Tools"
         '
-        'debugTextboxForFullLauncherCodeString
-        '
-        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(0, 300)
-        Me.debugTextboxForFullLauncherCodeString.Margin = New System.Windows.Forms.Padding(2)
-        Me.debugTextboxForFullLauncherCodeString.Multiline = True
-        Me.debugTextboxForFullLauncherCodeString.Name = "debugTextboxForFullLauncherCodeString"
-        Me.debugTextboxForFullLauncherCodeString.Size = New System.Drawing.Size(192, 51)
-        Me.debugTextboxForFullLauncherCodeString.TabIndex = 27
-        Me.debugTextboxForFullLauncherCodeString.Text = "debugTextboxForFullLauncherCodeString"
-        '
         'buttonRunOneNoteQuickLaunch
         '
-        Me.buttonRunOneNoteQuickLaunch.Location = New System.Drawing.Point(63, 212)
+        Me.buttonRunOneNoteQuickLaunch.Location = New System.Drawing.Point(79, 265)
         Me.buttonRunOneNoteQuickLaunch.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunOneNoteQuickLaunch.Name = "buttonRunOneNoteQuickLaunch"
-        Me.buttonRunOneNoteQuickLaunch.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunOneNoteQuickLaunch.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunOneNoteQuickLaunch.TabIndex = 25
         Me.buttonRunOneNoteQuickLaunch.Text = "Microsoft OneNote Quick Launch"
         Me.buttonRunOneNoteQuickLaunch.UseVisualStyleBackColor = True
@@ -912,20 +778,20 @@ Partial Class aaformMainWindow
         'pictureQueryIcon
         '
         Me.pictureQueryIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Microsoft_Query
-        Me.pictureQueryIcon.Location = New System.Drawing.Point(7, 20)
+        Me.pictureQueryIcon.Location = New System.Drawing.Point(9, 25)
         Me.pictureQueryIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureQueryIcon.Name = "pictureQueryIcon"
-        Me.pictureQueryIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureQueryIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureQueryIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureQueryIcon.TabIndex = 18
         Me.pictureQueryIcon.TabStop = False
         '
         'buttonRunQuery
         '
-        Me.buttonRunQuery.Location = New System.Drawing.Point(63, 20)
+        Me.buttonRunQuery.Location = New System.Drawing.Point(79, 25)
         Me.buttonRunQuery.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunQuery.Name = "buttonRunQuery"
-        Me.buttonRunQuery.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunQuery.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunQuery.TabIndex = 22
         Me.buttonRunQuery.Text = "Microsoft Query"
         Me.buttonRunQuery.UseVisualStyleBackColor = True
@@ -933,20 +799,20 @@ Partial Class aaformMainWindow
         'pictureOneNoteQuickLaunchIcon
         '
         Me.pictureOneNoteQuickLaunchIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Onenote
-        Me.pictureOneNoteQuickLaunchIcon.Location = New System.Drawing.Point(7, 212)
+        Me.pictureOneNoteQuickLaunchIcon.Location = New System.Drawing.Point(9, 265)
         Me.pictureOneNoteQuickLaunchIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureOneNoteQuickLaunchIcon.Name = "pictureOneNoteQuickLaunchIcon"
-        Me.pictureOneNoteQuickLaunchIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureOneNoteQuickLaunchIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureOneNoteQuickLaunchIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureOneNoteQuickLaunchIcon.TabIndex = 21
         Me.pictureOneNoteQuickLaunchIcon.TabStop = False
         '
         'buttonRunPictureManager
         '
-        Me.buttonRunPictureManager.Location = New System.Drawing.Point(63, 148)
+        Me.buttonRunPictureManager.Location = New System.Drawing.Point(79, 185)
         Me.buttonRunPictureManager.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunPictureManager.Name = "buttonRunPictureManager"
-        Me.buttonRunPictureManager.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunPictureManager.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunPictureManager.TabIndex = 24
         Me.buttonRunPictureManager.Text = "Microsoft Office Picture Manager"
         Me.buttonRunPictureManager.UseVisualStyleBackColor = True
@@ -954,10 +820,10 @@ Partial Class aaformMainWindow
         'picturePictureManagerIcon
         '
         Me.picturePictureManagerIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Picture_Manager
-        Me.picturePictureManagerIcon.Location = New System.Drawing.Point(7, 148)
+        Me.picturePictureManagerIcon.Location = New System.Drawing.Point(9, 185)
         Me.picturePictureManagerIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.picturePictureManagerIcon.Name = "picturePictureManagerIcon"
-        Me.picturePictureManagerIcon.Size = New System.Drawing.Size(50, 50)
+        Me.picturePictureManagerIcon.Size = New System.Drawing.Size(62, 62)
         Me.picturePictureManagerIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.picturePictureManagerIcon.TabIndex = 20
         Me.picturePictureManagerIcon.TabStop = False
@@ -965,33 +831,23 @@ Partial Class aaformMainWindow
         'pictureClipOrganizerIcon
         '
         Me.pictureClipOrganizerIcon.Image = Global.UXL_Launcher.My.Resources.Resources.Clip_Organizer
-        Me.pictureClipOrganizerIcon.Location = New System.Drawing.Point(7, 85)
+        Me.pictureClipOrganizerIcon.Location = New System.Drawing.Point(9, 106)
         Me.pictureClipOrganizerIcon.Margin = New System.Windows.Forms.Padding(2)
         Me.pictureClipOrganizerIcon.Name = "pictureClipOrganizerIcon"
-        Me.pictureClipOrganizerIcon.Size = New System.Drawing.Size(50, 50)
+        Me.pictureClipOrganizerIcon.Size = New System.Drawing.Size(62, 62)
         Me.pictureClipOrganizerIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom
         Me.pictureClipOrganizerIcon.TabIndex = 19
         Me.pictureClipOrganizerIcon.TabStop = False
         '
         'buttonRunClipOrganizer
         '
-        Me.buttonRunClipOrganizer.Location = New System.Drawing.Point(63, 84)
+        Me.buttonRunClipOrganizer.Location = New System.Drawing.Point(79, 105)
         Me.buttonRunClipOrganizer.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonRunClipOrganizer.Name = "buttonRunClipOrganizer"
-        Me.buttonRunClipOrganizer.Size = New System.Drawing.Size(105, 50)
+        Me.buttonRunClipOrganizer.Size = New System.Drawing.Size(131, 62)
         Me.buttonRunClipOrganizer.TabIndex = 23
         Me.buttonRunClipOrganizer.Text = "Microsoft Clip Organizer"
         Me.buttonRunClipOrganizer.UseVisualStyleBackColor = True
-        '
-        'debugLabelForAlwaysOnTop
-        '
-        Me.debugLabelForAlwaysOnTop.AutoSize = True
-        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(4, 368)
-        Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
-        Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(167, 26)
-        Me.debugLabelForAlwaysOnTop.TabIndex = 10
-        Me.debugLabelForAlwaysOnTop.Text = "This debug label shows the status" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "of the Always On Top feature."
         '
         'notifyiconTaskbarLaunchers
         '
@@ -1008,15 +864,16 @@ Partial Class aaformMainWindow
         '
         'aaformMainWindow
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(640, 527)
+        Me.ClientSize = New System.Drawing.Size(800, 659)
         Me.Controls.Add(Me.statusbarMainWindow)
         Me.Controls.Add(Me.flowLayoutPanel)
         Me.Controls.Add(Me.menubarMainWindow)
         Me.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle
         Me.Icon = CType(resources.GetObject("$this.Icon"), System.Drawing.Icon)
         Me.MainMenuStrip = Me.menubarMainWindow
+        Me.Margin = New System.Windows.Forms.Padding(4)
         Me.MaximizeBox = False
         Me.Name = "aaformMainWindow"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen
@@ -1034,13 +891,11 @@ Partial Class aaformMainWindow
         CType(Me.pictureExcelIcon, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.pictureWordIcon, System.ComponentModel.ISupportInitialize).EndInit()
         Me.groupboxProApps.ResumeLayout(False)
-        Me.groupboxProApps.PerformLayout()
         CType(Me.pictureAccessIcon, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.picturePublisherIcon, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.pictureInfoPathIcon, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.pictureSharepointIcon, System.ComponentModel.ISupportInitialize).EndInit()
         Me.groupboxExtraApps.ResumeLayout(False)
-        Me.groupboxExtraApps.PerformLayout()
         CType(Me.pictureQueryIcon, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.pictureOneNoteQuickLaunchIcon, System.ComponentModel.ISupportInitialize).EndInit()
         CType(Me.picturePictureManagerIcon, System.ComponentModel.ISupportInitialize).EndInit()
@@ -1099,13 +954,6 @@ Partial Class aaformMainWindow
     Friend WithEvents zseparatorToolsMenu1 As ToolStripSeparator
     Friend WithEvents menubarViewMenu As ToolStripMenuItem
     Friend WithEvents menubarAlwaysOnTopButton As ToolStripMenuItem
-    Friend WithEvents debugLabelForAlwaysOnTop As Label
-    Friend WithEvents debugLabelForcpuTypeString As Label
-    Friend WithEvents debugLabelForofficeInstallMethodString As Label
-    Friend WithEvents debugLabelForuserOfficeVersion As Label
-    Friend WithEvents debugLabelForofficeDriveLocation As Label
-    Friend WithEvents debugTextboxForFullLauncherCodeString As TextBox
-    Friend WithEvents debugLabelForUserHasOfficeThreeSixFive As Label
     Friend WithEvents notifyiconTaskbarLaunchers As NotifyIcon
     Friend WithEvents contextmenuNotifyicon As ContextMenuStrip
     Friend WithEvents notifyiconWord As ToolStripMenuItem
@@ -1123,16 +971,9 @@ Partial Class aaformMainWindow
     Friend WithEvents notifyiconUXLOptions As ToolStripMenuItem
     Friend WithEvents notifyiconOfficeLang As ToolStripMenuItem
     Friend WithEvents notifyiconSeparator3 As ToolStripSeparator
-    Friend WithEvents debugButtonTestThemeSetter As Button
-    Friend WithEvents debugButtonDefaultThemeSetter As Button
-    Friend WithEvents debugLabelXmlThemeDescription As Label
-    Friend WithEvents debugLabelXmlThemeTitle As Label
-    Friend WithEvents debugLabelXmlThemeAuthor As Label
     Friend WithEvents menubarRevertThemeButton As ToolStripMenuItem
     Friend WithEvents menubarHideWhenMinimizedButton As ToolStripMenuItem
-    Friend WithEvents debugLabelXmlThemeUseThemeEngineVersion As Label
     Friend WithEvents notifyiconShowApp As ToolStripMenuItem
-    Friend WithEvents debugLabelXmlThemeFileVersion As Label
     Friend WithEvents menubarOpenButton As ToolStripMenuItem
     Friend WithEvents zToolStripSeparatorFileMenu As ToolStripSeparator
     Friend WithEvents openfiledialogOpenDocument As OpenFileDialog
@@ -1145,4 +986,6 @@ Partial Class aaformMainWindow
     Friend WithEvents zSeparatorOutlookArea As ToolStripSeparator
     Friend WithEvents zSeparatorNewMenuProfessionalApps As ToolStripSeparator
     Friend WithEvents menuitemNewPublisherPublication As ToolStripMenuItem
+    Friend WithEvents menubarDebugMenu As ToolStripMenuItem
+    Friend WithEvents menuitemShowDebugWindow As ToolStripMenuItem
 End Class

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -437,6 +437,11 @@ Public Class aaformMainWindow
         End If
     End Sub
 #End Region
+
+    Private Sub ShowDebugwindowToolStripMenuItem_Click(sender As Object, e As EventArgs) Handles menuitemShowDebugWindow.Click
+        ' Show the window with the debug labels.
+        aaformDebugLabels.Show()
+    End Sub
 #End Region
 
 #Region "App Launcher Code."
@@ -576,7 +581,7 @@ Public Class aaformMainWindow
 #End Region
 
 #Region "Theme Tester Buttons."
-    Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonTestThemeSetter.Click
+    Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs)
         ' Attempt to apply the theme the user chose.
         If My.Settings.enableThemeEngine = True Then
             themeChooser()
@@ -599,20 +604,20 @@ Public Class aaformMainWindow
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(forceOptionsWindowTab, UXLToolstripRenderer)
     End Sub
 
-    Private Sub debugButtonDefaultThemeSetter_Click(sender As Object, e As EventArgs) Handles debugButtonDefaultThemeSetter.Click
+    Private Sub debugButtonDefaultThemeSetter_Click(sender As Object, e As EventArgs)
         ' Attempt to apply the default theme.
         If My.Settings.enableThemeEngine = True Then
             UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.DefaultTheme_XML)
             themeApplier()
             ' First make sure theme engine output is enabled.
             If My.Settings.debugmodeShowThemeEngineOutput = True Then
-                Debug.WriteLine("userTheme:")
+                Diagnostics.Debug.WriteLine("userTheme:")
                 ' Due to changes to the theme engine, I had to change
                 ' how the theme engine outputs the user's theme file
                 ' and it doesn't look as good as it used to, but this
                 ' should be fine. "OuterXml" property from here:
                 ' https://msdn.microsoft.com/en-us/library/system.xml.xmlnode.outerxml.aspx
-                Debug.Print(UXLLauncher_ThemeEngine.userTheme.OuterXml)
+                Diagnostics.Debug.Print(UXLLauncher_ThemeEngine.userTheme.OuterXml)
             End If
         End If
     End Sub

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -60,6 +60,9 @@ Public Class aaformMainWindow
         ' to My.Settings.enableThemeEngine.
         ' This ensures that the theme engine isn't used by accident when
         ' saving settings in the Options window.
+        ' This can also be used to check if the theme engine was enabled
+        ' when the application started to prevent accidental starting with
+        ' the Debug window buttons.
         aaformOptionsWindow.boolIsThemeEngineEnabled = My.Settings.enableThemeEngine
 
 #Region "Start the theme engine."
@@ -581,12 +584,7 @@ Public Class aaformMainWindow
 #End Region
 
 #Region "Theme Tester Buttons."
-    Private Sub debugButtonTestThemeSetter_Click(sender As Object, e As EventArgs)
-        ' Attempt to apply the theme the user chose.
-        If My.Settings.enableThemeEngine = True Then
-            themeChooser()
-        End If
-    End Sub
+    ' Theme tester buttons have been moved to the debug window.
 
     Public Shared Sub themeChooser()
         ' This is the list of forms that the theme engine applies stuff to
@@ -604,24 +602,6 @@ Public Class aaformMainWindow
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(aaformDebugLabels, UXLToolstripRenderer)
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(forceAboutWindowTab, UXLToolstripRenderer)
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(forceOptionsWindowTab, UXLToolstripRenderer)
-    End Sub
-
-    Private Sub debugButtonDefaultThemeSetter_Click(sender As Object, e As EventArgs)
-        ' Attempt to apply the default theme.
-        If My.Settings.enableThemeEngine = True Then
-            UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.DefaultTheme_XML)
-            themeApplier()
-            ' First make sure theme engine output is enabled.
-            If My.Settings.debugmodeShowThemeEngineOutput = True Then
-                Diagnostics.Debug.WriteLine("userTheme:")
-                ' Due to changes to the theme engine, I had to change
-                ' how the theme engine outputs the user's theme file
-                ' and it doesn't look as good as it used to, but this
-                ' should be fine. "OuterXml" property from here:
-                ' https://msdn.microsoft.com/en-us/library/system.xml.xmlnode.outerxml.aspx
-                Diagnostics.Debug.Print(UXLLauncher_ThemeEngine.userTheme.OuterXml)
-            End If
-        End If
     End Sub
 #End Region
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -318,7 +318,7 @@ Public Class aaformMainWindow
     ' In Version 3.3, this also prevents opening
     ' multiple Options windows from the Quickmenu or from the main window by
     ' clicking the "Show UXL Launcher" button in the Quickmenu, pressing Alt,
-' then navigating to the Tools>Options... button. That navigation bug should be worked on
+    ' then navigating to the Tools>Options... button. That navigation bug should be worked on
     ' and described in a bug report, but it's not easy to hit.
     Friend Shared forceOptionsWindowTab As New aaformOptionsWindow
 

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -592,6 +592,7 @@ Public Class aaformMainWindow
         ' This is the list of forms that the theme engine applies stuff to
         ' when choosing the theme on its own.
         UXLLauncher_ThemeEngine.themeEngine_ChooseUserTheme(aaformMainWindow, UXLToolstripRenderer)
+        UXLLauncher_ThemeEngine.themeEngine_ChooseUserTheme(aaformDebugLabels, UXLToolstripRenderer)
         UXLLauncher_ThemeEngine.themeEngine_ChooseUserTheme(forceAboutWindowTab, UXLToolstripRenderer)
         UXLLauncher_ThemeEngine.themeEngine_ChooseUserTheme(forceOptionsWindowTab, UXLToolstripRenderer)
     End Sub
@@ -600,6 +601,7 @@ Public Class aaformMainWindow
         ' This is the list of forms that the theme engine applies stuff to
         ' when the theme is pre-specified.
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(aaformMainWindow, UXLToolstripRenderer)
+        UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(aaformDebugLabels, UXLToolstripRenderer)
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(forceAboutWindowTab, UXLToolstripRenderer)
         UXLLauncher_ThemeEngine.themeEngine_ApplyTheme(forceOptionsWindowTab, UXLToolstripRenderer)
     End Sub

--- a/UXL-Launcher/UXL-Launcher.vbproj
+++ b/UXL-Launcher/UXL-Launcher.vbproj
@@ -103,6 +103,12 @@
     <Import Include="System.Xml.XPath" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DebugLabelsWindow.Designer.vb">
+      <DependentUpon>DebugLabelsWindow.vb</DependentUpon>
+    </Compile>
+    <Compile Include="DebugLabelsWindow.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="GlobalSuppressions.vb" />
     <Compile Include="MainWindow.vb">
       <SubType>Form</SubType>
@@ -146,6 +152,9 @@
     <Compile Include="VB Code-behind\Themes\WindowsThemeSettings.vb" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="DebugLabelsWindow.resx">
+      <DependentUpon>DebugLabelsWindow.vb</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="MainWindow.resx">
       <DependentUpon>MainWindow.vb</DependentUpon>
     </EmbeddedResource>

--- a/UXL-Launcher/VB Code-behind/Themes/Eyesore2Theme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/Eyesore2Theme_XML.xml
@@ -45,6 +45,11 @@
         <ForeColor>White</ForeColor>
       </Label>
 
+      <Panel>
+        <BackColor>Orchid</BackColor>
+        <ForeColor>Purple</ForeColor>
+      </Panel>
+
       <RadioButton>
         <BackColor>LightBlue</BackColor>
         <ForeColor>Magenta</ForeColor>

--- a/UXL-Launcher/VB Code-behind/Themes/EyesoreTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/EyesoreTheme_XML.xml
@@ -44,6 +44,11 @@
         <BackColor>Transparent</BackColor>
         <ForeColor>White</ForeColor>
       </Label>
+      
+      <Panel>
+        <BackColor>Red</BackColor>
+        <ForeColor>White</ForeColor>
+      </Panel>
 
       <TableLayoutPanel>
         <BackColor>Yellow</BackColor>

--- a/UXL-Launcher/VB Code-behind/Themes/MaudernClassicTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/MaudernClassicTheme_XML.xml
@@ -73,7 +73,7 @@
         <LinkColor>LightBlue</LinkColor>
       </LinkLabel>
 	  
-	  <RadioButton>
+	    <RadioButton>
         <BackColor>Transparent</BackColor>
         <ForeColor>White</ForeColor>
       </RadioButton>
@@ -86,6 +86,11 @@
         <BackColor>Transparent</BackColor>
         <ForeColor>White</ForeColor>
       </Label>
+
+      <Panel>
+        <BackColor>DimGray</BackColor>
+        <ForeColor>White</ForeColor>
+      </Panel>
 
       <TextBox>
         <BackColor>Gray</BackColor>

--- a/UXL-Launcher/VB Code-behind/Themes/MaudernTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/MaudernTheme_XML.xml
@@ -82,6 +82,11 @@
         <LinkColor>DodgerBlue</LinkColor>
       </LinkLabel>
 
+      <Panel>
+        <BackColor>#363636</BackColor>
+        <ForeColor>White</ForeColor>
+      </Panel>
+
       <RadioButton>
         <BackColor>Transparent</BackColor>
         <ForeColor>White</ForeColor>

--- a/UXL-Launcher/VB Code-behind/Themes/MittyTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/MittyTheme_XML.xml
@@ -45,6 +45,11 @@
         <ForeColor>Black</ForeColor>
       </Label>
 
+      <Panel>
+        <BackColor>DarkOrange</BackColor>
+        <ForeColor>Black</ForeColor>
+      </Panel>
+
       <TabPage>
         <BackColor>DarkOrange</BackColor>
         <ForeColor>Black</ForeColor>

--- a/UXL-Launcher/VB Code-behind/Themes/RGBTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/RGBTheme_XML.xml
@@ -61,6 +61,11 @@
         <ForeColor>Black</ForeColor>
       </Label>
 
+      <Panel>
+        <BackColor>White</BackColor>
+        <ForeColor>Black</ForeColor>
+      </Panel>
+
       <TextBox>
         <BackColor>White</BackColor>
         <ForeColor>Black</ForeColor>

--- a/UXL-Launcher/VB Code-behind/Themes/ReturnOfNightTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/ReturnOfNightTheme_XML.xml
@@ -71,6 +71,11 @@
         <LinkColor>Aqua</LinkColor>
       </LinkLabel>
 
+      <Panel>
+        <BackColor>Indigo</BackColor>
+        <ForeColor>White</ForeColor>
+      </Panel>
+
       <RadioButton>
         <BackColor>Transparent</BackColor>
         <ForeColor>White</ForeColor>

--- a/UXL-Launcher/VB Code-behind/Themes/TenDarkTheme_XML.xml
+++ b/UXL-Launcher/VB Code-behind/Themes/TenDarkTheme_XML.xml
@@ -86,6 +86,11 @@
         <ActiveLinkColor>Red</ActiveLinkColor>
         <LinkColor>DodgerBlue</LinkColor>
       </LinkLabel>
+      
+      <Panel>
+        <BackColor>Black</BackColor>
+        <ForeColor>White</ForeColor>
+      </Panel>
 
       <RadioButton>
         <BackColor>Transparent</BackColor>

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -114,7 +114,7 @@ Public Class UXLLauncher_ThemeEngine
         Dim colorLinkLabelForeColor As Color ' used for non-link text.
         Dim colorLinkLabelLinkColor As Color ' used for the link's usual color when not clicking it.
         Dim colorLinkLabelActiveLinkColor As Color ' used when clicking on a link.
-        ' FlowLayoutPanel colors:
+        ' Panel colors:
         Dim colorPanelBackColor As Color
         Dim colorPanelForeColor As Color
         ' Radio Button colors:

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -114,6 +114,9 @@ Public Class UXLLauncher_ThemeEngine
         Dim colorLinkLabelForeColor As Color ' used for non-link text.
         Dim colorLinkLabelLinkColor As Color ' used for the link's usual color when not clicking it.
         Dim colorLinkLabelActiveLinkColor As Color ' used when clicking on a link.
+        ' FlowLayoutPanel colors:
+        Dim colorPanelBackColor As Color
+        Dim colorPanelForeColor As Color
         ' Radio Button colors:
         Dim colorRadioButtonBackColor As Color
         Dim colorRadioButtonForeColor As Color
@@ -617,6 +620,38 @@ Public Class UXLLauncher_ThemeEngine
         Else
             ' If the element doesn't exist, overwrite it with the Default theme's value.
             colorLinkLabelForeColor = Color.FromKnownColor(KnownColor.ControlText)
+        End If
+#End Region
+
+#Region "Panel BackColor."
+        ' Only pull the Panel BackColor element from XML if it exists.
+        If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/Panel/BackColor[1]", themeNamespaceManager) IsNot Nothing Then
+            Try
+                colorPanelBackColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/Panel/BackColor[1]", themeNamespaceManager).InnerText)
+                debugmodeStuff.updateDebugLabels()
+                ' If the element isn't a valid HTML color, just replace it with the default.
+            Catch ex As Exception
+                colorPanelBackColor = Color.FromKnownColor(KnownColor.Control)
+            End Try
+        Else
+            ' If the element doesn't exist, overwrite it with the Default theme's value.
+            colorPanelBackColor = Color.FromKnownColor(KnownColor.Control)
+        End If
+#End Region
+
+#Region "Panel ForeColor"
+        ' Only pull the Panel ForeColor element from XML if it exists.
+        If themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/Panel/ForeColor[1]", themeNamespaceManager) IsNot Nothing Then
+            Try
+                colorPanelForeColor = ColorTranslator.FromHtml(themeSheet.SelectSingleNode("/UXL_Launcher_Theme/Theme_Colors/Panel/ForeColor[1]", themeNamespaceManager).InnerText)
+                debugmodeStuff.updateDebugLabels()
+                ' If the element isn't a valid HTML color, just replace it with the default.
+            Catch ex As Exception
+                colorPanelForeColor = Color.FromKnownColor(KnownColor.ControlText)
+            End Try
+        Else
+            ' If the element doesn't exist, overwrite it with the Default theme's value.
+            colorPanelForeColor = Color.FromKnownColor(KnownColor.ControlText)
         End If
 #End Region
 

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -988,7 +988,7 @@ Public Class UXLLauncher_ThemeEngine
 
 #Region "Apply default colors to forms not supported by TE1.02 or lower."
         ' Apply default colors to forms that aren't supported by TE1.02 or lower.
-        If formToApplyTo.Name = "aaformAboutWindow" AndAlso themeSheetUseThemeEngineVersion < 1.03 Or formToApplyTo.Name = "aaformOptionsWindow" AndAlso themeSheetUseThemeEngineVersion < 1.03 Then
+        If formToApplyTo.Name IsNot "aaformMainWindow" AndAlso themeSheetUseThemeEngineVersion < 1.03 Then
             ' If the theme doesn't support TE1.03, apply defaults.
             ' Default button colors.
             colorButtonBackColor = Color.FromKnownColor(KnownColor.Transparent)
@@ -1033,6 +1033,10 @@ Public Class UXLLauncher_ThemeEngine
             colorLinkLabelForeColor = Color.FromKnownColor(KnownColor.ControlText)
             colorLinkLabelLinkColor = Color.FromArgb(0, 0, 255)
             colorLinkLabelActiveLinkColor = Color.FromKnownColor(KnownColor.Red)
+
+            ' Default Panel colors.
+            colorPanelBackColor = Color.FromKnownColor(KnownColor.Control)
+            colorPanelForeColor = Color.FromKnownColor(KnownColor.ControlText)
 
             ' Default About window banner.
             bannerStyle = My.Resources.UXL_Launcher_Banner
@@ -1176,6 +1180,13 @@ Public Class UXLLauncher_ThemeEngine
                     ctrl.BackColor = colorTabPageBackColor
                     ctrl.ForeColor = colorTabPageForeColor
                 End If
+
+            ElseIf TypeOf ctrl Is Panel Then
+                ' If the control is a panel, theme it as such.
+                ' Panel BackColor.
+                ctrl.BackColor = colorPanelBackColor
+                ' Panel ForeColor.
+                ctrl.ForeColor = colorPanelForeColor
 
             ElseIf TypeOf ctrl Is PictureBox AndAlso ctrl.Name = "pictureboxUXLBanner" Then
                 ' Apply dark/light banners in the About window if the theme

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -34,13 +34,16 @@ Public Class debugmodeStuff
             ' Show the debug menu item if showing debug labels is enabled.
             aaformMainWindow.menubarDebugMenu.Visible = True
 
-            ' Show theme debug labels if the theme engine is enabled.
-            If My.Settings.enableThemeEngine = True Then
+            ' Show theme debug labels if the theme engine was enabled
+            ' on application startup.
+            If My.Settings.enableThemeEngine = True AndAlso aaformOptionsWindow.boolIsThemeEngineEnabled = True Then
                 aaformDebugLabels.groupboxThemeInfo.Show()
 
-            ElseIf My.Settings.enableThemeEngine = False Then
-                ' Otherwise, hide the theme debug labels and tester buttons.
+            ElseIf My.Settings.enableThemeEngine = False Or aaformOptionsWindow.boolIsThemeEngineEnabled = False Then
+                ' If it's disabled at the moment, hide the
+                ' theme debug labels and tester buttons.
                 aaformDebugLabels.groupboxThemeInfo.Hide()
+
 
             End If
 

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -31,56 +31,22 @@ Public Class debugmodeStuff
     ' This document is used to contain all the debug labels and textboxes.
     Public Shared Sub showDebugLabels()
         If My.Settings.debugmodeShowLabels = True Then
+            ' Show the debug menu item if showing debug labels is enabled.
             aaformMainWindow.menubarDebugMenu.Visible = True
 
-            aaformDebugLabels.debugLabelForAlwaysOnTop.Show()
-            aaformDebugLabels.debugLabelForofficeDriveLocation.Show()
-            aaformDebugLabels.debugLabelForcpuTypeString.Show()
-            aaformDebugLabels.debugLabelForofficeInstallMethodString.Show()
-            aaformDebugLabels.debugLabelForuserOfficeVersion.Show()
-            aaformDebugLabels.debugTextboxForFullLauncherCodeString.Show()
-            aaformDebugLabels.debugLabelForUserHasOfficeThreeSixFive.Show()
             ' Show theme debug labels if the theme engine is enabled.
             If My.Settings.enableThemeEngine = True Then
-                aaformDebugLabels.debugLabelXmlThemeTitle.Show()
-                aaformDebugLabels.debugLabelXmlThemeDescription.Show()
-                aaformDebugLabels.debugLabelXmlThemeAuthor.Show()
-                aaformDebugLabels.debugLabelXmlThemeFileVersion.Show()
-                aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Show()
-                ' Show theme tester buttons if the theme engine is enabled.
-                aaformDebugLabels.debugButtonDefaultThemeSetter.Show()
-                aaformDebugLabels.debugButtonTestThemeSetter.Show()
+                aaformDebugLabels.groupboxThemeInfo.Show()
+
             ElseIf My.Settings.enableThemeEngine = False Then
                 ' Otherwise, hide the theme debug labels and tester buttons.
-                aaformDebugLabels.debugButtonDefaultThemeSetter.Hide()
-                aaformDebugLabels.debugButtonTestThemeSetter.Hide()
-                ' Theme debug labels hiding.
-                aaformDebugLabels.debugLabelXmlThemeTitle.Hide()
-                aaformDebugLabels.debugLabelXmlThemeDescription.Hide()
-                aaformDebugLabels.debugLabelXmlThemeAuthor.Hide()
-                aaformDebugLabels.debugLabelXmlThemeFileVersion.Hide()
-                aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Hide()
+                aaformDebugLabels.groupboxThemeInfo.Hide()
+
             End If
 
         ElseIf My.Settings.debugmodeShowLabels = False Then
             aaformMainWindow.menubarDebugMenu.Visible = False
 
-            aaformDebugLabels.debugLabelForAlwaysOnTop.Hide()
-            aaformDebugLabels.debugLabelForofficeDriveLocation.Hide()
-            aaformDebugLabels.debugLabelForcpuTypeString.Hide()
-            aaformDebugLabels.debugLabelForofficeInstallMethodString.Hide()
-            aaformDebugLabels.debugLabelForuserOfficeVersion.Hide()
-            aaformDebugLabels.debugTextboxForFullLauncherCodeString.Hide()
-            aaformDebugLabels.debugLabelForUserHasOfficeThreeSixFive.Hide()
-            ' Theme tester buttons.
-            aaformDebugLabels.debugButtonDefaultThemeSetter.Hide()
-            aaformDebugLabels.debugButtonTestThemeSetter.Hide()
-            ' Theme debug labels hiding.
-            aaformDebugLabels.debugLabelXmlThemeTitle.Hide()
-            aaformDebugLabels.debugLabelXmlThemeDescription.Hide()
-            aaformDebugLabels.debugLabelXmlThemeAuthor.Hide()
-            aaformDebugLabels.debugLabelXmlThemeFileVersion.Hide()
-            aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Hide()
         End If
     End Sub
 #Region "Update the debug labels on the main form."

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -44,17 +44,17 @@ Public Class debugmodeStuff
                 ' theme debug labels and tester buttons.
                 aaformDebugLabels.groupboxThemeInfo.Hide()
 
-
             End If
 
         ElseIf My.Settings.debugmodeShowLabels = False Then
+            ' If debug labels aren't supposed to be shown, hide the debug menu.
             aaformMainWindow.menubarDebugMenu.Visible = False
 
         End If
     End Sub
-#Region "Update the debug labels on the main form."
+#Region "Update the debug window labels."
     Public Shared Sub updateDebugLabels()
-        ' Update the debug labels on the main window.
+        ' Update the debug window labels.
 
         ' Debug label for officeDriveLocation.
         aaformDebugLabels.debugLabelForofficeDriveLocation.Text = "officeDriveLocation: " & My.Settings.officeDriveLocation

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -31,52 +31,56 @@ Public Class debugmodeStuff
     ' This document is used to contain all the debug labels and textboxes.
     Public Shared Sub showDebugLabels()
         If My.Settings.debugmodeShowLabels = True Then
-            aaformMainWindow.debugLabelForAlwaysOnTop.Show()
-            aaformMainWindow.debugLabelForofficeDriveLocation.Show()
-            aaformMainWindow.debugLabelForcpuTypeString.Show()
-            aaformMainWindow.debugLabelForofficeInstallMethodString.Show()
-            aaformMainWindow.debugLabelForuserOfficeVersion.Show()
-            aaformMainWindow.debugTextboxForFullLauncherCodeString.Show()
-            aaformMainWindow.debugLabelForUserHasOfficeThreeSixFive.Show()
+            aaformMainWindow.menubarDebugMenu.Visible = True
+
+            aaformDebugLabels.debugLabelForAlwaysOnTop.Show()
+            aaformDebugLabels.debugLabelForofficeDriveLocation.Show()
+            aaformDebugLabels.debugLabelForcpuTypeString.Show()
+            aaformDebugLabels.debugLabelForofficeInstallMethodString.Show()
+            aaformDebugLabels.debugLabelForuserOfficeVersion.Show()
+            aaformDebugLabels.debugTextboxForFullLauncherCodeString.Show()
+            aaformDebugLabels.debugLabelForUserHasOfficeThreeSixFive.Show()
             ' Show theme debug labels if the theme engine is enabled.
             If My.Settings.enableThemeEngine = True Then
-                aaformMainWindow.debugLabelXmlThemeTitle.Show()
-                aaformMainWindow.debugLabelXmlThemeDescription.Show()
-                aaformMainWindow.debugLabelXmlThemeAuthor.Show()
-                aaformMainWindow.debugLabelXmlThemeFileVersion.Show()
-                aaformMainWindow.debugLabelXmlThemeUseThemeEngineVersion.Show()
+                aaformDebugLabels.debugLabelXmlThemeTitle.Show()
+                aaformDebugLabels.debugLabelXmlThemeDescription.Show()
+                aaformDebugLabels.debugLabelXmlThemeAuthor.Show()
+                aaformDebugLabels.debugLabelXmlThemeFileVersion.Show()
+                aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Show()
                 ' Show theme tester buttons if the theme engine is enabled.
-                aaformMainWindow.debugButtonDefaultThemeSetter.Show()
-                aaformMainWindow.debugButtonTestThemeSetter.Show()
+                aaformDebugLabels.debugButtonDefaultThemeSetter.Show()
+                aaformDebugLabels.debugButtonTestThemeSetter.Show()
             ElseIf My.Settings.enableThemeEngine = False Then
                 ' Otherwise, hide the theme debug labels and tester buttons.
-                aaformMainWindow.debugButtonDefaultThemeSetter.Hide()
-                aaformMainWindow.debugButtonTestThemeSetter.Hide()
+                aaformDebugLabels.debugButtonDefaultThemeSetter.Hide()
+                aaformDebugLabels.debugButtonTestThemeSetter.Hide()
                 ' Theme debug labels hiding.
-                aaformMainWindow.debugLabelXmlThemeTitle.Hide()
-                aaformMainWindow.debugLabelXmlThemeDescription.Hide()
-                aaformMainWindow.debugLabelXmlThemeAuthor.Hide()
-                aaformMainWindow.debugLabelXmlThemeFileVersion.Hide()
-                aaformMainWindow.debugLabelXmlThemeUseThemeEngineVersion.Hide()
+                aaformDebugLabels.debugLabelXmlThemeTitle.Hide()
+                aaformDebugLabels.debugLabelXmlThemeDescription.Hide()
+                aaformDebugLabels.debugLabelXmlThemeAuthor.Hide()
+                aaformDebugLabels.debugLabelXmlThemeFileVersion.Hide()
+                aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Hide()
             End If
 
         ElseIf My.Settings.debugmodeShowLabels = False Then
-            aaformMainWindow.debugLabelForAlwaysOnTop.Hide()
-            aaformMainWindow.debugLabelForofficeDriveLocation.Hide()
-            aaformMainWindow.debugLabelForcpuTypeString.Hide()
-            aaformMainWindow.debugLabelForofficeInstallMethodString.Hide()
-            aaformMainWindow.debugLabelForuserOfficeVersion.Hide()
-            aaformMainWindow.debugTextboxForFullLauncherCodeString.Hide()
-            aaformMainWindow.debugLabelForUserHasOfficeThreeSixFive.Hide()
+            aaformMainWindow.menubarDebugMenu.Visible = False
+
+            aaformDebugLabels.debugLabelForAlwaysOnTop.Hide()
+            aaformDebugLabels.debugLabelForofficeDriveLocation.Hide()
+            aaformDebugLabels.debugLabelForcpuTypeString.Hide()
+            aaformDebugLabels.debugLabelForofficeInstallMethodString.Hide()
+            aaformDebugLabels.debugLabelForuserOfficeVersion.Hide()
+            aaformDebugLabels.debugTextboxForFullLauncherCodeString.Hide()
+            aaformDebugLabels.debugLabelForUserHasOfficeThreeSixFive.Hide()
             ' Theme tester buttons.
-            aaformMainWindow.debugButtonDefaultThemeSetter.Hide()
-            aaformMainWindow.debugButtonTestThemeSetter.Hide()
+            aaformDebugLabels.debugButtonDefaultThemeSetter.Hide()
+            aaformDebugLabels.debugButtonTestThemeSetter.Hide()
             ' Theme debug labels hiding.
-            aaformMainWindow.debugLabelXmlThemeTitle.Hide()
-            aaformMainWindow.debugLabelXmlThemeDescription.Hide()
-            aaformMainWindow.debugLabelXmlThemeAuthor.Hide()
-            aaformMainWindow.debugLabelXmlThemeFileVersion.Hide()
-            aaformMainWindow.debugLabelXmlThemeUseThemeEngineVersion.Hide()
+            aaformDebugLabels.debugLabelXmlThemeTitle.Hide()
+            aaformDebugLabels.debugLabelXmlThemeDescription.Hide()
+            aaformDebugLabels.debugLabelXmlThemeAuthor.Hide()
+            aaformDebugLabels.debugLabelXmlThemeFileVersion.Hide()
+            aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Hide()
         End If
     End Sub
 #Region "Update the debug labels on the main form."
@@ -84,36 +88,36 @@ Public Class debugmodeStuff
         ' Update the debug labels on the main window.
 
         ' Debug label for officeDriveLocation.
-        aaformMainWindow.debugLabelForofficeDriveLocation.Text = "officeDriveLocation: " & My.Settings.officeDriveLocation
+        aaformDebugLabels.debugLabelForofficeDriveLocation.Text = "officeDriveLocation: " & My.Settings.officeDriveLocation
         ' Debug label for cpuTypeString.
-        aaformMainWindow.debugLabelForcpuTypeString.Text = "cpuTypeString: " & OfficeLocater.cpuTypeString
+        aaformDebugLabels.debugLabelForcpuTypeString.Text = "cpuTypeString: " & OfficeLocater.cpuTypeString
 
         ' Debug label for officeInstallMethodString depending on the value of userHasOfficeThreeSixFive.
         If My.Settings.userHasOfficeThreeSixFive = True Then
-            aaformMainWindow.debugLabelForofficeInstallMethodString.Text = "officeInstallMethodString: " & "\root"
+            aaformDebugLabels.debugLabelForofficeInstallMethodString.Text = "officeInstallMethodString: " & "\root"
         ElseIf My.Settings.userHasOfficeThreeSixFive = False Then
-            aaformMainWindow.debugLabelForofficeInstallMethodString.Text = "officeInstallMethodString: " & ""
+            aaformDebugLabels.debugLabelForofficeInstallMethodString.Text = "officeInstallMethodString: " & ""
         End If
 
         ' Debug label for the Always On Top feature.
-        aaformMainWindow.debugLabelForAlwaysOnTop.Text = "menubar button checkstate: " & aaformMainWindow.menubarAlwaysOnTopButton.CheckState & vbNewLine &
+        aaformDebugLabels.debugLabelForAlwaysOnTop.Text = "menubar button checkstate: " & aaformMainWindow.menubarAlwaysOnTopButton.CheckState & vbNewLine &
         "alwaysOnTop setting: " & My.Settings.alwaysOnTop & vbNewLine &
         "main window TopMost: " & aaformMainWindow.TopMost
 
 
         ' Debug label for userOfficeVersion.
-        aaformMainWindow.debugLabelForuserOfficeVersion.Text = "userOfficeVersion: " & My.Settings.userOfficeVersion
+        aaformDebugLabels.debugLabelForuserOfficeVersion.Text = "userOfficeVersion: " & My.Settings.userOfficeVersion
         ' Debug label for userHasOfficeThreeSixFive.
-        aaformMainWindow.debugLabelForUserHasOfficeThreeSixFive.Text = "userHasOfficeThreeSixFive: " & My.Settings.userHasOfficeThreeSixFive
+        aaformDebugLabels.debugLabelForUserHasOfficeThreeSixFive.Text = "userHasOfficeThreeSixFive: " & My.Settings.userHasOfficeThreeSixFive
         ' Debug textbox for fullLauncherCodeString.
-        aaformMainWindow.debugTextboxForFullLauncherCodeString.Text = OfficeLocater.fullLauncherCodeString
+        aaformDebugLabels.debugTextboxForFullLauncherCodeString.Text = OfficeLocater.fullLauncherCodeString
 
         ' Debug labels for theme titles and descriptions.
-        aaformMainWindow.debugLabelXmlThemeTitle.Text = "Title string: " & UXLLauncher_ThemeEngine.themeSheetTitle
-        aaformMainWindow.debugLabelXmlThemeDescription.Text = "Description string: " & UXLLauncher_ThemeEngine.themeSheetDescription
-        aaformMainWindow.debugLabelXmlThemeAuthor.Text = "Author string: " & UXLLauncher_ThemeEngine.themeSheetAuthor
-        aaformMainWindow.debugLabelXmlThemeFileVersion.Text = "File version string: " & UXLLauncher_ThemeEngine.themeSheetFileVersion
-        aaformMainWindow.debugLabelXmlThemeUseThemeEngineVersion.Text = "UseThemeEngineVersion string: " &
+        aaformDebugLabels.debugLabelXmlThemeTitle.Text = "Title string: " & UXLLauncher_ThemeEngine.themeSheetTitle
+        aaformDebugLabels.debugLabelXmlThemeDescription.Text = "Description string: " & UXLLauncher_ThemeEngine.themeSheetDescription
+        aaformDebugLabels.debugLabelXmlThemeAuthor.Text = "Author string: " & UXLLauncher_ThemeEngine.themeSheetAuthor
+        aaformDebugLabels.debugLabelXmlThemeFileVersion.Text = "File version string: " & UXLLauncher_ThemeEngine.themeSheetFileVersion
+        aaformDebugLabels.debugLabelXmlThemeUseThemeEngineVersion.Text = "UseThemeEngineVersion string: " &
             CType(UXLLauncher_ThemeEngine.themeSheetUseThemeEngineVersion, String)
 
     End Sub


### PR DESCRIPTION
Fixes #86. This keeps the main window clean during design and debug. The debug window can be accessed from `debug > Debug info window...` and may need to be manually resized to fit longer labels like the theme description label. Turning off the theme engine while the application is open will hide the theme info groupbox. Likewise, the theme info groupbox won't be shown if the theme engine is off when the application is started. Since the debug window uses a `Panel` control, support for theming `Panel` controls has been added to the built-in theme engine, though it still needs to be added to the portable one.

See #86 for more information.

Unrelated to the debug window, the built-in theme engine now checks to see if the form to apply to isn't the main window rather than checking the form against a list of known forms when seeing if the theme file supports TE 1.03 or greater. This allows for more forms to be added more easily while automatically having the themes applied to them with a little less work, minus any additional controls that need to be supported.