### PR TITLE
Allow UI configuration for bypass all compatible apps.

### DIFF
--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -41,6 +41,9 @@ Partial Class aaformOptionsWindow
         Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
         Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
+        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
         Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.groupboxCPUType = New System.Windows.Forms.GroupBox()
         Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
@@ -72,9 +75,6 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
-        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -303,6 +303,39 @@ Partial Class aaformOptionsWindow
         Me.groupboxBypassConfiguredLocation.TabIndex = 1
         Me.groupboxBypassConfiguredLocation.TabStop = False
         Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
+        '
+        'radiobuttonBypassConfiguredLocationAllApps
+        '
+        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(55, 124)
+        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonBypassConfiguredLocationDeprecatedApps
+        '
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(55, 101)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated/removed apps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonDontBypassConfiguredLocation
+        '
+        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
+        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(55, 78)
+        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
+        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
+        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
+        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
+        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
+        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
         '
         'labelBypassConfiguredLocation
         '
@@ -619,39 +652,6 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.AutoPopDelay = 10000
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
-        '
-        'radiobuttonDontBypassConfiguredLocation
-        '
-        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
-        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(55, 78)
-        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
-        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
-        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
-        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
-        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
-        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
-        '
-        'radiobuttonBypassConfiguredLocationDeprecatedApps
-        '
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(55, 101)
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(306, 17)
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated or removed apps"
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
-        '
-        'radiobuttonBypassConfiguredLocationAllApps
-        '
-        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(55, 124)
-        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
-        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
-        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
-        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
-        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
         '
         'aaformOptionsWindow
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -342,11 +342,9 @@ Partial Class aaformOptionsWindow
         Me.labelBypassConfiguredLocation.AutoSize = True
         Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(52, 23)
         Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
-        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
+        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(345, 39)
         Me.labelBypassConfiguredLocation.TabIndex = 0
-        Me.labelBypassConfiguredLocation.Text = "If you'd like, you can bypass the configured location when launching" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "some apps, " &
-    "such as ones that have been deprecated or removed from" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "later Office versions, o" &
-    "r all compatible apps."
+        Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
         '
         'groupboxCPUType
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -342,7 +342,7 @@ Partial Class aaformOptionsWindow
         Me.labelBypassConfiguredLocation.AutoSize = True
         Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(52, 23)
         Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
-        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(345, 39)
+        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
         Me.labelBypassConfiguredLocation.TabIndex = 0
         Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -41,7 +41,6 @@ Partial Class aaformOptionsWindow
         Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
         Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps = New System.Windows.Forms.CheckBox()
         Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.groupboxCPUType = New System.Windows.Forms.GroupBox()
         Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
@@ -73,6 +72,9 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
+        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -291,7 +293,9 @@ Partial Class aaformOptionsWindow
         '
         'groupboxBypassConfiguredLocation
         '
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.checkboxBypassConfiguredLocationForDeprecatedApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationAllApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
         Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(6, 171)
         Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
@@ -300,24 +304,16 @@ Partial Class aaformOptionsWindow
         Me.groupboxBypassConfiguredLocation.TabStop = False
         Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
         '
-        'checkboxBypassConfiguredLocationForDeprecatedApps
-        '
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.AutoSize = True
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.Location = New System.Drawing.Point(55, 89)
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.Name = "checkboxBypassConfiguredLocationForDeprecatedApps"
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.Size = New System.Drawing.Size(307, 17)
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.TabIndex = 1
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.Text = "Bypass configured location for deprecated or removed apps"
-        Me.checkboxBypassConfiguredLocationForDeprecatedApps.UseVisualStyleBackColor = True
-        '
         'labelBypassConfiguredLocation
         '
         Me.labelBypassConfiguredLocation.AutoSize = True
         Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(52, 23)
         Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
-        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(308, 52)
+        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
         Me.labelBypassConfiguredLocation.TabIndex = 0
-        Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
+        Me.labelBypassConfiguredLocation.Text = "If you'd like, you can bypass the configured location when launching" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "some apps, " &
+    "such as ones that have been deprecated or removed from" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "later Office versions, o" &
+    "r all compatible apps."
         '
         'groupboxCPUType
         '
@@ -624,6 +620,39 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
+        'radiobuttonDontBypassConfiguredLocation
+        '
+        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
+        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(55, 78)
+        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
+        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
+        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
+        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
+        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
+        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
+        '
+        'radiobuttonBypassConfiguredLocationDeprecatedApps
+        '
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(55, 101)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(306, 17)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated or removed apps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonBypassConfiguredLocationAllApps
+        '
+        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(55, 124)
+        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
+        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -706,8 +735,10 @@ Partial Class aaformOptionsWindow
     Friend WithEvents labelRecommendedWindowsEdition As Label
     Friend WithEvents groupboxBypassConfiguredLocation As GroupBox
     Friend WithEvents labelBypassConfiguredLocation As Label
-    Friend WithEvents checkboxBypassConfiguredLocationForDeprecatedApps As CheckBox
     Friend WithEvents tooltipCustomThemePath As ToolTip
     Friend WithEvents checkboxMatchWindows10ThemeSettings As CheckBox
     Friend WithEvents tooltipMatchWindows10ThemeSettings As ToolTip
+    Friend WithEvents radiobuttonDontBypassConfiguredLocation As RadioButton
+    Friend WithEvents radiobuttonBypassConfiguredLocationDeprecatedApps As RadioButton
+    Friend WithEvents radiobuttonBypassConfiguredLocationAllApps As RadioButton
 End Class

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -150,10 +150,4 @@ Windows is recommended to you; please report.</value>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
   </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
-  </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -131,12 +131,6 @@ On some versions of Office such as Office 2016, Microsoft places the EXE files i
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
   </data>
-  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
-    <value>Some apps such as Microsoft InfoPath, SharePoint Workspace,
-Picture Manager, and OneNote for desktop were removed from
-different Office versions, but you might be able to launch them
-by bypassing the configured location if they're still installed.</value>
-  </data>
   <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
     <value>16-bit Windows is the recommended option for you, but if
 using Office 2013, you may need to select "32-bit Windows"
@@ -155,5 +149,11 @@ Windows is recommended to you; please report.</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
+  </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,11 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
-    <value>If you'd like, you can bypass the configured location when launching
-some apps, such as ones that have been deprecated or removed from
-later Office versions, or all compatible apps. Not all apps are compatible.</value>
-  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -135,6 +130,11 @@ so this setting will be ignored if those versions are selected in the dropdown b
 On some versions of Office such as Office 2016, Microsoft places the EXE files in a slightly different location
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
+  </data>
+  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
+    <value>If you'd like, you can bypass the configured location when launching
+some apps, such as ones that have been deprecated or removed from
+later Office versions, or all compatible apps (ones that open from Run).</value>
   </data>
   <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
     <value>16-bit Windows is the recommended option for you, but if
@@ -154,11 +154,5 @@ Windows is recommended to you; please report.</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
-  </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,6 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
+    <value>If you'd like, you can bypass the configured location when launching
+some apps, such as ones that have been deprecated or removed from
+later Office versions, or all compatible apps. Not all apps are compatible.</value>
+  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -149,5 +154,11 @@ Windows is recommended to you; please report.</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
+  </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -74,7 +74,13 @@ Public Class aaformOptionsWindow
         ' Check the checkbox for bypassing configured location for deprecated apps
         ' if My.Settings.bypassConfiguredLocationForDeprecatedApps = True.
         ' Simplified from original "If" statement.
-        checkboxBypassConfiguredLocationForDeprecatedApps.Checked = My.Settings.bypassConfiguredLocationForDeprecatedApps
+        If My.Settings.bypassConfiguredLocationForAllApps = True Then
+            radiobuttonBypassConfiguredLocationAllApps.Checked = True
+        ElseIf My.Settings.bypassConfiguredLocationForDeprecatedApps = True Then
+            radiobuttonBypassConfiguredLocationDeprecatedApps.Checked = True
+        Else
+            radiobuttonDontBypassConfiguredLocation.Checked = True
+        End If
 
 #Region "Personalization tab."
         ' Load the settings for the Personalization tab.
@@ -266,8 +272,7 @@ Public Class aaformOptionsWindow
 
         ' Reset the bypass configured location for deprecated or
         ' removed apps checkbox to be unchecked.
-        checkboxBypassConfiguredLocationForDeprecatedApps.Checked = False
-
+        radiobuttonDontBypassConfiguredLocation.Checked = True
 
 
         '
@@ -388,7 +393,8 @@ Public Class aaformOptionsWindow
             ' Save the status of whether to bypass the configured location for
             ' deprecated or removed apps.
             ' Simplified from original "If" statement.
-            My.Settings.bypassConfiguredLocationForDeprecatedApps = checkboxBypassConfiguredLocationForDeprecatedApps.Checked
+            My.Settings.bypassConfiguredLocationForDeprecatedApps = radiobuttonBypassConfiguredLocationDeprecatedApps.Checked
+            My.Settings.bypassConfiguredLocationForAllApps = radiobuttonBypassConfiguredLocationAllApps.Checked
 
 #End Region
 

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -71,9 +71,10 @@ Public Class aaformOptionsWindow
         ' Simplified from original "If" statement.
         checkboxO365InstallMethod.Checked = My.Settings.userHasOfficeThreeSixFive
 
-        ' Check the checkbox for bypassing configured location for deprecated apps
-        ' if My.Settings.bypassConfiguredLocationForDeprecatedApps = True.
-        ' Simplified from original "If" statement.
+        ' Determine which radio button to check for bypassing configured location.
+        ' Check the one for all compatible apps if My.Settings.bypassConfiguredLocationForAllApps = True,
+        ' check the deprecated/removed apps one if My.Settings.bypassConfiguredLocationForDeprecatedApps = True,
+        ' or else check the one to not bypass configured location.
         If My.Settings.bypassConfiguredLocationForAllApps = True Then
             radiobuttonBypassConfiguredLocationAllApps.Checked = True
         ElseIf My.Settings.bypassConfiguredLocationForDeprecatedApps = True Then
@@ -271,7 +272,8 @@ Public Class aaformOptionsWindow
         radiobuttonDefaultStatusbarGreeting.Checked = True
 
         ' Reset the bypass configured location for deprecated or
-        ' removed apps checkbox to be unchecked.
+        ' removed apps radio buttons to have the "Don't bypass"
+        ' one checked.
         radiobuttonDontBypassConfiguredLocation.Checked = True
 
 
@@ -391,8 +393,7 @@ Public Class aaformOptionsWindow
             My.Settings.userFirstNameForCustomStatusbarGreeting = textboxFirstname.Text
 
             ' Save the status of whether to bypass the configured location for
-            ' deprecated or removed apps.
-            ' Simplified from original "If" statement.
+            ' deprecated or removed apps, or all compatible apps.
             My.Settings.bypassConfiguredLocationForDeprecatedApps = radiobuttonBypassConfiguredLocationDeprecatedApps.Checked
             My.Settings.bypassConfiguredLocationForAllApps = radiobuttonBypassConfiguredLocationAllApps.Checked
 


### PR DESCRIPTION
Bypassing configured location for all compatible apps can now be set from the Options window.

Additional changes in this pr:
- Description label is now shorter/simpler.
- Radio buttons are used instead of checkboxes to make things make more sense.
  - To turn off bypassing configured location, the `Don't bypass configured location` radio button is used.
  - To bypass configured location for deprecated/removed apps, the `Bypass configured location for deprecated/removed apps` radio button is used.
  - To bypass configured location for all compatible apps (including compatible deprecated/removed apps), the `Bypass configured location for all compatible apps` radio button is used.