### PR TITLE
Options window controls text and functionality update.

### DIFF
--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -21,14 +21,14 @@
       <setting name="officeDriveLocation" serializeAs="String">
         <value>C</value>
       </setting>
-      <setting name="cpuIsSixtyFourBit" serializeAs="String">
+      <setting name="pathUsePFxEightySix" serializeAs="String">
         <value>True</value>
       </setting>
       <setting name="userHasOfficeThreeSixFive" serializeAs="String">
         <value>False</value>
       </setting>
       <setting name="userOfficeVersion" serializeAs="String">
-        <value>14</value>
+        <value>16nomsi</value>
       </setting>
       <setting name="debugmodeShowLabels" serializeAs="String">
         <value>False</value>

--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -22,7 +22,7 @@
         <value>C</value>
       </setting>
       <setting name="pathUsePFxEightySix" serializeAs="String">
-        <value>True</value>
+        <value>False</value>
       </setting>
       <setting name="userHasOfficeThreeSixFive" serializeAs="String">
         <value>False</value>

--- a/UXL-Launcher/DebugLabelsWindow.Designer.vb
+++ b/UXL-Launcher/DebugLabelsWindow.Designer.vb
@@ -31,7 +31,7 @@ Partial Class aaformDebugLabels
         Me.debugLabelForofficeDriveLocation = New System.Windows.Forms.Label()
         Me.debugLabelForuserOfficeVersion = New System.Windows.Forms.Label()
         Me.debugLabelForofficeInstallMethodString = New System.Windows.Forms.Label()
-        Me.debugLabelForcpuTypeString = New System.Windows.Forms.Label()
+        Me.debugLabelForpfPathString = New System.Windows.Forms.Label()
         Me.debugTextboxForFullLauncherCodeString = New System.Windows.Forms.TextBox()
         Me.debugLabelForAlwaysOnTop = New System.Windows.Forms.Label()
         Me.debugButtonDefaultThemeSetter = New System.Windows.Forms.Button()
@@ -49,139 +49,131 @@ Partial Class aaformDebugLabels
         'debugLabelXmlThemeFileVersion
         '
         Me.debugLabelXmlThemeFileVersion.AutoSize = True
-        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(5, 68)
-        Me.debugLabelXmlThemeFileVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeFileVersion.Location = New System.Drawing.Point(4, 54)
         Me.debugLabelXmlThemeFileVersion.Name = "debugLabelXmlThemeFileVersion"
-        Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(220, 17)
+        Me.debugLabelXmlThemeFileVersion.Size = New System.Drawing.Size(164, 13)
         Me.debugLabelXmlThemeFileVersion.TabIndex = 37
         Me.debugLabelXmlThemeFileVersion.Text = "debugLabelXmlThemeFileVersion"
         '
         'debugLabelXmlThemeUseThemeEngineVersion
         '
         Me.debugLabelXmlThemeUseThemeEngineVersion.AutoSize = True
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(5, 85)
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Location = New System.Drawing.Point(4, 68)
         Me.debugLabelXmlThemeUseThemeEngineVersion.Name = "debugLabelXmlThemeUseThemeEngineVersion"
-        Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(311, 17)
+        Me.debugLabelXmlThemeUseThemeEngineVersion.Size = New System.Drawing.Size(233, 13)
         Me.debugLabelXmlThemeUseThemeEngineVersion.TabIndex = 36
         Me.debugLabelXmlThemeUseThemeEngineVersion.Text = "debugLabelXmlThemeUseThemeEngineVersion"
         '
         'debugLabelXmlThemeAuthor
         '
         Me.debugLabelXmlThemeAuthor.AutoSize = True
-        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(5, 51)
+        Me.debugLabelXmlThemeAuthor.Location = New System.Drawing.Point(4, 41)
         Me.debugLabelXmlThemeAuthor.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelXmlThemeAuthor.Name = "debugLabelXmlThemeAuthor"
-        Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(192, 17)
+        Me.debugLabelXmlThemeAuthor.Size = New System.Drawing.Size(144, 13)
         Me.debugLabelXmlThemeAuthor.TabIndex = 35
         Me.debugLabelXmlThemeAuthor.Text = "debugLabelXmlThemeAuthor"
         '
         'debugLabelXmlThemeTitle
         '
         Me.debugLabelXmlThemeTitle.AutoSize = True
-        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(5, 17)
-        Me.debugLabelXmlThemeTitle.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeTitle.Location = New System.Drawing.Point(4, 14)
         Me.debugLabelXmlThemeTitle.Name = "debugLabelXmlThemeTitle"
-        Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(177, 17)
+        Me.debugLabelXmlThemeTitle.Size = New System.Drawing.Size(133, 13)
         Me.debugLabelXmlThemeTitle.TabIndex = 34
         Me.debugLabelXmlThemeTitle.Text = "debugLabelXmlThemeTitle"
         '
         'debugLabelXmlThemeDescription
         '
         Me.debugLabelXmlThemeDescription.AutoSize = True
-        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(5, 34)
-        Me.debugLabelXmlThemeDescription.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelXmlThemeDescription.Location = New System.Drawing.Point(4, 27)
         Me.debugLabelXmlThemeDescription.Name = "debugLabelXmlThemeDescription"
-        Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(221, 17)
+        Me.debugLabelXmlThemeDescription.Size = New System.Drawing.Size(166, 13)
         Me.debugLabelXmlThemeDescription.TabIndex = 33
         Me.debugLabelXmlThemeDescription.Text = "debugLabelXmlThemeDescription"
         '
         'debugLabelForUserHasOfficeThreeSixFive
         '
         Me.debugLabelForUserHasOfficeThreeSixFive.AutoSize = True
-        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(5, 98)
-        Me.debugLabelForUserHasOfficeThreeSixFive.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
+        Me.debugLabelForUserHasOfficeThreeSixFive.Location = New System.Drawing.Point(4, 78)
         Me.debugLabelForUserHasOfficeThreeSixFive.Name = "debugLabelForUserHasOfficeThreeSixFive"
-        Me.debugLabelForUserHasOfficeThreeSixFive.Size = New System.Drawing.Size(278, 17)
+        Me.debugLabelForUserHasOfficeThreeSixFive.Size = New System.Drawing.Size(209, 13)
         Me.debugLabelForUserHasOfficeThreeSixFive.TabIndex = 32
         Me.debugLabelForUserHasOfficeThreeSixFive.Text = "debugLabelForUserHasOfficeThreeSixFive"
         '
         'debugLabelForofficeDriveLocation
         '
         Me.debugLabelForofficeDriveLocation.AutoSize = True
-        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(5, 18)
+        Me.debugLabelForofficeDriveLocation.Location = New System.Drawing.Point(4, 14)
         Me.debugLabelForofficeDriveLocation.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeDriveLocation.Name = "debugLabelForofficeDriveLocation"
-        Me.debugLabelForofficeDriveLocation.Size = New System.Drawing.Size(225, 17)
+        Me.debugLabelForofficeDriveLocation.Size = New System.Drawing.Size(170, 13)
         Me.debugLabelForofficeDriveLocation.TabIndex = 31
         Me.debugLabelForofficeDriveLocation.Text = "debugLabelForofficeDriveLocation"
         '
         'debugLabelForuserOfficeVersion
         '
         Me.debugLabelForuserOfficeVersion.AutoSize = True
-        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(5, 81)
+        Me.debugLabelForuserOfficeVersion.Location = New System.Drawing.Point(4, 65)
         Me.debugLabelForuserOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForuserOfficeVersion.Name = "debugLabelForuserOfficeVersion"
-        Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(217, 17)
+        Me.debugLabelForuserOfficeVersion.Size = New System.Drawing.Size(161, 13)
         Me.debugLabelForuserOfficeVersion.TabIndex = 30
         Me.debugLabelForuserOfficeVersion.Text = "debugLabelForuserOfficeVersion"
         '
         'debugLabelForofficeInstallMethodString
         '
         Me.debugLabelForofficeInstallMethodString.AutoSize = True
-        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(5, 49)
+        Me.debugLabelForofficeInstallMethodString.Location = New System.Drawing.Point(4, 39)
         Me.debugLabelForofficeInstallMethodString.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForofficeInstallMethodString.Name = "debugLabelForofficeInstallMethodString"
-        Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(258, 17)
+        Me.debugLabelForofficeInstallMethodString.Size = New System.Drawing.Size(194, 13)
         Me.debugLabelForofficeInstallMethodString.TabIndex = 29
         Me.debugLabelForofficeInstallMethodString.Text = "debugLabelForofficeInstallMethodString"
         '
-        'debugLabelForcpuTypeString
+        'debugLabelForpfPathString
         '
-        Me.debugLabelForcpuTypeString.AutoSize = True
-        Me.debugLabelForcpuTypeString.Location = New System.Drawing.Point(5, 32)
-        Me.debugLabelForcpuTypeString.Margin = New System.Windows.Forms.Padding(4, 0, 4, 0)
-        Me.debugLabelForcpuTypeString.Name = "debugLabelForcpuTypeString"
-        Me.debugLabelForcpuTypeString.Size = New System.Drawing.Size(196, 17)
-        Me.debugLabelForcpuTypeString.TabIndex = 28
-        Me.debugLabelForcpuTypeString.Text = "debugLabelForcpuTypeString"
+        Me.debugLabelForpfPathString.AutoSize = True
+        Me.debugLabelForpfPathString.Location = New System.Drawing.Point(4, 26)
+        Me.debugLabelForpfPathString.Name = "debugLabelForpfPathString"
+        Me.debugLabelForpfPathString.Size = New System.Drawing.Size(136, 13)
+        Me.debugLabelForpfPathString.TabIndex = 28
+        Me.debugLabelForpfPathString.Text = "debugLabelForpfPathString"
         '
         'debugTextboxForFullLauncherCodeString
         '
-        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(8, 123)
+        Me.debugTextboxForFullLauncherCodeString.Location = New System.Drawing.Point(6, 98)
         Me.debugTextboxForFullLauncherCodeString.Margin = New System.Windows.Forms.Padding(2)
         Me.debugTextboxForFullLauncherCodeString.Multiline = True
         Me.debugTextboxForFullLauncherCodeString.Name = "debugTextboxForFullLauncherCodeString"
-        Me.debugTextboxForFullLauncherCodeString.Size = New System.Drawing.Size(239, 63)
+        Me.debugTextboxForFullLauncherCodeString.Size = New System.Drawing.Size(192, 51)
         Me.debugTextboxForFullLauncherCodeString.TabIndex = 39
         Me.debugTextboxForFullLauncherCodeString.Text = "debugTextboxForFullLauncherCodeString"
         '
         'debugLabelForAlwaysOnTop
         '
         Me.debugLabelForAlwaysOnTop.AutoSize = True
-        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(5, 18)
+        Me.debugLabelForAlwaysOnTop.Location = New System.Drawing.Point(4, 14)
         Me.debugLabelForAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.debugLabelForAlwaysOnTop.Name = "debugLabelForAlwaysOnTop"
-        Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(222, 34)
+        Me.debugLabelForAlwaysOnTop.Size = New System.Drawing.Size(167, 26)
         Me.debugLabelForAlwaysOnTop.TabIndex = 38
         Me.debugLabelForAlwaysOnTop.Text = "This debug label shows the status" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "of the Always On Top feature."
         '
         'debugButtonDefaultThemeSetter
         '
-        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(112, 116)
-        Me.debugButtonDefaultThemeSetter.Margin = New System.Windows.Forms.Padding(4)
+        Me.debugButtonDefaultThemeSetter.Location = New System.Drawing.Point(90, 93)
         Me.debugButtonDefaultThemeSetter.Name = "debugButtonDefaultThemeSetter"
-        Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(94, 72)
+        Me.debugButtonDefaultThemeSetter.Size = New System.Drawing.Size(75, 58)
         Me.debugButtonDefaultThemeSetter.TabIndex = 41
         Me.debugButtonDefaultThemeSetter.Text = "Apply Default Theme"
         Me.debugButtonDefaultThemeSetter.UseVisualStyleBackColor = True
         '
         'debugButtonTestThemeSetter
         '
-        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(10, 116)
-        Me.debugButtonTestThemeSetter.Margin = New System.Windows.Forms.Padding(4)
+        Me.debugButtonTestThemeSetter.Location = New System.Drawing.Point(8, 93)
         Me.debugButtonTestThemeSetter.Name = "debugButtonTestThemeSetter"
-        Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(94, 72)
+        Me.debugButtonTestThemeSetter.Size = New System.Drawing.Size(75, 58)
         Me.debugButtonTestThemeSetter.TabIndex = 40
         Me.debugButtonTestThemeSetter.Text = "Apply Chosen Theme"
         Me.debugButtonTestThemeSetter.UseVisualStyleBackColor = True
@@ -193,12 +185,14 @@ Partial Class aaformDebugLabels
         Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForofficeDriveLocation)
         Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForUserHasOfficeThreeSixFive)
         Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForuserOfficeVersion)
-        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForcpuTypeString)
+        Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForpfPathString)
         Me.groupboxOfficeDetails.Controls.Add(Me.debugTextboxForFullLauncherCodeString)
         Me.groupboxOfficeDetails.Controls.Add(Me.debugLabelForofficeInstallMethodString)
-        Me.groupboxOfficeDetails.Location = New System.Drawing.Point(3, 3)
+        Me.groupboxOfficeDetails.Location = New System.Drawing.Point(2, 2)
+        Me.groupboxOfficeDetails.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.groupboxOfficeDetails.Name = "groupboxOfficeDetails"
-        Me.groupboxOfficeDetails.Size = New System.Drawing.Size(427, 193)
+        Me.groupboxOfficeDetails.Padding = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.groupboxOfficeDetails.Size = New System.Drawing.Size(342, 154)
         Me.groupboxOfficeDetails.TabIndex = 42
         Me.groupboxOfficeDetails.TabStop = False
         Me.groupboxOfficeDetails.Text = "Configured Location Details"
@@ -215,9 +209,11 @@ Partial Class aaformDebugLabels
         Me.groupboxThemeInfo.Controls.Add(Me.debugButtonTestThemeSetter)
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeDescription)
         Me.groupboxThemeInfo.Controls.Add(Me.debugLabelXmlThemeFileVersion)
-        Me.groupboxThemeInfo.Location = New System.Drawing.Point(3, 348)
+        Me.groupboxThemeInfo.Location = New System.Drawing.Point(2, 278)
+        Me.groupboxThemeInfo.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.groupboxThemeInfo.Name = "groupboxThemeInfo"
-        Me.groupboxThemeInfo.Size = New System.Drawing.Size(427, 198)
+        Me.groupboxThemeInfo.Padding = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.groupboxThemeInfo.Size = New System.Drawing.Size(342, 158)
         Me.groupboxThemeInfo.TabIndex = 43
         Me.groupboxThemeInfo.TabStop = False
         Me.groupboxThemeInfo.Text = "Theme Details"
@@ -227,9 +223,11 @@ Partial Class aaformDebugLabels
         Me.groupboxAlwaysOnTop.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.groupboxAlwaysOnTop.Controls.Add(Me.debugLabelForAlwaysOnTop)
-        Me.groupboxAlwaysOnTop.Location = New System.Drawing.Point(3, 202)
+        Me.groupboxAlwaysOnTop.Location = New System.Drawing.Point(2, 162)
+        Me.groupboxAlwaysOnTop.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.groupboxAlwaysOnTop.Name = "groupboxAlwaysOnTop"
-        Me.groupboxAlwaysOnTop.Size = New System.Drawing.Size(427, 140)
+        Me.groupboxAlwaysOnTop.Padding = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.groupboxAlwaysOnTop.Size = New System.Drawing.Size(342, 112)
         Me.groupboxAlwaysOnTop.TabIndex = 44
         Me.groupboxAlwaysOnTop.TabStop = False
         Me.groupboxAlwaysOnTop.Text = "Always On Top Details"
@@ -241,16 +239,18 @@ Partial Class aaformDebugLabels
         Me.panelLabelsTab.Controls.Add(Me.groupboxOfficeDetails)
         Me.panelLabelsTab.Dock = System.Windows.Forms.DockStyle.Fill
         Me.panelLabelsTab.Location = New System.Drawing.Point(0, 0)
+        Me.panelLabelsTab.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.panelLabelsTab.Name = "panelLabelsTab"
-        Me.panelLabelsTab.Size = New System.Drawing.Size(433, 549)
+        Me.panelLabelsTab.Size = New System.Drawing.Size(346, 439)
         Me.panelLabelsTab.TabIndex = 42
         '
         'aaformDebugLabels
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(433, 549)
+        Me.ClientSize = New System.Drawing.Size(346, 439)
         Me.Controls.Add(Me.panelLabelsTab)
+        Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.Name = "aaformDebugLabels"
         Me.Text = "Debug Info"
         Me.groupboxOfficeDetails.ResumeLayout(False)
@@ -273,7 +273,7 @@ Partial Class aaformDebugLabels
     Friend WithEvents debugLabelForofficeDriveLocation As Label
     Friend WithEvents debugLabelForuserOfficeVersion As Label
     Friend WithEvents debugLabelForofficeInstallMethodString As Label
-    Friend WithEvents debugLabelForcpuTypeString As Label
+    Friend WithEvents debugLabelForpfPathString As Label
     Friend WithEvents debugTextboxForFullLauncherCodeString As TextBox
     Friend WithEvents debugLabelForAlwaysOnTop As Label
     Friend WithEvents debugButtonDefaultThemeSetter As Button

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -66,7 +66,7 @@ Public Class aaformMainWindow
 
         ' Run the code in the combineStrings sub in OfficeLocater.vb
         ' This has to be run before changing the titlebar text because
-        ' part of the titlebar uses the OfficeLocater.titlebarBitModeString
+        ' part of the titlebar uses the OfficeLocater.titlebarProgramFilesModeString
         ' string.
         OfficeLocater.combineStrings()
 
@@ -193,7 +193,7 @@ Public Class aaformMainWindow
         ' When called, this updates the titlebar text of the main window.
         ' Moved into its own sub so that it can be updated in one place.
         Me.Text = "UXL Launcher Version " & My.Application.Info.Version.Major.ToString & "." & My.Application.Info.Version.Minor.ToString &
-    " (" & My.Resources.isStable & ", " & OfficeLocater.titlebarBitModeString & " Mode)"
+    " (" & My.Resources.isStable & ", " & OfficeLocater.titlebarProgramFilesModeString & " Mode)"
     End Sub
 #End Region
 

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -81,12 +81,12 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
-        Public Property cpuIsSixtyFourBit() As Boolean
+        Public Property pathUsePFxEightySix() As Boolean
             Get
-                Return CType(Me("cpuIsSixtyFourBit"),Boolean)
+                Return CType(Me("pathUsePFxEightySix"),Boolean)
             End Get
             Set
-                Me("cpuIsSixtyFourBit") = value
+                Me("pathUsePFxEightySix") = value
             End Set
         End Property
         
@@ -104,7 +104,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("14")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("16nomsi")>  _
         Public Property userOfficeVersion() As String
             Get
                 Return CType(Me("userOfficeVersion"),String)

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -80,7 +80,7 @@ Namespace My
         
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+         Global.System.Configuration.DefaultSettingValueAttribute("False")>  _
         Public Property pathUsePFxEightySix() As Boolean
             Get
                 Return CType(Me("pathUsePFxEightySix"),Boolean)

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -9,7 +9,7 @@
       <Value Profile="(Default)">C</Value>
     </Setting>
     <Setting Name="pathUsePFxEightySix" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="userHasOfficeThreeSixFive" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -8,14 +8,14 @@
     <Setting Name="officeDriveLocation" Type="System.String" Scope="User">
       <Value Profile="(Default)">C</Value>
     </Setting>
-    <Setting Name="cpuIsSixtyFourBit" Type="System.Boolean" Scope="User">
+    <Setting Name="pathUsePFxEightySix" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="userHasOfficeThreeSixFive" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="userOfficeVersion" Type="System.String" Scope="User">
-      <Value Profile="(Default)">14</Value>
+      <Value Profile="(Default)">16nomsi</Value>
     </Setting>
     <Setting Name="debugmodeShowLabels" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -30,8 +30,6 @@ Partial Class aaformOptionsWindow
         Me.tabcontrolOptionsWindow = New System.Windows.Forms.TabControl()
         Me.tabpageGeneral = New System.Windows.Forms.TabPage()
         Me.groupboxOfficeVersion = New System.Windows.Forms.GroupBox()
-        Me.labelHelpWithOfficeVersions = New System.Windows.Forms.Label()
-        Me.labelOfficeInstallMethodDescription = New System.Windows.Forms.Label()
         Me.checkboxO365InstallMethod = New System.Windows.Forms.CheckBox()
         Me.labelUserHasThisOfficeVersion = New System.Windows.Forms.Label()
         Me.comboboxOfficeVersionSelector = New System.Windows.Forms.ComboBox()
@@ -168,51 +166,29 @@ Partial Class aaformOptionsWindow
         '
         'groupboxOfficeVersion
         '
-        Me.groupboxOfficeVersion.Controls.Add(Me.labelHelpWithOfficeVersions)
-        Me.groupboxOfficeVersion.Controls.Add(Me.labelOfficeInstallMethodDescription)
         Me.groupboxOfficeVersion.Controls.Add(Me.checkboxO365InstallMethod)
         Me.groupboxOfficeVersion.Controls.Add(Me.labelUserHasThisOfficeVersion)
         Me.groupboxOfficeVersion.Controls.Add(Me.comboboxOfficeVersionSelector)
-        Me.groupboxOfficeVersion.Location = New System.Drawing.Point(3, 137)
+        Me.groupboxOfficeVersion.Location = New System.Drawing.Point(3, 211)
         Me.groupboxOfficeVersion.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxOfficeVersion.Name = "groupboxOfficeVersion"
         Me.groupboxOfficeVersion.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeVersion.Size = New System.Drawing.Size(415, 187)
+        Me.groupboxOfficeVersion.Size = New System.Drawing.Size(415, 113)
         Me.groupboxOfficeVersion.TabIndex = 1
         Me.groupboxOfficeVersion.TabStop = False
-        Me.groupboxOfficeVersion.Text = "What version of Microsoft Office do you use? How was it installed?"
-        '
-        'labelHelpWithOfficeVersions
-        '
-        Me.labelHelpWithOfficeVersions.AutoSize = True
-        Me.labelHelpWithOfficeVersions.Location = New System.Drawing.Point(71, 110)
-        Me.labelHelpWithOfficeVersions.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.labelHelpWithOfficeVersions.Name = "labelHelpWithOfficeVersions"
-        Me.labelHelpWithOfficeVersions.Size = New System.Drawing.Size(273, 39)
-        Me.labelHelpWithOfficeVersions.TabIndex = 6
-        Me.labelHelpWithOfficeVersions.Text = "If you're unsure of which version you use, just select" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "the latest one. A future " &
-    "version will default to Office 2019" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "since Office 2010 support ends October 2020" &
-    "."
-        '
-        'labelOfficeInstallMethodDescription
-        '
-        Me.labelOfficeInstallMethodDescription.AutoSize = True
-        Me.labelOfficeInstallMethodDescription.Location = New System.Drawing.Point(89, 60)
-        Me.labelOfficeInstallMethodDescription.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.labelOfficeInstallMethodDescription.Name = "labelOfficeInstallMethodDescription"
-        Me.labelOfficeInstallMethodDescription.Size = New System.Drawing.Size(191, 13)
-        Me.labelOfficeInstallMethodDescription.TabIndex = 5
-        Me.labelOfficeInstallMethodDescription.Text = "My Microsoft Office installation method:"
+        Me.groupboxOfficeVersion.Text = "Microsoft Office version + compatibility"
         '
         'checkboxO365InstallMethod
         '
         Me.checkboxO365InstallMethod.AutoSize = True
-        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(92, 75)
+        Me.checkboxO365InstallMethod.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(92, 64)
         Me.checkboxO365InstallMethod.Margin = New System.Windows.Forms.Padding(2)
         Me.checkboxO365InstallMethod.Name = "checkboxO365InstallMethod"
-        Me.checkboxO365InstallMethod.Size = New System.Drawing.Size(235, 17)
+        Me.checkboxO365InstallMethod.Size = New System.Drawing.Size(235, 30)
         Me.checkboxO365InstallMethod.TabIndex = 5
-        Me.checkboxO365InstallMethod.Text = "Enable Office 365/Click-to-Run Compatibility"
+        Me.checkboxO365InstallMethod.Text = "Enable Office 365/Click-to-Run Compatibility" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "(Always enabled for 2019 and above)" &
+    ""
         Me.tooltipO365InstallMethod.SetToolTip(Me.checkboxO365InstallMethod, resources.GetString("checkboxO365InstallMethod.ToolTip"))
         Me.checkboxO365InstallMethod.UseVisualStyleBackColor = True
         '
@@ -222,9 +198,9 @@ Partial Class aaformOptionsWindow
         Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(88, 25)
         Me.labelUserHasThisOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelUserHasThisOfficeVersion.Name = "labelUserHasThisOfficeVersion"
-        Me.labelUserHasThisOfficeVersion.Size = New System.Drawing.Size(178, 13)
+        Me.labelUserHasThisOfficeVersion.Size = New System.Drawing.Size(263, 13)
         Me.labelUserHasThisOfficeVersion.TabIndex = 2
-        Me.labelUserHasThisOfficeVersion.Text = "I use this version of Microsoft Office:"
+        Me.labelUserHasThisOfficeVersion.Text = "Please select your installed version of Microsoft Office:"
         '
         'comboboxOfficeVersionSelector
         '
@@ -741,7 +717,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents radiobuttonUseProgramFilesX86 As RadioButton
     Friend WithEvents radiobuttonCPUIsQBit As RadioButton
     Friend WithEvents buttonTestSettings As Button
-    Friend WithEvents labelOfficeInstallMethodDescription As Label
     Friend WithEvents tooltipO365InstallMethod As ToolTip
     Friend WithEvents labelDriveTextboxLabel As Label
     Friend WithEvents tooltipSystemInfo As ToolTip
@@ -771,6 +746,5 @@ Partial Class aaformOptionsWindow
     Friend WithEvents radiobuttonDontBypassConfiguredLocation As RadioButton
     Friend WithEvents radiobuttonBypassConfiguredLocationDeprecatedApps As RadioButton
     Friend WithEvents radiobuttonBypassConfiguredLocationAllApps As RadioButton
-    Friend WithEvents labelHelpWithOfficeVersions As Label
     Friend WithEvents linklabelTempFutureChanges As LinkLabel
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -29,11 +29,20 @@ Partial Class aaformOptionsWindow
         Me.buttonCancel = New System.Windows.Forms.Button()
         Me.tabcontrolOptionsWindow = New System.Windows.Forms.TabControl()
         Me.tabpageGeneral = New System.Windows.Forms.TabPage()
+        Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
+        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
+        Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.groupboxOfficeVersion = New System.Windows.Forms.GroupBox()
         Me.checkboxO365InstallMethod = New System.Windows.Forms.CheckBox()
         Me.labelUserHasThisOfficeVersion = New System.Windows.Forms.Label()
         Me.comboboxOfficeVersionSelector = New System.Windows.Forms.ComboBox()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
+        Me.groupboxOfficeLocation = New System.Windows.Forms.GroupBox()
+        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
+        Me.labelDriveTextboxLabel = New System.Windows.Forms.Label()
+        Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.groupboxCPUType = New System.Windows.Forms.GroupBox()
         Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
         Me.radiobuttonCPUIsQBit = New System.Windows.Forms.RadioButton()
@@ -65,26 +74,17 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
-        Me.groupboxOfficeLocation = New System.Windows.Forms.GroupBox()
-        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
-        Me.labelDriveTextboxLabel = New System.Windows.Forms.Label()
-        Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
-        Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
-        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
-        Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
+        Me.groupboxBypassConfiguredLocation.SuspendLayout()
         Me.groupboxOfficeVersion.SuspendLayout()
         Me.tabpageAdvanced.SuspendLayout()
+        Me.groupboxOfficeLocation.SuspendLayout()
         Me.groupboxCPUType.SuspendLayout()
         Me.tabpagePersonalization.SuspendLayout()
         Me.groupboxStatusbar.SuspendLayout()
         Me.groupboxAppearance.SuspendLayout()
-        Me.groupboxOfficeLocation.SuspendLayout()
-        Me.groupboxBypassConfiguredLocation.SuspendLayout()
         Me.SuspendLayout()
         '
         'tableLayoutPanelOptionsWindow
@@ -163,6 +163,62 @@ Partial Class aaformOptionsWindow
         Me.tabpageGeneral.Text = "Versions + Compatibility"
         Me.tabpageGeneral.UseVisualStyleBackColor = True
         '
+        'groupboxBypassConfiguredLocation
+        '
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationAllApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
+        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 167)
+        Me.groupboxBypassConfiguredLocation.Margin = New System.Windows.Forms.Padding(2)
+        Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
+        Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 155)
+        Me.groupboxBypassConfiguredLocation.TabIndex = 2
+        Me.groupboxBypassConfiguredLocation.TabStop = False
+        Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
+        '
+        'radiobuttonBypassConfiguredLocationAllApps
+        '
+        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(57, 120)
+        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonBypassConfiguredLocationDeprecatedApps
+        '
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(57, 97)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated/removed apps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonDontBypassConfiguredLocation
+        '
+        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
+        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(57, 74)
+        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
+        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
+        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
+        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
+        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
+        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
+        '
+        'labelBypassConfiguredLocation
+        '
+        Me.labelBypassConfiguredLocation.AutoSize = True
+        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(36, 22)
+        Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
+        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
+        Me.labelBypassConfiguredLocation.TabIndex = 0
+        Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
+        '
         'groupboxOfficeVersion
         '
         Me.groupboxOfficeVersion.Controls.Add(Me.checkboxO365InstallMethod)
@@ -224,6 +280,48 @@ Partial Class aaformOptionsWindow
         Me.tabpageAdvanced.Text = "Root Path"
         Me.tabpageAdvanced.UseVisualStyleBackColor = True
         '
+        'groupboxOfficeLocation
+        '
+        Me.groupboxOfficeLocation.Controls.Add(Me.comboboxDriveSelector)
+        Me.groupboxOfficeLocation.Controls.Add(Me.labelDriveTextboxLabel)
+        Me.groupboxOfficeLocation.Controls.Add(Me.labelOfficeInstalledToDrive)
+        Me.groupboxOfficeLocation.Location = New System.Drawing.Point(4, 4)
+        Me.groupboxOfficeLocation.Margin = New System.Windows.Forms.Padding(2)
+        Me.groupboxOfficeLocation.Name = "groupboxOfficeLocation"
+        Me.groupboxOfficeLocation.Padding = New System.Windows.Forms.Padding(2)
+        Me.groupboxOfficeLocation.Size = New System.Drawing.Size(415, 122)
+        Me.groupboxOfficeLocation.TabIndex = 6
+        Me.groupboxOfficeLocation.TabStop = False
+        Me.groupboxOfficeLocation.Text = "Microsoft Office drive location"
+        '
+        'comboboxDriveSelector
+        '
+        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDriveSelector.FormattingEnabled = True
+        Me.comboboxDriveSelector.Location = New System.Drawing.Point(131, 61)
+        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
+        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
+        Me.comboboxDriveSelector.TabIndex = 5
+        '
+        'labelDriveTextboxLabel
+        '
+        Me.labelDriveTextboxLabel.AutoSize = True
+        Me.labelDriveTextboxLabel.Location = New System.Drawing.Point(93, 64)
+        Me.labelDriveTextboxLabel.Name = "labelDriveTextboxLabel"
+        Me.labelDriveTextboxLabel.Size = New System.Drawing.Size(32, 13)
+        Me.labelDriveTextboxLabel.TabIndex = 4
+        Me.labelDriveTextboxLabel.Text = "Drive"
+        '
+        'labelOfficeInstalledToDrive
+        '
+        Me.labelOfficeInstalledToDrive.AutoSize = True
+        Me.labelOfficeInstalledToDrive.Location = New System.Drawing.Point(93, 41)
+        Me.labelOfficeInstalledToDrive.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.labelOfficeInstalledToDrive.Name = "labelOfficeInstalledToDrive"
+        Me.labelOfficeInstalledToDrive.Size = New System.Drawing.Size(228, 13)
+        Me.labelOfficeInstalledToDrive.TabIndex = 1
+        Me.labelOfficeInstalledToDrive.Text = "Please choose the drive you installed Office to:"
+        '
         'groupboxCPUType
         '
         Me.groupboxCPUType.Controls.Add(Me.labelRecommendedWindowsEdition)
@@ -231,11 +329,11 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType.Controls.Add(Me.radiobuttonUseProgramFilesX86)
         Me.groupboxCPUType.Controls.Add(Me.radiobuttonUseProgramFiles)
         Me.groupboxCPUType.Controls.Add(Me.labelCPUTypeDescription)
-        Me.groupboxCPUType.Location = New System.Drawing.Point(3, 3)
+        Me.groupboxCPUType.Location = New System.Drawing.Point(4, 130)
         Me.groupboxCPUType.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxCPUType.Name = "groupboxCPUType"
         Me.groupboxCPUType.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxCPUType.Size = New System.Drawing.Size(415, 162)
+        Me.groupboxCPUType.Size = New System.Drawing.Size(415, 192)
         Me.groupboxCPUType.TabIndex = 0
         Me.groupboxCPUType.TabStop = False
         Me.groupboxCPUType.Text = "Program Files path"
@@ -243,7 +341,7 @@ Partial Class aaformOptionsWindow
         'labelRecommendedWindowsEdition
         '
         Me.labelRecommendedWindowsEdition.AutoSize = True
-        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(36, 89)
+        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(36, 101)
         Me.labelRecommendedWindowsEdition.Name = "labelRecommendedWindowsEdition"
         Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(369, 65)
         Me.labelRecommendedWindowsEdition.TabIndex = 5
@@ -544,104 +642,6 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
-        'groupboxOfficeLocation
-        '
-        Me.groupboxOfficeLocation.Controls.Add(Me.comboboxDriveSelector)
-        Me.groupboxOfficeLocation.Controls.Add(Me.labelDriveTextboxLabel)
-        Me.groupboxOfficeLocation.Controls.Add(Me.labelOfficeInstalledToDrive)
-        Me.groupboxOfficeLocation.Location = New System.Drawing.Point(3, 169)
-        Me.groupboxOfficeLocation.Margin = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeLocation.Name = "groupboxOfficeLocation"
-        Me.groupboxOfficeLocation.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeLocation.Size = New System.Drawing.Size(415, 153)
-        Me.groupboxOfficeLocation.TabIndex = 6
-        Me.groupboxOfficeLocation.TabStop = False
-        Me.groupboxOfficeLocation.Text = "Microsoft Office drive location"
-        '
-        'comboboxDriveSelector
-        '
-        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-        Me.comboboxDriveSelector.FormattingEnabled = True
-        Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
-        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
-        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
-        Me.comboboxDriveSelector.TabIndex = 5
-        '
-        'labelDriveTextboxLabel
-        '
-        Me.labelDriveTextboxLabel.AutoSize = True
-        Me.labelDriveTextboxLabel.Location = New System.Drawing.Point(88, 60)
-        Me.labelDriveTextboxLabel.Name = "labelDriveTextboxLabel"
-        Me.labelDriveTextboxLabel.Size = New System.Drawing.Size(32, 13)
-        Me.labelDriveTextboxLabel.TabIndex = 4
-        Me.labelDriveTextboxLabel.Text = "Drive"
-        '
-        'labelOfficeInstalledToDrive
-        '
-        Me.labelOfficeInstalledToDrive.AutoSize = True
-        Me.labelOfficeInstalledToDrive.Location = New System.Drawing.Point(88, 37)
-        Me.labelOfficeInstalledToDrive.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.labelOfficeInstalledToDrive.Name = "labelOfficeInstalledToDrive"
-        Me.labelOfficeInstalledToDrive.Size = New System.Drawing.Size(228, 13)
-        Me.labelOfficeInstalledToDrive.TabIndex = 1
-        Me.labelOfficeInstalledToDrive.Text = "Please choose the drive you installed Office to:"
-        '
-        'groupboxBypassConfiguredLocation
-        '
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationAllApps)
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
-        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 167)
-        Me.groupboxBypassConfiguredLocation.Margin = New System.Windows.Forms.Padding(2)
-        Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
-        Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 155)
-        Me.groupboxBypassConfiguredLocation.TabIndex = 2
-        Me.groupboxBypassConfiguredLocation.TabStop = False
-        Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
-        '
-        'radiobuttonBypassConfiguredLocationAllApps
-        '
-        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(57, 120)
-        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
-        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
-        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
-        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
-        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
-        '
-        'radiobuttonBypassConfiguredLocationDeprecatedApps
-        '
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(57, 97)
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated/removed apps"
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
-        '
-        'radiobuttonDontBypassConfiguredLocation
-        '
-        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
-        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(57, 74)
-        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
-        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
-        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
-        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
-        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
-        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
-        '
-        'labelBypassConfiguredLocation
-        '
-        Me.labelBypassConfiguredLocation.AutoSize = True
-        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(36, 22)
-        Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
-        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
-        Me.labelBypassConfiguredLocation.TabIndex = 0
-        Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
-        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -661,9 +661,13 @@ Partial Class aaformOptionsWindow
         Me.tableLayoutPanelOptionsWindow.PerformLayout()
         Me.tabcontrolOptionsWindow.ResumeLayout(False)
         Me.tabpageGeneral.ResumeLayout(False)
+        Me.groupboxBypassConfiguredLocation.ResumeLayout(False)
+        Me.groupboxBypassConfiguredLocation.PerformLayout()
         Me.groupboxOfficeVersion.ResumeLayout(False)
         Me.groupboxOfficeVersion.PerformLayout()
         Me.tabpageAdvanced.ResumeLayout(False)
+        Me.groupboxOfficeLocation.ResumeLayout(False)
+        Me.groupboxOfficeLocation.PerformLayout()
         Me.groupboxCPUType.ResumeLayout(False)
         Me.groupboxCPUType.PerformLayout()
         Me.tabpagePersonalization.ResumeLayout(False)
@@ -671,10 +675,6 @@ Partial Class aaformOptionsWindow
         Me.groupboxStatusbar.PerformLayout()
         Me.groupboxAppearance.ResumeLayout(False)
         Me.groupboxAppearance.PerformLayout()
-        Me.groupboxOfficeLocation.ResumeLayout(False)
-        Me.groupboxOfficeLocation.PerformLayout()
-        Me.groupboxBypassConfiguredLocation.ResumeLayout(False)
-        Me.groupboxBypassConfiguredLocation.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -35,8 +35,6 @@ Partial Class aaformOptionsWindow
         Me.comboboxOfficeVersionSelector = New System.Windows.Forms.ComboBox()
         Me.groupboxOfficeLocation = New System.Windows.Forms.GroupBox()
         Me.labelDriveTextboxLabel = New System.Windows.Forms.Label()
-        Me.buttonClearDriveLetter = New System.Windows.Forms.Button()
-        Me.textboxOfficeDrive = New System.Windows.Forms.TextBox()
         Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
         Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
@@ -217,8 +215,6 @@ Partial Class aaformOptionsWindow
         '
         Me.groupboxOfficeLocation.Controls.Add(Me.comboboxDriveSelector)
         Me.groupboxOfficeLocation.Controls.Add(Me.labelDriveTextboxLabel)
-        Me.groupboxOfficeLocation.Controls.Add(Me.buttonClearDriveLetter)
-        Me.groupboxOfficeLocation.Controls.Add(Me.textboxOfficeDrive)
         Me.groupboxOfficeLocation.Controls.Add(Me.labelOfficeInstalledToDrive)
         Me.groupboxOfficeLocation.Location = New System.Drawing.Point(3, 3)
         Me.groupboxOfficeLocation.Margin = New System.Windows.Forms.Padding(2)
@@ -237,30 +233,6 @@ Partial Class aaformOptionsWindow
         Me.labelDriveTextboxLabel.Size = New System.Drawing.Size(32, 13)
         Me.labelDriveTextboxLabel.TabIndex = 4
         Me.labelDriveTextboxLabel.Text = "Drive"
-        '
-        'buttonClearDriveLetter
-        '
-        Me.buttonClearDriveLetter.AutoSize = True
-        Me.buttonClearDriveLetter.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.buttonClearDriveLetter.Location = New System.Drawing.Point(150, 92)
-        Me.buttonClearDriveLetter.Margin = New System.Windows.Forms.Padding(2)
-        Me.buttonClearDriveLetter.Name = "buttonClearDriveLetter"
-        Me.buttonClearDriveLetter.Size = New System.Drawing.Size(41, 23)
-        Me.buttonClearDriveLetter.TabIndex = 3
-        Me.buttonClearDriveLetter.Text = "Clear"
-        Me.buttonClearDriveLetter.UseVisualStyleBackColor = True
-        '
-        'textboxOfficeDrive
-        '
-        Me.textboxOfficeDrive.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper
-        Me.textboxOfficeDrive.Location = New System.Drawing.Point(126, 94)
-        Me.textboxOfficeDrive.Margin = New System.Windows.Forms.Padding(2)
-        Me.textboxOfficeDrive.MaxLength = 1
-        Me.textboxOfficeDrive.Name = "textboxOfficeDrive"
-        Me.textboxOfficeDrive.ShortcutsEnabled = False
-        Me.textboxOfficeDrive.Size = New System.Drawing.Size(20, 20)
-        Me.textboxOfficeDrive.TabIndex = 2
-        Me.textboxOfficeDrive.TextAlign = System.Windows.Forms.HorizontalAlignment.Center
         '
         'labelOfficeInstalledToDrive
         '
@@ -716,8 +688,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents tabpageAdvanced As TabPage
     Friend WithEvents groupboxOfficeLocation As GroupBox
     Friend WithEvents labelOfficeInstalledToDrive As Label
-    Friend WithEvents textboxOfficeDrive As TextBox
-    Friend WithEvents buttonClearDriveLetter As Button
     Friend WithEvents groupboxOfficeVersion As GroupBox
     Friend WithEvents comboboxOfficeVersionSelector As ComboBox
     Friend WithEvents labelUserHasThisOfficeVersion As Label

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -382,9 +382,9 @@ Partial Class aaformOptionsWindow
         'labelRecommendedWindowsEdition
         '
         Me.labelRecommendedWindowsEdition.AutoSize = True
-        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(62, 91)
+        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(36, 89)
         Me.labelRecommendedWindowsEdition.Name = "labelRecommendedWindowsEdition"
-        Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(281, 65)
+        Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(369, 65)
         Me.labelRecommendedWindowsEdition.TabIndex = 5
         Me.labelRecommendedWindowsEdition.Text = resources.GetString("labelRecommendedWindowsEdition.Text")
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -223,7 +223,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeLocation.Size = New System.Drawing.Size(415, 130)
         Me.groupboxOfficeLocation.TabIndex = 0
         Me.groupboxOfficeLocation.TabStop = False
-        Me.groupboxOfficeLocation.Text = "Where is Microsoft Office located?"
+        Me.groupboxOfficeLocation.Text = "Microsoft Office drive location"
         '
         'comboboxDriveSelector
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -169,10 +169,10 @@ Partial Class aaformOptionsWindow
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
-        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 167)
+        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 147)
         Me.groupboxBypassConfiguredLocation.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
-        Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 155)
+        Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 175)
         Me.groupboxBypassConfiguredLocation.TabIndex = 2
         Me.groupboxBypassConfiguredLocation.TabStop = False
         Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
@@ -180,7 +180,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonBypassConfiguredLocationAllApps
         '
         Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(57, 120)
+        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(59, 135)
         Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
         Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
         Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
@@ -191,7 +191,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonBypassConfiguredLocationDeprecatedApps
         '
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(57, 97)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(59, 112)
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
@@ -202,7 +202,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonDontBypassConfiguredLocation
         '
         Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
-        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(57, 74)
+        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(59, 89)
         Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
         Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
         Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
@@ -213,7 +213,7 @@ Partial Class aaformOptionsWindow
         'labelBypassConfiguredLocation
         '
         Me.labelBypassConfiguredLocation.AutoSize = True
-        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(36, 22)
+        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(38, 31)
         Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
         Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
         Me.labelBypassConfiguredLocation.TabIndex = 0
@@ -228,7 +228,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeVersion.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxOfficeVersion.Name = "groupboxOfficeVersion"
         Me.groupboxOfficeVersion.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeVersion.Size = New System.Drawing.Size(415, 159)
+        Me.groupboxOfficeVersion.Size = New System.Drawing.Size(415, 139)
         Me.groupboxOfficeVersion.TabIndex = 1
         Me.groupboxOfficeVersion.TabStop = False
         Me.groupboxOfficeVersion.Text = "Microsoft Office versions + C2R"

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -292,7 +292,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeLocation.Size = New System.Drawing.Size(415, 122)
         Me.groupboxOfficeLocation.TabIndex = 6
         Me.groupboxOfficeLocation.TabStop = False
-        Me.groupboxOfficeLocation.Text = "Microsoft Office drive location"
+        Me.groupboxOfficeLocation.Text = "Root drive path"
         '
         'comboboxDriveSelector
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -48,7 +48,7 @@ Partial Class aaformOptionsWindow
         Me.radiobuttonCPUIsQBit = New System.Windows.Forms.RadioButton()
         Me.radiobuttonUseProgramFilesX86 = New System.Windows.Forms.RadioButton()
         Me.radiobuttonUseProgramFiles = New System.Windows.Forms.RadioButton()
-        Me.labelCPUTypeDescription = New System.Windows.Forms.Label()
+        Me.labelPFPathDescription = New System.Windows.Forms.Label()
         Me.tabpagePersonalization = New System.Windows.Forms.TabPage()
         Me.groupboxStatusbar = New System.Windows.Forms.GroupBox()
         Me.buttonClearFirstname = New System.Windows.Forms.Button()
@@ -326,7 +326,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType.Controls.Add(Me.radiobuttonCPUIsQBit)
         Me.groupboxCPUType.Controls.Add(Me.radiobuttonUseProgramFilesX86)
         Me.groupboxCPUType.Controls.Add(Me.radiobuttonUseProgramFiles)
-        Me.groupboxCPUType.Controls.Add(Me.labelCPUTypeDescription)
+        Me.groupboxCPUType.Controls.Add(Me.labelPFPathDescription)
         Me.groupboxCPUType.Location = New System.Drawing.Point(4, 130)
         Me.groupboxCPUType.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxCPUType.Name = "groupboxCPUType"
@@ -384,15 +384,15 @@ Partial Class aaformOptionsWindow
     " or 32-bit Office 2013 from Office 365"
         Me.radiobuttonUseProgramFiles.UseVisualStyleBackColor = True
         '
-        'labelCPUTypeDescription
+        'labelPFPathDescription
         '
-        Me.labelCPUTypeDescription.AutoSize = True
-        Me.labelCPUTypeDescription.Location = New System.Drawing.Point(36, 21)
-        Me.labelCPUTypeDescription.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.labelCPUTypeDescription.Name = "labelCPUTypeDescription"
-        Me.labelCPUTypeDescription.Size = New System.Drawing.Size(280, 13)
-        Me.labelCPUTypeDescription.TabIndex = 0
-        Me.labelCPUTypeDescription.Text = "Select the Program Files path used by your copy of Office:"
+        Me.labelPFPathDescription.AutoSize = True
+        Me.labelPFPathDescription.Location = New System.Drawing.Point(36, 21)
+        Me.labelPFPathDescription.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.labelPFPathDescription.Name = "labelPFPathDescription"
+        Me.labelPFPathDescription.Size = New System.Drawing.Size(280, 13)
+        Me.labelPFPathDescription.TabIndex = 0
+        Me.labelPFPathDescription.Text = "Select the Program Files path used by your copy of Office:"
         '
         'tabpagePersonalization
         '
@@ -677,7 +677,7 @@ Partial Class aaformOptionsWindow
     Friend WithEvents labelUserHasThisOfficeVersion As Label
     Friend WithEvents checkboxO365InstallMethod As CheckBox
     Friend WithEvents groupboxCPUType As GroupBox
-    Friend WithEvents labelCPUTypeDescription As Label
+    Friend WithEvents labelPFPathDescription As Label
     Friend WithEvents radiobuttonUseProgramFiles As RadioButton
     Friend WithEvents radiobuttonUseProgramFilesX86 As RadioButton
     Friend WithEvents radiobuttonCPUIsQBit As RadioButton

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -417,10 +417,10 @@ Partial Class aaformOptionsWindow
         Me.groupboxStatusbar.Controls.Add(Me.radiobuttonCustomStatusbarGreeting)
         Me.groupboxStatusbar.Controls.Add(Me.radiobuttonDefaultStatusbarGreeting)
         Me.groupboxStatusbar.Controls.Add(Me.labelCustomStatusbarGreeting)
-        Me.groupboxStatusbar.Location = New System.Drawing.Point(3, 192)
+        Me.groupboxStatusbar.Location = New System.Drawing.Point(4, 192)
         Me.groupboxStatusbar.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxStatusbar.Name = "groupboxStatusbar"
-        Me.groupboxStatusbar.Size = New System.Drawing.Size(415, 132)
+        Me.groupboxStatusbar.Size = New System.Drawing.Size(415, 130)
         Me.groupboxStatusbar.TabIndex = 1
         Me.groupboxStatusbar.TabStop = False
         Me.groupboxStatusbar.Text = "Statusbar"
@@ -492,10 +492,10 @@ Partial Class aaformOptionsWindow
         Me.groupboxAppearance.Controls.Add(Me.comboboxThemeList)
         Me.groupboxAppearance.Controls.Add(Me.textboxThemeInfo)
         Me.groupboxAppearance.Controls.Add(Me.checkboxEnableThemeEngine)
-        Me.groupboxAppearance.Location = New System.Drawing.Point(3, 3)
+        Me.groupboxAppearance.Location = New System.Drawing.Point(4, 4)
         Me.groupboxAppearance.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxAppearance.Name = "groupboxAppearance"
-        Me.groupboxAppearance.Size = New System.Drawing.Size(415, 185)
+        Me.groupboxAppearance.Size = New System.Drawing.Size(415, 184)
         Me.groupboxAppearance.TabIndex = 0
         Me.groupboxAppearance.TabStop = False
         Me.groupboxAppearance.Text = "Appearance"
@@ -516,7 +516,7 @@ Partial Class aaformOptionsWindow
         '
         Me.labelCustomThemePath.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.labelCustomThemePath.AutoSize = True
-        Me.labelCustomThemePath.Location = New System.Drawing.Point(217, 143)
+        Me.labelCustomThemePath.Location = New System.Drawing.Point(217, 142)
         Me.labelCustomThemePath.Name = "labelCustomThemePath"
         Me.labelCustomThemePath.Size = New System.Drawing.Size(101, 13)
         Me.labelCustomThemePath.TabIndex = 6
@@ -525,7 +525,7 @@ Partial Class aaformOptionsWindow
         'buttonCustomThemesBrowse
         '
         Me.buttonCustomThemesBrowse.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.buttonCustomThemesBrowse.Location = New System.Drawing.Point(340, 156)
+        Me.buttonCustomThemesBrowse.Location = New System.Drawing.Point(340, 155)
         Me.buttonCustomThemesBrowse.Name = "buttonCustomThemesBrowse"
         Me.buttonCustomThemesBrowse.Size = New System.Drawing.Size(68, 23)
         Me.buttonCustomThemesBrowse.TabIndex = 5
@@ -535,7 +535,7 @@ Partial Class aaformOptionsWindow
         'textboxCustomThemePath
         '
         Me.textboxCustomThemePath.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.textboxCustomThemePath.Location = New System.Drawing.Point(220, 159)
+        Me.textboxCustomThemePath.Location = New System.Drawing.Point(220, 158)
         Me.textboxCustomThemePath.Name = "textboxCustomThemePath"
         Me.textboxCustomThemePath.Size = New System.Drawing.Size(117, 20)
         Me.textboxCustomThemePath.TabIndex = 4
@@ -564,7 +564,7 @@ Partial Class aaformOptionsWindow
         'textboxThemeInfo
         '
         Me.textboxThemeInfo.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.textboxThemeInfo.Location = New System.Drawing.Point(7, 50)
+        Me.textboxThemeInfo.Location = New System.Drawing.Point(7, 49)
         Me.textboxThemeInfo.Multiline = True
         Me.textboxThemeInfo.Name = "textboxThemeInfo"
         Me.textboxThemeInfo.ReadOnly = True

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -163,7 +163,7 @@ Partial Class aaformOptionsWindow
         Me.tabpageGeneral.Padding = New System.Windows.Forms.Padding(2)
         Me.tabpageGeneral.Size = New System.Drawing.Size(422, 326)
         Me.tabpageGeneral.TabIndex = 0
-        Me.tabpageGeneral.Text = "General"
+        Me.tabpageGeneral.Text = "Office Version"
         Me.tabpageGeneral.UseVisualStyleBackColor = True
         '
         'groupboxOfficeVersion
@@ -304,7 +304,7 @@ Partial Class aaformOptionsWindow
         Me.tabpageAdvanced.Padding = New System.Windows.Forms.Padding(2)
         Me.tabpageAdvanced.Size = New System.Drawing.Size(422, 326)
         Me.tabpageAdvanced.TabIndex = 1
-        Me.tabpageAdvanced.Text = "Advanced"
+        Me.tabpageAdvanced.Text = "Root Path"
         Me.tabpageAdvanced.UseVisualStyleBackColor = True
         '
         'groupboxBypassConfiguredLocation
@@ -377,14 +377,14 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType.Size = New System.Drawing.Size(415, 162)
         Me.groupboxCPUType.TabIndex = 0
         Me.groupboxCPUType.TabStop = False
-        Me.groupboxCPUType.Text = "What edition of Windows do you run?"
+        Me.groupboxCPUType.Text = "Program Files path"
         '
         'labelRecommendedWindowsEdition
         '
         Me.labelRecommendedWindowsEdition.AutoSize = True
-        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(62, 82)
+        Me.labelRecommendedWindowsEdition.Location = New System.Drawing.Point(62, 91)
         Me.labelRecommendedWindowsEdition.Name = "labelRecommendedWindowsEdition"
-        Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(291, 65)
+        Me.labelRecommendedWindowsEdition.Size = New System.Drawing.Size(281, 65)
         Me.labelRecommendedWindowsEdition.TabIndex = 5
         Me.labelRecommendedWindowsEdition.Text = resources.GetString("labelRecommendedWindowsEdition.Text")
         '
@@ -404,36 +404,38 @@ Partial Class aaformOptionsWindow
         'radiobuttonCPUIs64Bit
         '
         Me.radiobuttonCPUIs64Bit.AutoSize = True
-        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(65, 54)
+        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(39, 70)
         Me.radiobuttonCPUIs64Bit.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonCPUIs64Bit.Name = "radiobuttonCPUIs64Bit"
-        Me.radiobuttonCPUIs64Bit.Size = New System.Drawing.Size(98, 17)
+        Me.radiobuttonCPUIs64Bit.Size = New System.Drawing.Size(268, 17)
         Me.radiobuttonCPUIs64Bit.TabIndex = 3
         Me.radiobuttonCPUIs64Bit.TabStop = True
-        Me.radiobuttonCPUIs64Bit.Text = "64-bit Windows"
+        Me.radiobuttonCPUIs64Bit.Text = "Program Files (x86): 32-bit Office on 64-bit Windows"
         Me.radiobuttonCPUIs64Bit.UseVisualStyleBackColor = True
         '
         'radiobuttonCPUIs32Bit
         '
         Me.radiobuttonCPUIs32Bit.AutoSize = True
-        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(65, 36)
+        Me.radiobuttonCPUIs32Bit.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(39, 36)
         Me.radiobuttonCPUIs32Bit.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonCPUIs32Bit.Name = "radiobuttonCPUIs32Bit"
-        Me.radiobuttonCPUIs32Bit.Size = New System.Drawing.Size(98, 17)
+        Me.radiobuttonCPUIs32Bit.Size = New System.Drawing.Size(350, 30)
         Me.radiobuttonCPUIs32Bit.TabIndex = 2
         Me.radiobuttonCPUIs32Bit.TabStop = True
-        Me.radiobuttonCPUIs32Bit.Text = "32-bit Windows"
+        Me.radiobuttonCPUIs32Bit.Text = "Program Files: 64-bit Office on 64-bit Windows," & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "32-bit Office on 32-bit Windows," &
+    " or 32-bit Office 2013 from Office 365"
         Me.radiobuttonCPUIs32Bit.UseVisualStyleBackColor = True
         '
         'labelCPUTypeDescription
         '
         Me.labelCPUTypeDescription.AutoSize = True
-        Me.labelCPUTypeDescription.Location = New System.Drawing.Point(62, 21)
+        Me.labelCPUTypeDescription.Location = New System.Drawing.Point(36, 21)
         Me.labelCPUTypeDescription.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelCPUTypeDescription.Name = "labelCPUTypeDescription"
-        Me.labelCPUTypeDescription.Size = New System.Drawing.Size(229, 13)
+        Me.labelCPUTypeDescription.Size = New System.Drawing.Size(280, 13)
         Me.labelCPUTypeDescription.TabIndex = 0
-        Me.labelCPUTypeDescription.Text = "Choose which edition of Windows you're using:"
+        Me.labelCPUTypeDescription.Text = "Select the Program Files path used by your copy of Office:"
         '
         'tabpagePersonalization
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -235,7 +235,7 @@ Partial Class aaformOptionsWindow
         '
         Me.checkboxO365InstallMethod.AutoSize = True
         Me.checkboxO365InstallMethod.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(79, 91)
+        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(79, 81)
         Me.checkboxO365InstallMethod.Margin = New System.Windows.Forms.Padding(2)
         Me.checkboxO365InstallMethod.Name = "checkboxO365InstallMethod"
         Me.checkboxO365InstallMethod.Size = New System.Drawing.Size(235, 30)
@@ -248,7 +248,7 @@ Partial Class aaformOptionsWindow
         'labelUserHasThisOfficeVersion
         '
         Me.labelUserHasThisOfficeVersion.AutoSize = True
-        Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(76, 37)
+        Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(76, 27)
         Me.labelUserHasThisOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelUserHasThisOfficeVersion.Name = "labelUserHasThisOfficeVersion"
         Me.labelUserHasThisOfficeVersion.Size = New System.Drawing.Size(263, 13)
@@ -259,7 +259,7 @@ Partial Class aaformOptionsWindow
         '
         Me.comboboxOfficeVersionSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.comboboxOfficeVersionSelector.FormattingEnabled = True
-        Me.comboboxOfficeVersionSelector.Location = New System.Drawing.Point(79, 52)
+        Me.comboboxOfficeVersionSelector.Location = New System.Drawing.Point(79, 42)
         Me.comboboxOfficeVersionSelector.Margin = New System.Windows.Forms.Padding(2)
         Me.comboboxOfficeVersionSelector.Name = "comboboxOfficeVersionSelector"
         Me.comboboxOfficeVersionSelector.Size = New System.Drawing.Size(138, 21)

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -34,6 +34,7 @@ Partial Class aaformOptionsWindow
         Me.labelUserHasThisOfficeVersion = New System.Windows.Forms.Label()
         Me.comboboxOfficeVersionSelector = New System.Windows.Forms.ComboBox()
         Me.groupboxOfficeLocation = New System.Windows.Forms.GroupBox()
+        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
         Me.labelDriveTextboxLabel = New System.Windows.Forms.Label()
         Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
@@ -73,7 +74,6 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
-        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -224,6 +224,15 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeLocation.TabIndex = 0
         Me.groupboxOfficeLocation.TabStop = False
         Me.groupboxOfficeLocation.Text = "Where is Microsoft Office located?"
+        '
+        'comboboxDriveSelector
+        '
+        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDriveSelector.FormattingEnabled = True
+        Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
+        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
+        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
+        Me.comboboxDriveSelector.TabIndex = 5
         '
         'labelDriveTextboxLabel
         '
@@ -632,15 +641,6 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.AutoPopDelay = 10000
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
-        '
-        'comboboxDriveSelector
-        '
-        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-        Me.comboboxDriveSelector.FormattingEnabled = True
-        Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
-        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
-        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
-        Me.comboboxDriveSelector.TabIndex = 5
         '
         'aaformOptionsWindow
         '

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -49,8 +49,8 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType = New System.Windows.Forms.GroupBox()
         Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
         Me.radiobuttonCPUIsQBit = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonCPUIs64Bit = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonCPUIs32Bit = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonUseProgramFilesX86 = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonUseProgramFiles = New System.Windows.Forms.RadioButton()
         Me.labelCPUTypeDescription = New System.Windows.Forms.Label()
         Me.tabpagePersonalization = New System.Windows.Forms.TabPage()
         Me.groupboxStatusbar = New System.Windows.Forms.GroupBox()
@@ -367,8 +367,8 @@ Partial Class aaformOptionsWindow
         '
         Me.groupboxCPUType.Controls.Add(Me.labelRecommendedWindowsEdition)
         Me.groupboxCPUType.Controls.Add(Me.radiobuttonCPUIsQBit)
-        Me.groupboxCPUType.Controls.Add(Me.radiobuttonCPUIs64Bit)
-        Me.groupboxCPUType.Controls.Add(Me.radiobuttonCPUIs32Bit)
+        Me.groupboxCPUType.Controls.Add(Me.radiobuttonUseProgramFilesX86)
+        Me.groupboxCPUType.Controls.Add(Me.radiobuttonUseProgramFiles)
         Me.groupboxCPUType.Controls.Add(Me.labelCPUTypeDescription)
         Me.groupboxCPUType.Location = New System.Drawing.Point(3, 3)
         Me.groupboxCPUType.Margin = New System.Windows.Forms.Padding(2)
@@ -401,31 +401,31 @@ Partial Class aaformOptionsWindow
     "tton!)"
         Me.radiobuttonCPUIsQBit.UseVisualStyleBackColor = True
         '
-        'radiobuttonCPUIs64Bit
+        'radiobuttonUseProgramFilesX86
         '
-        Me.radiobuttonCPUIs64Bit.AutoSize = True
-        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(39, 70)
-        Me.radiobuttonCPUIs64Bit.Margin = New System.Windows.Forms.Padding(2)
-        Me.radiobuttonCPUIs64Bit.Name = "radiobuttonCPUIs64Bit"
-        Me.radiobuttonCPUIs64Bit.Size = New System.Drawing.Size(268, 17)
-        Me.radiobuttonCPUIs64Bit.TabIndex = 3
-        Me.radiobuttonCPUIs64Bit.TabStop = True
-        Me.radiobuttonCPUIs64Bit.Text = "Program Files (x86): 32-bit Office on 64-bit Windows"
-        Me.radiobuttonCPUIs64Bit.UseVisualStyleBackColor = True
+        Me.radiobuttonUseProgramFilesX86.AutoSize = True
+        Me.radiobuttonUseProgramFilesX86.Location = New System.Drawing.Point(39, 70)
+        Me.radiobuttonUseProgramFilesX86.Margin = New System.Windows.Forms.Padding(2)
+        Me.radiobuttonUseProgramFilesX86.Name = "radiobuttonUseProgramFilesX86"
+        Me.radiobuttonUseProgramFilesX86.Size = New System.Drawing.Size(268, 17)
+        Me.radiobuttonUseProgramFilesX86.TabIndex = 3
+        Me.radiobuttonUseProgramFilesX86.TabStop = True
+        Me.radiobuttonUseProgramFilesX86.Text = "Program Files (x86): 32-bit Office on 64-bit Windows"
+        Me.radiobuttonUseProgramFilesX86.UseVisualStyleBackColor = True
         '
-        'radiobuttonCPUIs32Bit
+        'radiobuttonUseProgramFiles
         '
-        Me.radiobuttonCPUIs32Bit.AutoSize = True
-        Me.radiobuttonCPUIs32Bit.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(39, 36)
-        Me.radiobuttonCPUIs32Bit.Margin = New System.Windows.Forms.Padding(2)
-        Me.radiobuttonCPUIs32Bit.Name = "radiobuttonCPUIs32Bit"
-        Me.radiobuttonCPUIs32Bit.Size = New System.Drawing.Size(350, 30)
-        Me.radiobuttonCPUIs32Bit.TabIndex = 2
-        Me.radiobuttonCPUIs32Bit.TabStop = True
-        Me.radiobuttonCPUIs32Bit.Text = "Program Files: 64-bit Office on 64-bit Windows," & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "32-bit Office on 32-bit Windows," &
+        Me.radiobuttonUseProgramFiles.AutoSize = True
+        Me.radiobuttonUseProgramFiles.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.radiobuttonUseProgramFiles.Location = New System.Drawing.Point(39, 36)
+        Me.radiobuttonUseProgramFiles.Margin = New System.Windows.Forms.Padding(2)
+        Me.radiobuttonUseProgramFiles.Name = "radiobuttonUseProgramFiles"
+        Me.radiobuttonUseProgramFiles.Size = New System.Drawing.Size(350, 30)
+        Me.radiobuttonUseProgramFiles.TabIndex = 2
+        Me.radiobuttonUseProgramFiles.TabStop = True
+        Me.radiobuttonUseProgramFiles.Text = "Program Files: 64-bit Office on 64-bit Windows," & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "32-bit Office on 32-bit Windows," &
     " or 32-bit Office 2013 from Office 365"
-        Me.radiobuttonCPUIs32Bit.UseVisualStyleBackColor = True
+        Me.radiobuttonUseProgramFiles.UseVisualStyleBackColor = True
         '
         'labelCPUTypeDescription
         '
@@ -737,8 +737,8 @@ Partial Class aaformOptionsWindow
     Friend WithEvents checkboxO365InstallMethod As CheckBox
     Friend WithEvents groupboxCPUType As GroupBox
     Friend WithEvents labelCPUTypeDescription As Label
-    Friend WithEvents radiobuttonCPUIs32Bit As RadioButton
-    Friend WithEvents radiobuttonCPUIs64Bit As RadioButton
+    Friend WithEvents radiobuttonUseProgramFiles As RadioButton
+    Friend WithEvents radiobuttonUseProgramFilesX86 As RadioButton
     Friend WithEvents radiobuttonCPUIsQBit As RadioButton
     Friend WithEvents buttonTestSettings As Button
     Friend WithEvents labelOfficeInstallMethodDescription As Label

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -169,7 +169,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
         Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
-        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 147)
+        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(4, 147)
         Me.groupboxBypassConfiguredLocation.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
         Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 175)
@@ -224,7 +224,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeVersion.Controls.Add(Me.checkboxO365InstallMethod)
         Me.groupboxOfficeVersion.Controls.Add(Me.labelUserHasThisOfficeVersion)
         Me.groupboxOfficeVersion.Controls.Add(Me.comboboxOfficeVersionSelector)
-        Me.groupboxOfficeVersion.Location = New System.Drawing.Point(3, 4)
+        Me.groupboxOfficeVersion.Location = New System.Drawing.Point(4, 4)
         Me.groupboxOfficeVersion.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxOfficeVersion.Name = "groupboxOfficeVersion"
         Me.groupboxOfficeVersion.Padding = New System.Windows.Forms.Padding(2)

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -404,7 +404,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonCPUIs64Bit
         '
         Me.radiobuttonCPUIs64Bit.AutoSize = True
-        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(39, 36)
+        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(39, 70)
         Me.radiobuttonCPUIs64Bit.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonCPUIs64Bit.Name = "radiobuttonCPUIs64Bit"
         Me.radiobuttonCPUIs64Bit.Size = New System.Drawing.Size(268, 17)
@@ -417,7 +417,7 @@ Partial Class aaformOptionsWindow
         '
         Me.radiobuttonCPUIs32Bit.AutoSize = True
         Me.radiobuttonCPUIs32Bit.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(39, 57)
+        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(39, 36)
         Me.radiobuttonCPUIs32Bit.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonCPUIs32Bit.Name = "radiobuttonCPUIs32Bit"
         Me.radiobuttonCPUIs32Bit.Size = New System.Drawing.Size(350, 30)

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -68,7 +68,6 @@ Partial Class aaformOptionsWindow
         Me.checkboxEnableThemeEngine = New System.Windows.Forms.CheckBox()
         Me.buttonTestSettings = New System.Windows.Forms.Button()
         Me.buttonDefaultSettings = New System.Windows.Forms.Button()
-        Me.linklabelTempFutureChanges = New System.Windows.Forms.LinkLabel()
         Me.tooltipO365InstallMethod = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipSystemInfo = New System.Windows.Forms.ToolTip(Me.components)
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
@@ -100,7 +99,6 @@ Partial Class aaformOptionsWindow
         Me.tableLayoutPanelOptionsWindow.Controls.Add(Me.tabcontrolOptionsWindow, 0, 0)
         Me.tableLayoutPanelOptionsWindow.Controls.Add(Me.buttonTestSettings, 1, 1)
         Me.tableLayoutPanelOptionsWindow.Controls.Add(Me.buttonDefaultSettings, 0, 1)
-        Me.tableLayoutPanelOptionsWindow.Controls.Add(Me.linklabelTempFutureChanges, 2, 1)
         Me.tableLayoutPanelOptionsWindow.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tableLayoutPanelOptionsWindow.Location = New System.Drawing.Point(0, 0)
         Me.tableLayoutPanelOptionsWindow.Margin = New System.Windows.Forms.Padding(2)
@@ -607,18 +605,6 @@ Partial Class aaformOptionsWindow
         Me.buttonDefaultSettings.Text = "Defaults"
         Me.buttonDefaultSettings.UseVisualStyleBackColor = True
         '
-        'linklabelTempFutureChanges
-        '
-        Me.linklabelTempFutureChanges.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.linklabelTempFutureChanges.AutoSize = True
-        Me.linklabelTempFutureChanges.Location = New System.Drawing.Point(156, 377)
-        Me.linklabelTempFutureChanges.Margin = New System.Windows.Forms.Padding(4, 0, 2, 4)
-        Me.linklabelTempFutureChanges.Name = "linklabelTempFutureChanges"
-        Me.linklabelTempFutureChanges.Size = New System.Drawing.Size(117, 13)
-        Me.linklabelTempFutureChanges.TabIndex = 10
-        Me.linklabelTempFutureChanges.TabStop = True
-        Me.linklabelTempFutureChanges.Text = "Future change notice..."
-        '
         'tooltipO365InstallMethod
         '
         Me.tooltipO365InstallMethod.AutoPopDelay = 32766
@@ -719,7 +705,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents tooltipCustomThemePath As ToolTip
     Friend WithEvents checkboxMatchWindows10ThemeSettings As CheckBox
     Friend WithEvents tooltipMatchWindows10ThemeSettings As ToolTip
-    Friend WithEvents linklabelTempFutureChanges As LinkLabel
     Friend WithEvents groupboxBypassConfiguredLocation As GroupBox
     Friend WithEvents radiobuttonBypassConfiguredLocationAllApps As RadioButton
     Friend WithEvents radiobuttonBypassConfiguredLocationDeprecatedApps As RadioButton

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -404,7 +404,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonCPUIs64Bit
         '
         Me.radiobuttonCPUIs64Bit.AutoSize = True
-        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(39, 70)
+        Me.radiobuttonCPUIs64Bit.Location = New System.Drawing.Point(39, 36)
         Me.radiobuttonCPUIs64Bit.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonCPUIs64Bit.Name = "radiobuttonCPUIs64Bit"
         Me.radiobuttonCPUIs64Bit.Size = New System.Drawing.Size(268, 17)
@@ -417,7 +417,7 @@ Partial Class aaformOptionsWindow
         '
         Me.radiobuttonCPUIs32Bit.AutoSize = True
         Me.radiobuttonCPUIs32Bit.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(39, 36)
+        Me.radiobuttonCPUIs32Bit.Location = New System.Drawing.Point(39, 57)
         Me.radiobuttonCPUIs32Bit.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonCPUIs32Bit.Name = "radiobuttonCPUIs32Bit"
         Me.radiobuttonCPUIs32Bit.Size = New System.Drawing.Size(350, 30)

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -33,16 +33,7 @@ Partial Class aaformOptionsWindow
         Me.checkboxO365InstallMethod = New System.Windows.Forms.CheckBox()
         Me.labelUserHasThisOfficeVersion = New System.Windows.Forms.Label()
         Me.comboboxOfficeVersionSelector = New System.Windows.Forms.ComboBox()
-        Me.groupboxOfficeLocation = New System.Windows.Forms.GroupBox()
-        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
-        Me.labelDriveTextboxLabel = New System.Windows.Forms.Label()
-        Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
         Me.tabpageAdvanced = New System.Windows.Forms.TabPage()
-        Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
-        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
-        Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.groupboxCPUType = New System.Windows.Forms.GroupBox()
         Me.labelRecommendedWindowsEdition = New System.Windows.Forms.Label()
         Me.radiobuttonCPUIsQBit = New System.Windows.Forms.RadioButton()
@@ -74,17 +65,26 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
+        Me.groupboxOfficeLocation = New System.Windows.Forms.GroupBox()
+        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
+        Me.labelDriveTextboxLabel = New System.Windows.Forms.Label()
+        Me.labelOfficeInstalledToDrive = New System.Windows.Forms.Label()
+        Me.groupboxBypassConfiguredLocation = New System.Windows.Forms.GroupBox()
+        Me.radiobuttonBypassConfiguredLocationAllApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
+        Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
         Me.groupboxOfficeVersion.SuspendLayout()
-        Me.groupboxOfficeLocation.SuspendLayout()
         Me.tabpageAdvanced.SuspendLayout()
-        Me.groupboxBypassConfiguredLocation.SuspendLayout()
         Me.groupboxCPUType.SuspendLayout()
         Me.tabpagePersonalization.SuspendLayout()
         Me.groupboxStatusbar.SuspendLayout()
         Me.groupboxAppearance.SuspendLayout()
+        Me.groupboxOfficeLocation.SuspendLayout()
+        Me.groupboxBypassConfiguredLocation.SuspendLayout()
         Me.SuspendLayout()
         '
         'tableLayoutPanelOptionsWindow
@@ -152,15 +152,15 @@ Partial Class aaformOptionsWindow
         '
         'tabpageGeneral
         '
+        Me.tabpageGeneral.Controls.Add(Me.groupboxBypassConfiguredLocation)
         Me.tabpageGeneral.Controls.Add(Me.groupboxOfficeVersion)
-        Me.tabpageGeneral.Controls.Add(Me.groupboxOfficeLocation)
         Me.tabpageGeneral.Location = New System.Drawing.Point(4, 22)
         Me.tabpageGeneral.Margin = New System.Windows.Forms.Padding(2)
         Me.tabpageGeneral.Name = "tabpageGeneral"
         Me.tabpageGeneral.Padding = New System.Windows.Forms.Padding(2)
         Me.tabpageGeneral.Size = New System.Drawing.Size(422, 326)
         Me.tabpageGeneral.TabIndex = 0
-        Me.tabpageGeneral.Text = "Office Version"
+        Me.tabpageGeneral.Text = "Versions + Compatibility"
         Me.tabpageGeneral.UseVisualStyleBackColor = True
         '
         'groupboxOfficeVersion
@@ -168,20 +168,20 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeVersion.Controls.Add(Me.checkboxO365InstallMethod)
         Me.groupboxOfficeVersion.Controls.Add(Me.labelUserHasThisOfficeVersion)
         Me.groupboxOfficeVersion.Controls.Add(Me.comboboxOfficeVersionSelector)
-        Me.groupboxOfficeVersion.Location = New System.Drawing.Point(3, 211)
+        Me.groupboxOfficeVersion.Location = New System.Drawing.Point(3, 4)
         Me.groupboxOfficeVersion.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxOfficeVersion.Name = "groupboxOfficeVersion"
         Me.groupboxOfficeVersion.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeVersion.Size = New System.Drawing.Size(415, 113)
+        Me.groupboxOfficeVersion.Size = New System.Drawing.Size(415, 159)
         Me.groupboxOfficeVersion.TabIndex = 1
         Me.groupboxOfficeVersion.TabStop = False
-        Me.groupboxOfficeVersion.Text = "Microsoft Office version + compatibility"
+        Me.groupboxOfficeVersion.Text = "Microsoft Office versions + C2R"
         '
         'checkboxO365InstallMethod
         '
         Me.checkboxO365InstallMethod.AutoSize = True
         Me.checkboxO365InstallMethod.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(92, 64)
+        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(79, 91)
         Me.checkboxO365InstallMethod.Margin = New System.Windows.Forms.Padding(2)
         Me.checkboxO365InstallMethod.Name = "checkboxO365InstallMethod"
         Me.checkboxO365InstallMethod.Size = New System.Drawing.Size(235, 30)
@@ -194,7 +194,7 @@ Partial Class aaformOptionsWindow
         'labelUserHasThisOfficeVersion
         '
         Me.labelUserHasThisOfficeVersion.AutoSize = True
-        Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(88, 25)
+        Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(76, 37)
         Me.labelUserHasThisOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelUserHasThisOfficeVersion.Name = "labelUserHasThisOfficeVersion"
         Me.labelUserHasThisOfficeVersion.Size = New System.Drawing.Size(263, 13)
@@ -205,57 +205,15 @@ Partial Class aaformOptionsWindow
         '
         Me.comboboxOfficeVersionSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.comboboxOfficeVersionSelector.FormattingEnabled = True
-        Me.comboboxOfficeVersionSelector.Location = New System.Drawing.Point(92, 39)
+        Me.comboboxOfficeVersionSelector.Location = New System.Drawing.Point(79, 52)
         Me.comboboxOfficeVersionSelector.Margin = New System.Windows.Forms.Padding(2)
         Me.comboboxOfficeVersionSelector.Name = "comboboxOfficeVersionSelector"
         Me.comboboxOfficeVersionSelector.Size = New System.Drawing.Size(138, 21)
         Me.comboboxOfficeVersionSelector.TabIndex = 4
         '
-        'groupboxOfficeLocation
-        '
-        Me.groupboxOfficeLocation.Controls.Add(Me.comboboxDriveSelector)
-        Me.groupboxOfficeLocation.Controls.Add(Me.labelDriveTextboxLabel)
-        Me.groupboxOfficeLocation.Controls.Add(Me.labelOfficeInstalledToDrive)
-        Me.groupboxOfficeLocation.Location = New System.Drawing.Point(3, 3)
-        Me.groupboxOfficeLocation.Margin = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeLocation.Name = "groupboxOfficeLocation"
-        Me.groupboxOfficeLocation.Padding = New System.Windows.Forms.Padding(2)
-        Me.groupboxOfficeLocation.Size = New System.Drawing.Size(415, 130)
-        Me.groupboxOfficeLocation.TabIndex = 0
-        Me.groupboxOfficeLocation.TabStop = False
-        Me.groupboxOfficeLocation.Text = "Microsoft Office drive location"
-        '
-        'comboboxDriveSelector
-        '
-        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-        Me.comboboxDriveSelector.FormattingEnabled = True
-        Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
-        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
-        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
-        Me.comboboxDriveSelector.TabIndex = 5
-        '
-        'labelDriveTextboxLabel
-        '
-        Me.labelDriveTextboxLabel.AutoSize = True
-        Me.labelDriveTextboxLabel.Location = New System.Drawing.Point(88, 60)
-        Me.labelDriveTextboxLabel.Name = "labelDriveTextboxLabel"
-        Me.labelDriveTextboxLabel.Size = New System.Drawing.Size(32, 13)
-        Me.labelDriveTextboxLabel.TabIndex = 4
-        Me.labelDriveTextboxLabel.Text = "Drive"
-        '
-        'labelOfficeInstalledToDrive
-        '
-        Me.labelOfficeInstalledToDrive.AutoSize = True
-        Me.labelOfficeInstalledToDrive.Location = New System.Drawing.Point(88, 37)
-        Me.labelOfficeInstalledToDrive.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
-        Me.labelOfficeInstalledToDrive.Name = "labelOfficeInstalledToDrive"
-        Me.labelOfficeInstalledToDrive.Size = New System.Drawing.Size(228, 13)
-        Me.labelOfficeInstalledToDrive.TabIndex = 1
-        Me.labelOfficeInstalledToDrive.Text = "Please choose the drive you installed Office to:"
-        '
         'tabpageAdvanced
         '
-        Me.tabpageAdvanced.Controls.Add(Me.groupboxBypassConfiguredLocation)
+        Me.tabpageAdvanced.Controls.Add(Me.groupboxOfficeLocation)
         Me.tabpageAdvanced.Controls.Add(Me.groupboxCPUType)
         Me.tabpageAdvanced.Location = New System.Drawing.Point(4, 22)
         Me.tabpageAdvanced.Margin = New System.Windows.Forms.Padding(2)
@@ -265,62 +223,6 @@ Partial Class aaformOptionsWindow
         Me.tabpageAdvanced.TabIndex = 1
         Me.tabpageAdvanced.Text = "Root Path"
         Me.tabpageAdvanced.UseVisualStyleBackColor = True
-        '
-        'groupboxBypassConfiguredLocation
-        '
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationAllApps)
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
-        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
-        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 169)
-        Me.groupboxBypassConfiguredLocation.Margin = New System.Windows.Forms.Padding(2)
-        Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
-        Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 155)
-        Me.groupboxBypassConfiguredLocation.TabIndex = 1
-        Me.groupboxBypassConfiguredLocation.TabStop = False
-        Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
-        '
-        'radiobuttonBypassConfiguredLocationAllApps
-        '
-        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(57, 120)
-        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
-        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
-        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
-        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
-        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
-        '
-        'radiobuttonBypassConfiguredLocationDeprecatedApps
-        '
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(57, 97)
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated/removed apps"
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
-        '
-        'radiobuttonDontBypassConfiguredLocation
-        '
-        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
-        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(57, 74)
-        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
-        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
-        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
-        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
-        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
-        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
-        '
-        'labelBypassConfiguredLocation
-        '
-        Me.labelBypassConfiguredLocation.AutoSize = True
-        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(36, 22)
-        Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
-        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
-        Me.labelBypassConfiguredLocation.TabIndex = 0
-        Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
         '
         'groupboxCPUType
         '
@@ -642,6 +544,104 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
+        'groupboxOfficeLocation
+        '
+        Me.groupboxOfficeLocation.Controls.Add(Me.comboboxDriveSelector)
+        Me.groupboxOfficeLocation.Controls.Add(Me.labelDriveTextboxLabel)
+        Me.groupboxOfficeLocation.Controls.Add(Me.labelOfficeInstalledToDrive)
+        Me.groupboxOfficeLocation.Location = New System.Drawing.Point(3, 169)
+        Me.groupboxOfficeLocation.Margin = New System.Windows.Forms.Padding(2)
+        Me.groupboxOfficeLocation.Name = "groupboxOfficeLocation"
+        Me.groupboxOfficeLocation.Padding = New System.Windows.Forms.Padding(2)
+        Me.groupboxOfficeLocation.Size = New System.Drawing.Size(415, 153)
+        Me.groupboxOfficeLocation.TabIndex = 6
+        Me.groupboxOfficeLocation.TabStop = False
+        Me.groupboxOfficeLocation.Text = "Microsoft Office drive location"
+        '
+        'comboboxDriveSelector
+        '
+        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDriveSelector.FormattingEnabled = True
+        Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
+        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
+        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
+        Me.comboboxDriveSelector.TabIndex = 5
+        '
+        'labelDriveTextboxLabel
+        '
+        Me.labelDriveTextboxLabel.AutoSize = True
+        Me.labelDriveTextboxLabel.Location = New System.Drawing.Point(88, 60)
+        Me.labelDriveTextboxLabel.Name = "labelDriveTextboxLabel"
+        Me.labelDriveTextboxLabel.Size = New System.Drawing.Size(32, 13)
+        Me.labelDriveTextboxLabel.TabIndex = 4
+        Me.labelDriveTextboxLabel.Text = "Drive"
+        '
+        'labelOfficeInstalledToDrive
+        '
+        Me.labelOfficeInstalledToDrive.AutoSize = True
+        Me.labelOfficeInstalledToDrive.Location = New System.Drawing.Point(88, 37)
+        Me.labelOfficeInstalledToDrive.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.labelOfficeInstalledToDrive.Name = "labelOfficeInstalledToDrive"
+        Me.labelOfficeInstalledToDrive.Size = New System.Drawing.Size(228, 13)
+        Me.labelOfficeInstalledToDrive.TabIndex = 1
+        Me.labelOfficeInstalledToDrive.Text = "Please choose the drive you installed Office to:"
+        '
+        'groupboxBypassConfiguredLocation
+        '
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationAllApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonBypassConfiguredLocationDeprecatedApps)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.radiobuttonDontBypassConfiguredLocation)
+        Me.groupboxBypassConfiguredLocation.Controls.Add(Me.labelBypassConfiguredLocation)
+        Me.groupboxBypassConfiguredLocation.Location = New System.Drawing.Point(3, 167)
+        Me.groupboxBypassConfiguredLocation.Margin = New System.Windows.Forms.Padding(2)
+        Me.groupboxBypassConfiguredLocation.Name = "groupboxBypassConfiguredLocation"
+        Me.groupboxBypassConfiguredLocation.Size = New System.Drawing.Size(415, 155)
+        Me.groupboxBypassConfiguredLocation.TabIndex = 2
+        Me.groupboxBypassConfiguredLocation.TabStop = False
+        Me.groupboxBypassConfiguredLocation.Text = "Bypass configured location"
+        '
+        'radiobuttonBypassConfiguredLocationAllApps
+        '
+        Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(57, 120)
+        Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
+        Me.radiobuttonBypassConfiguredLocationAllApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationAllApps.Text = "Bypass configured location for all compatible apps"
+        Me.radiobuttonBypassConfiguredLocationAllApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonBypassConfiguredLocationDeprecatedApps
+        '
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(57, 97)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabStop = True
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Text = "Bypass configured location for deprecated/removed apps"
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.UseVisualStyleBackColor = True
+        '
+        'radiobuttonDontBypassConfiguredLocation
+        '
+        Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
+        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(57, 74)
+        Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
+        Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
+        Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
+        Me.radiobuttonDontBypassConfiguredLocation.TabStop = True
+        Me.radiobuttonDontBypassConfiguredLocation.Text = "Don't bypass configured location"
+        Me.radiobuttonDontBypassConfiguredLocation.UseVisualStyleBackColor = True
+        '
+        'labelBypassConfiguredLocation
+        '
+        Me.labelBypassConfiguredLocation.AutoSize = True
+        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(36, 22)
+        Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
+        Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
+        Me.labelBypassConfiguredLocation.TabIndex = 0
+        Me.labelBypassConfiguredLocation.Text = resources.GetString("labelBypassConfiguredLocation.Text")
+        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -663,11 +663,7 @@ Partial Class aaformOptionsWindow
         Me.tabpageGeneral.ResumeLayout(False)
         Me.groupboxOfficeVersion.ResumeLayout(False)
         Me.groupboxOfficeVersion.PerformLayout()
-        Me.groupboxOfficeLocation.ResumeLayout(False)
-        Me.groupboxOfficeLocation.PerformLayout()
         Me.tabpageAdvanced.ResumeLayout(False)
-        Me.groupboxBypassConfiguredLocation.ResumeLayout(False)
-        Me.groupboxBypassConfiguredLocation.PerformLayout()
         Me.groupboxCPUType.ResumeLayout(False)
         Me.groupboxCPUType.PerformLayout()
         Me.tabpagePersonalization.ResumeLayout(False)
@@ -675,6 +671,10 @@ Partial Class aaformOptionsWindow
         Me.groupboxStatusbar.PerformLayout()
         Me.groupboxAppearance.ResumeLayout(False)
         Me.groupboxAppearance.PerformLayout()
+        Me.groupboxOfficeLocation.ResumeLayout(False)
+        Me.groupboxOfficeLocation.PerformLayout()
+        Me.groupboxBypassConfiguredLocation.ResumeLayout(False)
+        Me.groupboxBypassConfiguredLocation.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -686,8 +686,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents tabcontrolOptionsWindow As TabControl
     Friend WithEvents tabpageGeneral As TabPage
     Friend WithEvents tabpageAdvanced As TabPage
-    Friend WithEvents groupboxOfficeLocation As GroupBox
-    Friend WithEvents labelOfficeInstalledToDrive As Label
     Friend WithEvents groupboxOfficeVersion As GroupBox
     Friend WithEvents comboboxOfficeVersionSelector As ComboBox
     Friend WithEvents labelUserHasThisOfficeVersion As Label
@@ -699,7 +697,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents radiobuttonCPUIsQBit As RadioButton
     Friend WithEvents buttonTestSettings As Button
     Friend WithEvents tooltipO365InstallMethod As ToolTip
-    Friend WithEvents labelDriveTextboxLabel As Label
     Friend WithEvents tooltipSystemInfo As ToolTip
     Friend WithEvents tabpagePersonalization As TabPage
     Friend WithEvents groupboxAppearance As GroupBox
@@ -719,14 +716,17 @@ Partial Class aaformOptionsWindow
     Friend WithEvents buttonClearFirstname As Button
     Friend WithEvents openfiledialogBrowseCustomThemeFile As OpenFileDialog
     Friend WithEvents labelRecommendedWindowsEdition As Label
-    Friend WithEvents groupboxBypassConfiguredLocation As GroupBox
-    Friend WithEvents labelBypassConfiguredLocation As Label
     Friend WithEvents tooltipCustomThemePath As ToolTip
     Friend WithEvents checkboxMatchWindows10ThemeSettings As CheckBox
     Friend WithEvents tooltipMatchWindows10ThemeSettings As ToolTip
-    Friend WithEvents radiobuttonDontBypassConfiguredLocation As RadioButton
-    Friend WithEvents radiobuttonBypassConfiguredLocationDeprecatedApps As RadioButton
-    Friend WithEvents radiobuttonBypassConfiguredLocationAllApps As RadioButton
     Friend WithEvents linklabelTempFutureChanges As LinkLabel
+    Friend WithEvents groupboxBypassConfiguredLocation As GroupBox
+    Friend WithEvents radiobuttonBypassConfiguredLocationAllApps As RadioButton
+    Friend WithEvents radiobuttonBypassConfiguredLocationDeprecatedApps As RadioButton
+    Friend WithEvents radiobuttonDontBypassConfiguredLocation As RadioButton
+    Friend WithEvents labelBypassConfiguredLocation As Label
+    Friend WithEvents groupboxOfficeLocation As GroupBox
     Friend WithEvents comboboxDriveSelector As ComboBox
+    Friend WithEvents labelDriveTextboxLabel As Label
+    Friend WithEvents labelOfficeInstalledToDrive As Label
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -75,6 +75,7 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
+        Me.comboboxDriveSelector = New System.Windows.Forms.ComboBox()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -214,6 +215,7 @@ Partial Class aaformOptionsWindow
         '
         'groupboxOfficeLocation
         '
+        Me.groupboxOfficeLocation.Controls.Add(Me.comboboxDriveSelector)
         Me.groupboxOfficeLocation.Controls.Add(Me.labelDriveTextboxLabel)
         Me.groupboxOfficeLocation.Controls.Add(Me.buttonClearDriveLetter)
         Me.groupboxOfficeLocation.Controls.Add(Me.textboxOfficeDrive)
@@ -240,7 +242,7 @@ Partial Class aaformOptionsWindow
         '
         Me.buttonClearDriveLetter.AutoSize = True
         Me.buttonClearDriveLetter.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
-        Me.buttonClearDriveLetter.Location = New System.Drawing.Point(150, 55)
+        Me.buttonClearDriveLetter.Location = New System.Drawing.Point(150, 92)
         Me.buttonClearDriveLetter.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonClearDriveLetter.Name = "buttonClearDriveLetter"
         Me.buttonClearDriveLetter.Size = New System.Drawing.Size(41, 23)
@@ -251,7 +253,7 @@ Partial Class aaformOptionsWindow
         'textboxOfficeDrive
         '
         Me.textboxOfficeDrive.CharacterCasing = System.Windows.Forms.CharacterCasing.Upper
-        Me.textboxOfficeDrive.Location = New System.Drawing.Point(126, 57)
+        Me.textboxOfficeDrive.Location = New System.Drawing.Point(126, 94)
         Me.textboxOfficeDrive.Margin = New System.Windows.Forms.Padding(2)
         Me.textboxOfficeDrive.MaxLength = 1
         Me.textboxOfficeDrive.Name = "textboxOfficeDrive"
@@ -266,9 +268,9 @@ Partial Class aaformOptionsWindow
         Me.labelOfficeInstalledToDrive.Location = New System.Drawing.Point(88, 37)
         Me.labelOfficeInstalledToDrive.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelOfficeInstalledToDrive.Name = "labelOfficeInstalledToDrive"
-        Me.labelOfficeInstalledToDrive.Size = New System.Drawing.Size(188, 13)
+        Me.labelOfficeInstalledToDrive.Size = New System.Drawing.Size(228, 13)
         Me.labelOfficeInstalledToDrive.TabIndex = 1
-        Me.labelOfficeInstalledToDrive.Text = "I installed Microsoft Office to this drive:"
+        Me.labelOfficeInstalledToDrive.Text = "Please choose the drive you installed Office to:"
         '
         'tabpageAdvanced
         '
@@ -659,6 +661,16 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
+        'comboboxDriveSelector
+        '
+        Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDriveSelector.FormattingEnabled = True
+        Me.comboboxDriveSelector.Items.AddRange(New Object() {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"})
+        Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
+        Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
+        Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)
+        Me.comboboxDriveSelector.TabIndex = 5
+        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -747,4 +759,5 @@ Partial Class aaformOptionsWindow
     Friend WithEvents radiobuttonBypassConfiguredLocationDeprecatedApps As RadioButton
     Friend WithEvents radiobuttonBypassConfiguredLocationAllApps As RadioButton
     Friend WithEvents linklabelTempFutureChanges As LinkLabel
+    Friend WithEvents comboboxDriveSelector As ComboBox
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -665,7 +665,6 @@ Partial Class aaformOptionsWindow
         '
         Me.comboboxDriveSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.comboboxDriveSelector.FormattingEnabled = True
-        Me.comboboxDriveSelector.Items.AddRange(New Object() {"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"})
         Me.comboboxDriveSelector.Location = New System.Drawing.Point(126, 57)
         Me.comboboxDriveSelector.Name = "comboboxDriveSelector"
         Me.comboboxDriveSelector.Size = New System.Drawing.Size(41, 21)

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -180,7 +180,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonBypassConfiguredLocationAllApps
         '
         Me.radiobuttonBypassConfiguredLocationAllApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(59, 135)
+        Me.radiobuttonBypassConfiguredLocationAllApps.Location = New System.Drawing.Point(59, 127)
         Me.radiobuttonBypassConfiguredLocationAllApps.Name = "radiobuttonBypassConfiguredLocationAllApps"
         Me.radiobuttonBypassConfiguredLocationAllApps.Size = New System.Drawing.Size(260, 17)
         Me.radiobuttonBypassConfiguredLocationAllApps.TabIndex = 5
@@ -191,7 +191,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonBypassConfiguredLocationDeprecatedApps
         '
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.AutoSize = True
-        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(59, 112)
+        Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Location = New System.Drawing.Point(59, 104)
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Name = "radiobuttonBypassConfiguredLocationDeprecatedApps"
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.Size = New System.Drawing.Size(296, 17)
         Me.radiobuttonBypassConfiguredLocationDeprecatedApps.TabIndex = 4
@@ -202,7 +202,7 @@ Partial Class aaformOptionsWindow
         'radiobuttonDontBypassConfiguredLocation
         '
         Me.radiobuttonDontBypassConfiguredLocation.AutoSize = True
-        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(59, 89)
+        Me.radiobuttonDontBypassConfiguredLocation.Location = New System.Drawing.Point(59, 81)
         Me.radiobuttonDontBypassConfiguredLocation.Name = "radiobuttonDontBypassConfiguredLocation"
         Me.radiobuttonDontBypassConfiguredLocation.Size = New System.Drawing.Size(179, 17)
         Me.radiobuttonDontBypassConfiguredLocation.TabIndex = 3
@@ -213,7 +213,7 @@ Partial Class aaformOptionsWindow
         'labelBypassConfiguredLocation
         '
         Me.labelBypassConfiguredLocation.AutoSize = True
-        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(38, 31)
+        Me.labelBypassConfiguredLocation.Location = New System.Drawing.Point(44, 30)
         Me.labelBypassConfiguredLocation.Name = "labelBypassConfiguredLocation"
         Me.labelBypassConfiguredLocation.Size = New System.Drawing.Size(338, 39)
         Me.labelBypassConfiguredLocation.TabIndex = 0

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,6 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
+    <value>If you'd like, you can bypass the configured location when launching
+some apps, such as ones that have been deprecated or removed from
+later Office versions, or all compatible apps (ones that open from Run).</value>
+  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -151,24 +156,10 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>629, 23</value>
   </metadata>
-  <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>22, 23</value>
-  </metadata>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>214, 23</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
   </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
-  </metadata>
-  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
-    <value>If you'd like, you can bypass the configured location when launching
-some apps, such as ones that have been deprecated or removed from
-later Office versions, or all compatible apps (ones that open from Run).</value>
-  </data>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,13 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
-    <value>Your installation of Windows is 16-bit, so you'll probably want to
-select "Program Files" if you're using any of the configurations not listed for it.
-If you're using 32-bit Office on 64-bit Windows, you'll need to select the
-"Program Files (x86)" option.
-Something is broken if 16-bit Windows is recommended to you; please report.</value>
-  </data>
   <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
     <value>If you'd like, you can bypass the configured location when launching
 some apps, such as ones that have been deprecated or removed from
@@ -143,6 +136,13 @@ On some versions of Office such as Office 2016, Microsoft places the EXE files i
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
   </data>
+  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
+    <value>Your installation of Windows is 16-bit, so you'll probably want to
+select "Program Files" if you're using any of the configurations not listed for it.
+If you're using 32-bit Office on 64-bit Windows, you'll need to select the
+"Program Files (x86)" option.
+Something is broken if 16-bit Windows is recommended to you; please report.</value>
+  </data>
   <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>820, 23</value>
   </metadata>
@@ -156,19 +156,10 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>629, 23</value>
   </metadata>
-  <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>22, 23</value>
-  </metadata>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>214, 23</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
-  </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -131,11 +131,6 @@ On some versions of Office such as Office 2016, Microsoft places the EXE files i
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
   </data>
-  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
-    <value>If you'd like, you can bypass the configured location when launching
-some apps, such as ones that have been deprecated or removed from
-later Office versions, or all compatible apps (ones that open from Run).</value>
-  </data>
   <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
     <value>Your installation of Windows is 16-bit, so you'll probably want to
 select "Program Files" if you're using any of the configurations not listed for it.
@@ -156,6 +151,9 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>629, 23</value>
   </metadata>
+  <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>22, 23</value>
+  </metadata>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>214, 23</value>
   </metadata>
@@ -168,4 +166,9 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>820, 23</value>
   </metadata>
+  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
+    <value>If you'd like, you can bypass the configured location when launching
+some apps, such as ones that have been deprecated or removed from
+later Office versions, or all compatible apps (ones that open from Run).</value>
+  </data>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,6 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
+    <value>Your installation of Windows is 16-bit, so you'll probably want to
+select "Program Files" if you're using any of the configurations not listed for it.
+If you're using 32-bit Office on 64-bit Windows, you'll need to select the
+"Program Files (x86)" option.
+Something is broken if 16-bit Windows is recommended to you; please report.</value>
+  </data>
   <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
     <value>If you'd like, you can bypass the configured location when launching
 some apps, such as ones that have been deprecated or removed from
@@ -136,13 +143,6 @@ On some versions of Office such as Office 2016, Microsoft places the EXE files i
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
   </data>
-  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
-    <value>Your installation of Windows is 16-bit, so you'll probably want to
-select "Program Files" if you're using any of the configurations not listed for it.
-If you're using 32-bit Office on 64-bit Windows, you'll need to select the
-"Program Files (x86)" option.
-Something is broken if 16-bit Windows is recommended to you; please report.</value>
-  </data>
   <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>820, 23</value>
   </metadata>
@@ -156,10 +156,19 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>629, 23</value>
   </metadata>
+  <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>22, 23</value>
+  </metadata>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>214, 23</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
+  </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -162,4 +162,10 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
   </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
+  </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,6 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
+    <value>16-bit Windows is the recommended option for you, but if
+using Office 2013, you may need to select "Program Files"
+due to the 32-bit version installing to "Program Files"
+even on 64-bit Windows. Something is broken if 16-bit
+Windows is recommended to you; please report.</value>
+  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -136,13 +143,6 @@ This option uses that folder instead of the default. If unsure of what this mean
 some apps, such as ones that have been deprecated or removed from
 later Office versions, or all compatible apps (ones that open from Run).</value>
   </data>
-  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
-    <value>16-bit Windows is the recommended option for you, but if
-using Office 2013, you may need to select "32-bit Windows"
-due to the 32-bit version installing to "Program Files"
-even on 64-bit Windows. Something is broken if 16-bit
-Windows is recommended to you; please report.</value>
-  </data>
   <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>820, 23</value>
   </metadata>
@@ -161,5 +161,11 @@ will be applied on app startup or when applying themes.</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
+  </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,11 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
-    <value>If you'd like, you can bypass the configured location when launching
-some apps, such as ones that have been deprecated or removed from
-later Office versions, or all compatible apps (ones that open from Run).</value>
-  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -135,6 +130,11 @@ so this setting will be ignored if those versions are selected in the dropdown b
 On some versions of Office such as Office 2016, Microsoft places the EXE files in a slightly different location
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
+  </data>
+  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
+    <value>If you'd like, you can bypass the configured location when launching
+some apps, such as ones that have been deprecated or removed from
+later Office versions, or all compatible apps (ones that open from Run).</value>
   </data>
   <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
     <value>Your installation of Windows is 16-bit, so you'll probably want to
@@ -161,5 +161,11 @@ will be applied on app startup or when applying themes.</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
+  </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,13 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
-    <value>Your installation of Windows is 16-bit, so you'll probably want to
-select "Program Files" if you're using any of the configurations not listed for it.
-If you're using 32-bit Office on 64-bit Windows, you'll need to select the
-"Program Files (x86)" option.
-Something is broken if 16-bit Windows is recommended to you; please report.</value>
-  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -142,6 +135,13 @@ This option uses that folder instead of the default. If unsure of what this mean
     <value>If you'd like, you can bypass the configured location when launching
 some apps, such as ones that have been deprecated or removed from
 later Office versions, or all compatible apps (ones that open from Run).</value>
+  </data>
+  <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
+    <value>Your installation of Windows is 16-bit, so you'll probably want to
+select "Program Files" if you're using any of the configurations not listed for it.
+If you're using 32-bit Office on 64-bit Windows, you'll need to select the
+"Program Files (x86)" option.
+Something is broken if 16-bit Windows is recommended to you; please report.</value>
   </data>
   <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>820, 23</value>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -162,10 +162,4 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
   </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
-  </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -117,6 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
+    <value>If you'd like, you can bypass the configured location when launching
+some apps, such as ones that have been deprecated or removed from
+later Office versions, or all compatible apps (ones that open from Run).</value>
+  </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>
   </metadata>
@@ -130,11 +135,6 @@ so this setting will be ignored if those versions are selected in the dropdown b
 On some versions of Office such as Office 2016, Microsoft places the EXE files in a slightly different location
 from older versions of Office. This is due to a technology called 'Click-to-Run', or 'C2R' for short.
 This option uses that folder instead of the default. If unsure of what this means, check this box.</value>
-  </data>
-  <data name="labelBypassConfiguredLocation.Text" xml:space="preserve">
-    <value>If you'd like, you can bypass the configured location when launching
-some apps, such as ones that have been deprecated or removed from
-later Office versions, or all compatible apps (ones that open from Run).</value>
   </data>
   <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
     <value>Your installation of Windows is 16-bit, so you'll probably want to
@@ -161,11 +161,5 @@ will be applied on app startup or when applying themes.</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
-  </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -118,11 +118,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="labelRecommendedWindowsEdition.Text" xml:space="preserve">
-    <value>16-bit Windows is the recommended option for you, but if
-using Office 2013, you may need to select "Program Files"
-due to the 32-bit version installing to "Program Files"
-even on 64-bit Windows. Something is broken if 16-bit
-Windows is recommended to you; please report.</value>
+    <value>Your installation of Windows is 16-bit, so you'll probably want to
+select "Program Files" if you're using any of the configurations not listed for it.
+If you're using 32-bit Office on 64-bit Windows, you'll need to select the
+"Program Files (x86)" option.
+Something is broken if 16-bit Windows is recommended to you; please report.</value>
   </data>
   <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>22, 23</value>

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -794,9 +794,13 @@ Public Class aaformOptionsWindow
 
     Private Sub comboboxOfficeVersionSelector_SelectedIndexChanged(sender As Object, e As EventArgs) Handles comboboxOfficeVersionSelector.SelectedIndexChanged
         If comboboxOfficeVersionSelector.SelectedIndex >= 3 Then
+            ' Office versions newer than 2016 don't support MSI
+            ' and default to C2R, so this checkbox is not necessary.
             labelOfficeInstallMethodDescription.Hide()
             checkboxO365InstallMethod.Hide()
         Else
+            ' Office versions older than 2019 support MSI
+            ' so this checkbox may be necessary.
             labelOfficeInstallMethodDescription.Show()
             checkboxO365InstallMethod.Show()
         End If

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -223,9 +223,9 @@ Public Class aaformOptionsWindow
         End If
 
         ' Load the user's settings for My.Settings.cpuIsSixtyFourBit.
-        If My.Settings.cpuIsSixtyFourBit = True Then
+        If My.Settings.pathUsePFxEightySix = True Then
             radiobuttonUseProgramFilesX86.Checked = True
-        ElseIf My.Settings.cpuIsSixtyFourBit = False Then
+        ElseIf My.Settings.pathUsePFxEightySix = False Then
             radiobuttonUseProgramFiles.Checked = True
         End If
 
@@ -364,21 +364,21 @@ Public Class aaformOptionsWindow
 
         ' Set My.Settings.cpuIsSixtyFourBit to True or False depending on the radio buttons.
         If radiobuttonUseProgramFiles.Checked = True Then
-            My.Settings.cpuIsSixtyFourBit = False
+            My.Settings.pathUsePFxEightySix = False
         ElseIf radiobuttonUseProgramFilesX86.Checked = True Then
-            My.Settings.cpuIsSixtyFourBit = True
+            My.Settings.pathUsePFxEightySix = True
         ElseIf radiobuttonCPUIsQBit.Checked = True Then
             ' Focus the "Advanced" tab.
             tabcontrolOptionsWindow.SelectedIndex = 1
             MessageBox.Show("Why do you have a quantum CPU?" & vbCrLf & "(Your currently saved settings will be re-applied because Qubits don't exist for consumers yet.)" & vbCrLf & "(Thank you for finding this hidden radio button!)", "Qubits don't exist for consumers yet.", MessageBoxButtons.OK,
                                 MessageBoxIcon.Error)
             ' Now set the radio buttons to current user settings.
-            If My.Settings.cpuIsSixtyFourBit = True Then
+            If My.Settings.pathUsePFxEightySix = True Then
                 radiobuttonUseProgramFilesX86.Checked = True
-                My.Settings.cpuIsSixtyFourBit = True
-            ElseIf My.Settings.cpuIsSixtyFourBit = False Then
+                My.Settings.pathUsePFxEightySix = True
+            ElseIf My.Settings.pathUsePFxEightySix = False Then
                 radiobuttonUseProgramFiles.Checked = True
-                My.Settings.cpuIsSixtyFourBit = False
+                My.Settings.pathUsePFxEightySix = False
             End If
         End If
 

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -796,12 +796,10 @@ Public Class aaformOptionsWindow
         If comboboxOfficeVersionSelector.SelectedIndex >= 3 Then
             ' Office versions newer than 2016 don't support MSI
             ' and default to C2R, so this checkbox is not necessary.
-            labelOfficeInstallMethodDescription.Hide()
             checkboxO365InstallMethod.Hide()
         Else
             ' Office versions older than 2019 support MSI
             ' so this checkbox may be necessary.
-            labelOfficeInstallMethodDescription.Show()
             checkboxO365InstallMethod.Show()
         End If
     End Sub

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -787,13 +787,6 @@ Public Class aaformOptionsWindow
 #End Region
 #End Region
 
-    Private Sub linklabelTempFutureChanges_LinkClicked(sender As Object, e As LinkLabelLinkClickedEventArgs) Handles linklabelTempFutureChanges.LinkClicked
-        ' Show future change notice messagebox with info based on
-        ' https://github.com/DrewNaylor/UXL-Launcher/issues/180
-        MessageBox.Show(Me, "In version 3.4, the Drive location/""I installed Microsoft Office to this drive:"" and Bypass configured location options will switch tabs. See also https://github.com/DrewNaylor/UXL-Launcher/issues/180",
-                        "Future Change Notice")
-    End Sub
-
     Private Sub comboboxOfficeVersionSelector_SelectedIndexChanged(sender As Object, e As EventArgs) Handles comboboxOfficeVersionSelector.SelectedIndexChanged
         If comboboxOfficeVersionSelector.SelectedIndex >= 3 Then
             ' Office versions newer than 2016 don't support MSI

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -204,9 +204,9 @@ Public Class aaformOptionsWindow
 
         ' Load the user's settings for My.Settings.cpuIsSixtyFourBit.
         If My.Settings.cpuIsSixtyFourBit = True Then
-            radiobuttonCPUIs64Bit.Checked = True
+            radiobuttonUseProgramFilesX86.Checked = True
         ElseIf My.Settings.cpuIsSixtyFourBit = False Then
-            radiobuttonCPUIs32Bit.Checked = True
+            radiobuttonUseProgramFiles.Checked = True
         End If
 
     End Sub
@@ -242,13 +242,13 @@ Public Class aaformOptionsWindow
         textboxOfficeDrive.Text = "C"
 
         ' Reset the Office Version Selector to Office 2010.
-        comboboxOfficeVersionSelector.Text = "Microsoft Office 2010"
+        comboboxOfficeVersionSelector.Text = "Microsoft Office 2019"
 
         ' Reset the Office 365 checkbox to unchecked.
         checkboxO365InstallMethod.Checked = False
 
         ' Reset the CPUType radio buttons to 64-bit.
-        radiobuttonCPUIs64Bit.Checked = True
+        radiobuttonUseProgramFilesX86.Checked = True
 
         ' Reset the theme to use to Default.
         comboboxThemeList.Text = "Default"
@@ -353,9 +353,9 @@ Public Class aaformOptionsWindow
             End If
 
             ' Set My.Settings.cpuIsSixtyFourBit to True or False depending on the radio buttons.
-            If radiobuttonCPUIs32Bit.Checked = True Then
+            If radiobuttonUseProgramFiles.Checked = True Then
                 My.Settings.cpuIsSixtyFourBit = False
-            ElseIf radiobuttonCPUIs64Bit.Checked = True Then
+            ElseIf radiobuttonUseProgramFilesX86.Checked = True Then
                 My.Settings.cpuIsSixtyFourBit = True
             ElseIf radiobuttonCPUIsQBit.Checked = True Then
                 ' Focus the "Advanced" tab.
@@ -364,10 +364,10 @@ Public Class aaformOptionsWindow
                                 MessageBoxIcon.Error)
                 ' Now set the radio buttons to current user settings.
                 If My.Settings.cpuIsSixtyFourBit = True Then
-                    radiobuttonCPUIs64Bit.Checked = True
+                    radiobuttonUseProgramFilesX86.Checked = True
                     My.Settings.cpuIsSixtyFourBit = True
                 ElseIf My.Settings.cpuIsSixtyFourBit = False Then
-                    radiobuttonCPUIs32Bit.Checked = True
+                    radiobuttonUseProgramFiles.Checked = True
                     My.Settings.cpuIsSixtyFourBit = False
                 End If
             End If

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -159,6 +159,9 @@ Public Class aaformOptionsWindow
 #End Region
 
 #Region "Set the drive list dropdown to the available drives."
+        ' Clear the drive letter list.
+        comboboxDriveSelector.Items.Clear()
+
         For Each DriveLetter As String In GetDriveLetters()
             ' Get the drive letters of all active drives and remove the ":\".
             comboboxDriveSelector.Items.Add(DriveLetter.Replace(":\", String.Empty))

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -248,7 +248,7 @@ Public Class aaformOptionsWindow
         checkboxO365InstallMethod.Checked = False
 
         ' Reset the CPUType radio buttons to 64-bit.
-        radiobuttonUseProgramFilesX86.Checked = True
+        radiobuttonUseProgramFiles.Checked = True
 
         ' Reset the theme to use to Default.
         comboboxThemeList.Text = "Default"
@@ -790,5 +790,15 @@ Public Class aaformOptionsWindow
         ' https://github.com/DrewNaylor/UXL-Launcher/issues/180
         MessageBox.Show(Me, "In version 3.4, the Drive location/""I installed Microsoft Office to this drive:"" and Bypass configured location options will switch tabs. See also https://github.com/DrewNaylor/UXL-Launcher/issues/180",
                         "Future Change Notice")
+    End Sub
+
+    Private Sub comboboxOfficeVersionSelector_SelectedIndexChanged(sender As Object, e As EventArgs) Handles comboboxOfficeVersionSelector.SelectedIndexChanged
+        If comboboxOfficeVersionSelector.SelectedIndex >= 3 Then
+            labelOfficeInstallMethodDescription.Hide()
+            checkboxO365InstallMethod.Hide()
+        Else
+            labelOfficeInstallMethodDescription.Show()
+            checkboxO365InstallMethod.Show()
+        End If
     End Sub
 End Class

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -63,9 +63,20 @@ Public Class aaformOptionsWindow
         End If
 #End Region
 
+#Region "Set the drive list dropdown to the available drives."
+        ' Clear the drive letter list.
+        comboboxDriveSelector.Items.Clear()
+
+        For Each DriveLetter As String In GetDriveLetters()
+            ' Get the drive letters of all active drives and remove the ":\".
+            comboboxDriveSelector.Items.Add(DriveLetter.Replace(":\", String.Empty))
+        Next
+#End Region
+
 #Region "Load the settings from My.Settings."
         ' Load the user's settings for My.Settings.officeDriveLocation when the Options window loads.
         textboxOfficeDrive.Text = My.Settings.officeDriveLocation
+        comboboxDriveSelector.Text = My.Settings.officeDriveLocation
 
         ' Load the user's settings for My.Settings.userHasOfficeThreeSixFive when the Options window loads.
         ' Simplified from original "If" statement.
@@ -157,17 +168,6 @@ Public Class aaformOptionsWindow
 #End Region
 #End Region
 #End Region
-
-#Region "Set the drive list dropdown to the available drives."
-        ' Clear the drive letter list.
-        comboboxDriveSelector.Items.Clear()
-
-        For Each DriveLetter As String In GetDriveLetters()
-            ' Get the drive letters of all active drives and remove the ":\".
-            comboboxDriveSelector.Items.Add(DriveLetter.Replace(":\", String.Empty))
-        Next
-#End Region
-
 
 #Region "Set the DataSource of the comboboxOfficeVersionSelector to a string."
         ' First, see if the user's Office version set in the config file

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -159,7 +159,9 @@ Public Class aaformOptionsWindow
 #End Region
 
 #Region "Set the drive list dropdown to the available drives."
-
+        For Each DriveLetter As String In GetDriveLetters()
+            comboboxDriveSelector.Items.Add(DriveLetter.Replace(":\", String.Empty))
+        Next
 #End Region
 
 
@@ -296,7 +298,7 @@ Public Class aaformOptionsWindow
 #End Region
 
 #Region "Get drive letters."
-    Private Function DriveLetters() As List(Of String)
+    Private Function GetDriveLetters() As List(Of String)
         ' Basing my code/copying off the answer for getting ready drives here:
         ' https://social.msdn.microsoft.com/Forums/vstudio/en-US/4605ebb2-fc2c-4166-9c42-9025c20eaa1e/populate-combo-box-with-drive-letters
         Dim DriveLettersList As New List(Of String)

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -52,14 +52,14 @@ Public Class aaformOptionsWindow
         If Environment.Is64BitOperatingSystem = True Then
             ' If the OS is 64-bit, recommend the user to click
             ' 64-bit Windows.
-            labelRecommendedWindowsEdition.Text = "64-bit Windows is the recommended option for you, but if" & vbCrLf &
-                "using Office 2013, you may need to select ""32-bit Windows""" & vbCrLf &
-                "due to the 32-bit version installing to ""Program Files""" & vbCrLf &
-                "even on 64-bit Windows. 64-bit Office (Office 2019's default)" & vbCrLf &
-                "requires ""32-bit Windows"" to be selected above."
+            labelRecommendedWindowsEdition.Text = "Your installation of Windows is 64-bit, so you'll probably want to" & vbCrLf &
+                "select ""Program Files"" if you're using any of the configurations listed for it." & vbCrLf &
+                "" & vbCrLf &
+                "If you're using 32-bit Office on 64-bit Windows, you'll need to select" & vbCrLf &
+                "the ""Program Files (x86)"" option."
         Else
             ' If the OS isn't 64-bit, recommend the 32-bit option.
-            labelRecommendedWindowsEdition.Text = "32-bit Windows is the recommended option for you."
+            labelRecommendedWindowsEdition.Text = "Your installation of Windows is 32-bit, so only ""Program Files"" can be used."
         End If
 #End Region
 

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -76,6 +76,15 @@ Public Class aaformOptionsWindow
 #Region "Load the settings from My.Settings."
         ' Load the user's settings for My.Settings.officeDriveLocation when the Options window loads.
         textboxOfficeDrive.Text = My.Settings.officeDriveLocation
+
+        ' If the drive the user wants to use isn't available in the dropdown,
+        ' add it to the dropdown.
+        If Not comboboxDriveSelector.Items.Contains(My.Settings.officeDriveLocation) Then
+            comboboxDriveSelector.Items.Add(My.Settings.officeDriveLocation)
+            comboboxDriveSelector.Sorted = True
+        End If
+
+        ' Select the drive letter in the drive letter dropdown box.
         comboboxDriveSelector.Text = My.Settings.officeDriveLocation
 
         ' Load the user's settings for My.Settings.userHasOfficeThreeSixFive when the Options window loads.

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -263,6 +263,7 @@ Public Class aaformOptionsWindow
     Private Sub buttonDefaultSettings_Click(sender As Object, e As EventArgs) Handles buttonDefaultSettings.Click
         ' Reset the "Office Install Drive" to drive C.
         textboxOfficeDrive.Text = "C"
+        comboboxDriveSelector.Text = "C"
 
         ' Reset the Office Version Selector to Office 2010.
         comboboxOfficeVersionSelector.Text = "Microsoft Office 2019"
@@ -370,7 +371,7 @@ Public Class aaformOptionsWindow
 
 #Region "Things to save to My.Settings."
             ' Set My.Settings.officeDriveLocation to the text in textboxOfficeDrive.
-            My.Settings.officeDriveLocation = textboxOfficeDrive.Text
+            My.Settings.officeDriveLocation = comboboxDriveSelector.Text
 
             ' My.Settings.userHasOfficeThreeSixFive will be set based on 
             ' the .Checked state of the checkboxO365InstallMethod.

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -160,6 +160,7 @@ Public Class aaformOptionsWindow
 
 #Region "Set the drive list dropdown to the available drives."
         For Each DriveLetter As String In GetDriveLetters()
+            ' Get the drive letters of all active drives and remove the ":\".
             comboboxDriveSelector.Items.Add(DriveLetter.Replace(":\", String.Empty))
         Next
 #End Region

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -81,6 +81,7 @@ Public Class aaformOptionsWindow
         ' add it to the dropdown.
         If Not comboboxDriveSelector.Items.Contains(My.Settings.officeDriveLocation) Then
             comboboxDriveSelector.Items.Add(My.Settings.officeDriveLocation)
+            ' Sort the list so it doesn't look bad.
             comboboxDriveSelector.Sorted = True
         End If
 

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -788,7 +788,7 @@ Public Class aaformOptionsWindow
 #End Region
 
     Private Sub comboboxOfficeVersionSelector_SelectedIndexChanged(sender As Object, e As EventArgs) Handles comboboxOfficeVersionSelector.SelectedIndexChanged
-        If comboboxOfficeVersionSelector.SelectedIndex >= 3 Then
+        If comboboxOfficeVersionSelector.SelectedIndex = 3 Then
             ' Office versions newer than 2016 don't support MSI
             ' and default to C2R, so this checkbox is not necessary.
             checkboxO365InstallMethod.Hide()

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -158,6 +158,10 @@ Public Class aaformOptionsWindow
 #End Region
 #End Region
 
+#Region "Set the drive list dropdown to the available drives."
+
+#End Region
+
 
 #Region "Set the DataSource of the comboboxOfficeVersionSelector to a string."
         ' First, see if the user's Office version set in the config file
@@ -289,6 +293,25 @@ Public Class aaformOptionsWindow
                         MessageBoxButtons.OK, MessageBoxIcon.Asterisk)
 
     End Sub
+#End Region
+
+#Region "Get drive letters."
+    Private Function DriveLetters() As List(Of String)
+        ' Basing my code/copying off the answer for getting ready drives here:
+        ' https://social.msdn.microsoft.com/Forums/vstudio/en-US/4605ebb2-fc2c-4166-9c42-9025c20eaa1e/populate-combo-box-with-drive-letters
+        Dim DriveLettersList As New List(Of String)
+
+        For Each Drive As System.IO.DriveInfo In IO.DriveInfo.GetDrives
+            ' Go through the list of drives and add their name
+            ' to the list if they're ready.
+            If Drive.IsReady = True Then
+                DriveLettersList.Add(Drive.Name)
+            End If
+        Next
+
+        ' Return the list.
+        Return DriveLettersList
+    End Function
 #End Region
 
 #Region "Code that runs when the user clicks the Save button."

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -243,7 +243,7 @@ Public Class aaformOptionsWindow
         ' Reset the Office 365 checkbox to unchecked.
         checkboxO365InstallMethod.Checked = False
 
-        ' Reset the CPUType radio buttons to 64-bit.
+        ' Reset the PFPath radio buttons to "Program Files".
         radiobuttonUseProgramFiles.Checked = True
 
         ' Reset the theme to use to Default.

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -64,9 +64,6 @@ Public Class aaformOptionsWindow
 #End Region
 
 #Region "Load the settings from My.Settings."
-        ' Load the user's settings for My.Settings.officeDriveLocation when the Options window loads.
-        textboxOfficeDrive.Text = My.Settings.officeDriveLocation
-
 #Region "Drive letters."
 #Region "Set drive letter dropdown to available drives."
         ' Clear the drive letter list.
@@ -235,34 +232,9 @@ Public Class aaformOptionsWindow
     End Sub
 #End Region
 
-
-
-#Region "Code that runs when the user types stuff in the textboxOfficeDrive."
-    Private Sub textboxOfficeDrive_KeyPress(sender As Object, e As KeyPressEventArgs) Handles textboxOfficeDrive.KeyPress
-        ' This sub is to make sure that people are only entering letters. Credit goes to this post on Stack Overflow
-        ' for this solution.  <http://stackoverflow.com/a/31161593>
-        ' 
-        If e.KeyChar <> vbBack And Char.IsLetter(e.KeyChar) = False Then
-
-            ' Display a message box when the user presses characters that aren't allowed.
-            e.Handled = True
-            MessageBox.Show("This textbox only accepts letters such as A, B, C etc." & vbCrLf &
-                            "You can clear the textbox by using the ""Clear"" button, or by pressing Delete or Backspace on your keyboard.",
-                            "Invalid input", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
-
-            ' Change the textbox for choosing the drive Office is installed on back to the user's current configuration.
-            textboxOfficeDrive.Text = My.Settings.officeDriveLocation
-            ' Focus and select the textbox.
-            textboxOfficeDrive.Focus()
-            textboxOfficeDrive.SelectAll()
-        End If
-    End Sub
-#End Region
-
 #Region "Code that runs when the user clicks the Defaults button."
     Private Sub buttonDefaultSettings_Click(sender As Object, e As EventArgs) Handles buttonDefaultSettings.Click
         ' Reset the "Office Install Drive" to drive C.
-        textboxOfficeDrive.Text = "C"
         comboboxDriveSelector.Text = "C"
 
         ' Reset the Office Version Selector to Office 2010.
@@ -348,30 +320,25 @@ Public Class aaformOptionsWindow
     Private Function saveStuff() As Integer
         ' Look at the length of the text in the "Office Install Drive" textbox and if there is no text in it then kindly tell the
         ' user they need to type in one drive letter.
-        If textboxOfficeDrive.Text.Length = 0 Then
-            MessageBox.Show("You must type one letter into the drive letter text box.", "Textbox length requirement not met", MessageBoxButtons.OK, MessageBoxIcon.Exclamation)
-            ' After telling them that, reset the "Office Install Drive" textbox to their current setting.
-            textboxOfficeDrive.Text = My.Settings.officeDriveLocation
-            ' Select the "General" tab.
-            ' This article helped me with selecting the tab:
-            ' https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.tabcontrol.selectedindex?view=netframework-4.6.1
-            tabcontrolOptionsWindow.SelectedIndex = 0
-            ' Set focus to the Office Drive Location textbox, and select all text in it.
-            textboxOfficeDrive.Focus()
-            textboxOfficeDrive.SelectAll()
-            ' Return 1, which means there's a problem.
-            ' When this happens, code that uses this function
-            ' will exit and not continue.
-            Return 1
-        Else
-            '
-            ' This space reserved for more settings.
-            '
-            '
+        'If SomeIssueHere Then
+
+        ' Return 1, which means there's a problem.
+        ' When this happens, code that uses this function
+        ' will exit and not continue.
+
+        ' This if...else statement will only be used if there's
+        ' something that would use it, but at the moment, it is
+        ' considered... irrelevant.
+        'Return 1
+        'Else
+        '
+        ' This space reserved for more settings.
+        '
+        '
 
 #Region "Things to save to My.Settings."
-            ' Set My.Settings.officeDriveLocation to the text in textboxOfficeDrive.
-            My.Settings.officeDriveLocation = comboboxDriveSelector.Text
+        ' Set My.Settings.officeDriveLocation to the text in textboxOfficeDrive.
+        My.Settings.officeDriveLocation = comboboxDriveSelector.Text
 
             ' My.Settings.userHasOfficeThreeSixFive will be set based on 
             ' the .Checked state of the checkboxO365InstallMethod.
@@ -479,7 +446,7 @@ Public Class aaformOptionsWindow
             ' Fortunately, this was just to save
             ' settings, rather than the entire world.
             Return 0
-        End If
+        'End If
     End Function
 #End Region
 
@@ -488,14 +455,6 @@ Public Class aaformOptionsWindow
         ' Cancel out of the Options window and reload the user's settings
         My.Settings.Reload()
         Me.Close()
-    End Sub
-#End Region
-
-#Region "Code that runs when the user clicks the Clear Textbox button next to the Office drive location."
-    Private Sub buttonClearTextbox_Click(sender As Object, e As EventArgs) Handles buttonClearDriveLetter.Click
-        ' Clear the OfficeDrive textbox and set focus to it.
-        textboxOfficeDrive.Text = ""
-        textboxOfficeDrive.Select()
     End Sub
 #End Region
 

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -63,7 +63,12 @@ Public Class aaformOptionsWindow
         End If
 #End Region
 
-#Region "Set the drive list dropdown to the available drives."
+#Region "Load the settings from My.Settings."
+        ' Load the user's settings for My.Settings.officeDriveLocation when the Options window loads.
+        textboxOfficeDrive.Text = My.Settings.officeDriveLocation
+
+#Region "Drive letters."
+#Region "Set drive letter dropdown to available drives."
         ' Clear the drive letter list.
         comboboxDriveSelector.Items.Clear()
 
@@ -72,11 +77,7 @@ Public Class aaformOptionsWindow
             comboboxDriveSelector.Items.Add(DriveLetter.Replace(":\", String.Empty))
         Next
 #End Region
-
-#Region "Load the settings from My.Settings."
-        ' Load the user's settings for My.Settings.officeDriveLocation when the Options window loads.
-        textboxOfficeDrive.Text = My.Settings.officeDriveLocation
-
+#Region "Set drive letters in the dropdown."
         ' If the drive the user wants to use isn't available in the dropdown,
         ' add it to the dropdown.
         If Not comboboxDriveSelector.Items.Contains(My.Settings.officeDriveLocation) Then
@@ -87,6 +88,8 @@ Public Class aaformOptionsWindow
 
         ' Select the drive letter in the drive letter dropdown box.
         comboboxDriveSelector.Text = My.Settings.officeDriveLocation
+#End Region
+#End Region
 
         ' Load the user's settings for My.Settings.userHasOfficeThreeSixFive when the Options window loads.
         ' Simplified from original "If" statement.

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -340,112 +340,112 @@ Public Class aaformOptionsWindow
         ' Set My.Settings.officeDriveLocation to the text in textboxOfficeDrive.
         My.Settings.officeDriveLocation = comboboxDriveSelector.Text
 
-            ' My.Settings.userHasOfficeThreeSixFive will be set based on 
-            ' the .Checked state of the checkboxO365InstallMethod.
-            ' Simplified from original "If" statement.
-            My.Settings.userHasOfficeThreeSixFive = checkboxO365InstallMethod.Checked
+        ' My.Settings.userHasOfficeThreeSixFive will be set based on 
+        ' the .Checked state of the checkboxO365InstallMethod.
+        ' Simplified from original "If" statement.
+        My.Settings.userHasOfficeThreeSixFive = checkboxO365InstallMethod.Checked
 
-            ' Set My.Settings.userOfficeVersion to a string based on whatever
-            ' comboboxOfficeVersionSelector.Text is set to.
-            If comboboxOfficeVersionSelector.Text = "Microsoft Office 2010" Then
-                My.Settings.userOfficeVersion = "14"
-            ElseIf comboboxOfficeVersionSelector.Text = "Microsoft Office 2013" Then
-                My.Settings.userOfficeVersion = "15"
-            ElseIf comboboxOfficeVersionSelector.Text = "Microsoft Office 2016" Then
-                My.Settings.userOfficeVersion = "16"
-            ElseIf comboboxOfficeVersionSelector.Text = "Microsoft Office 2019" Then
-                My.Settings.userOfficeVersion = "16nomsi"
-            Else
-                ' If none of the above Office versions are listed in the dropdown
-                ' box, just save the current My.Settings.userOfficeVersion to
-                ' itself.
-                My.Settings.userOfficeVersion = My.Settings.userOfficeVersion
-            End If
+        ' Set My.Settings.userOfficeVersion to a string based on whatever
+        ' comboboxOfficeVersionSelector.Text is set to.
+        If comboboxOfficeVersionSelector.Text = "Microsoft Office 2010" Then
+            My.Settings.userOfficeVersion = "14"
+        ElseIf comboboxOfficeVersionSelector.Text = "Microsoft Office 2013" Then
+            My.Settings.userOfficeVersion = "15"
+        ElseIf comboboxOfficeVersionSelector.Text = "Microsoft Office 2016" Then
+            My.Settings.userOfficeVersion = "16"
+        ElseIf comboboxOfficeVersionSelector.Text = "Microsoft Office 2019" Then
+            My.Settings.userOfficeVersion = "16nomsi"
+        Else
+            ' If none of the above Office versions are listed in the dropdown
+            ' box, just save the current My.Settings.userOfficeVersion to
+            ' itself.
+            My.Settings.userOfficeVersion = My.Settings.userOfficeVersion
+        End If
 
-            ' Set My.Settings.cpuIsSixtyFourBit to True or False depending on the radio buttons.
-            If radiobuttonUseProgramFiles.Checked = True Then
-                My.Settings.cpuIsSixtyFourBit = False
-            ElseIf radiobuttonUseProgramFilesX86.Checked = True Then
-                My.Settings.cpuIsSixtyFourBit = True
-            ElseIf radiobuttonCPUIsQBit.Checked = True Then
-                ' Focus the "Advanced" tab.
-                tabcontrolOptionsWindow.SelectedIndex = 1
-                MessageBox.Show("Why do you have a quantum CPU?" & vbCrLf & "(Your currently saved settings will be re-applied because Qubits don't exist for consumers yet.)" & vbCrLf & "(Thank you for finding this hidden radio button!)", "Qubits don't exist for consumers yet.", MessageBoxButtons.OK,
+        ' Set My.Settings.cpuIsSixtyFourBit to True or False depending on the radio buttons.
+        If radiobuttonUseProgramFiles.Checked = True Then
+            My.Settings.cpuIsSixtyFourBit = False
+        ElseIf radiobuttonUseProgramFilesX86.Checked = True Then
+            My.Settings.cpuIsSixtyFourBit = True
+        ElseIf radiobuttonCPUIsQBit.Checked = True Then
+            ' Focus the "Advanced" tab.
+            tabcontrolOptionsWindow.SelectedIndex = 1
+            MessageBox.Show("Why do you have a quantum CPU?" & vbCrLf & "(Your currently saved settings will be re-applied because Qubits don't exist for consumers yet.)" & vbCrLf & "(Thank you for finding this hidden radio button!)", "Qubits don't exist for consumers yet.", MessageBoxButtons.OK,
                                 MessageBoxIcon.Error)
-                ' Now set the radio buttons to current user settings.
-                If My.Settings.cpuIsSixtyFourBit = True Then
-                    radiobuttonUseProgramFilesX86.Checked = True
-                    My.Settings.cpuIsSixtyFourBit = True
-                ElseIf My.Settings.cpuIsSixtyFourBit = False Then
-                    radiobuttonUseProgramFiles.Checked = True
-                    My.Settings.cpuIsSixtyFourBit = False
-                End If
+            ' Now set the radio buttons to current user settings.
+            If My.Settings.cpuIsSixtyFourBit = True Then
+                radiobuttonUseProgramFilesX86.Checked = True
+                My.Settings.cpuIsSixtyFourBit = True
+            ElseIf My.Settings.cpuIsSixtyFourBit = False Then
+                radiobuttonUseProgramFiles.Checked = True
+                My.Settings.cpuIsSixtyFourBit = False
             End If
+        End If
 
-            ' Set My.Settings.enableThemeEngine to True or False based on the checkbox.
-            ' Simplified from original "If" statement.
-            My.Settings.enableThemeEngine = checkboxEnableThemeEngine.Checked
+        ' Set My.Settings.enableThemeEngine to True or False based on the checkbox.
+        ' Simplified from original "If" statement.
+        My.Settings.enableThemeEngine = checkboxEnableThemeEngine.Checked
 
-            ' Set My.Settings.matchWindows10ThemeSettings to True or False based on the checkbox.
-            My.Settings.matchWindows10ThemeSettings = checkboxMatchWindows10ThemeSettings.Checked
+        ' Set My.Settings.matchWindows10ThemeSettings to True or False based on the checkbox.
+        My.Settings.matchWindows10ThemeSettings = checkboxMatchWindows10ThemeSettings.Checked
 
-            ' Set My.Settings.userChosenTheme to the text in the theme list dropdown box.
-            My.Settings.userChosenTheme = comboboxThemeList.Text
+        ' Set My.Settings.userChosenTheme to the text in the theme list dropdown box.
+        My.Settings.userChosenTheme = comboboxThemeList.Text
 
-            ' Set My.Settings.userCustomThemePath to the custom theme path textbox.
-            My.Settings.userCustomThemePath = textboxCustomThemePath.Text
+        ' Set My.Settings.userCustomThemePath to the custom theme path textbox.
+        My.Settings.userCustomThemePath = textboxCustomThemePath.Text
 
-            ' Set My.Settings.userUseCustomStatusbarGreeting to True or False based
-            ' on which radio button is selected.
-            If radiobuttonDefaultStatusbarGreeting.Checked = True Then
-                My.Settings.userUseCustomStatusbarGreeting = False
-            ElseIf radiobuttonCustomStatusbarGreeting.Checked = True Then
-                My.Settings.userUseCustomStatusbarGreeting = True
-            End If
+        ' Set My.Settings.userUseCustomStatusbarGreeting to True or False based
+        ' on which radio button is selected.
+        If radiobuttonDefaultStatusbarGreeting.Checked = True Then
+            My.Settings.userUseCustomStatusbarGreeting = False
+        ElseIf radiobuttonCustomStatusbarGreeting.Checked = True Then
+            My.Settings.userUseCustomStatusbarGreeting = True
+        End If
 
-            ' Set the My.Settings value for the user's firstname/nickname
-            ' for personalized statusbar greetings to the textbox
-            ' for the name.
-            My.Settings.userFirstNameForCustomStatusbarGreeting = textboxFirstname.Text
+        ' Set the My.Settings value for the user's firstname/nickname
+        ' for personalized statusbar greetings to the textbox
+        ' for the name.
+        My.Settings.userFirstNameForCustomStatusbarGreeting = textboxFirstname.Text
 
-            ' Save the status of whether to bypass the configured location for
-            ' deprecated or removed apps, or all compatible apps.
-            My.Settings.bypassConfiguredLocationForDeprecatedApps = radiobuttonBypassConfiguredLocationDeprecatedApps.Checked
-            My.Settings.bypassConfiguredLocationForAllApps = radiobuttonBypassConfiguredLocationAllApps.Checked
+        ' Save the status of whether to bypass the configured location for
+        ' deprecated or removed apps, or all compatible apps.
+        My.Settings.bypassConfiguredLocationForDeprecatedApps = radiobuttonBypassConfiguredLocationDeprecatedApps.Checked
+        My.Settings.bypassConfiguredLocationForAllApps = radiobuttonBypassConfiguredLocationAllApps.Checked
 
 #End Region
 
 #Region "This is where the settings get saved and things update."
-            ' Save settings.
-            My.Settings.Save()
-            My.Settings.Reload()
-            ' Update the user's theme if the theme engine is enabled
-            ' and the boolean variable set at the beginning of this
-            ' class is set to True.
-            If My.Settings.enableThemeEngine = True And boolIsThemeEngineEnabled = True Then
+        ' Save settings.
+        My.Settings.Save()
+        My.Settings.Reload()
+        ' Update the user's theme if the theme engine is enabled
+        ' and the boolean variable set at the beginning of this
+        ' class is set to True.
+        If My.Settings.enableThemeEngine = True And boolIsThemeEngineEnabled = True Then
 
-                ' If the user wants to match the Windows 10 theme, then do so,
-                ' but if not, then the user's chosen theme will be used instead.
-                ' Code moved to its own sub to make editing easier.
-                WindowsThemeSettings.checkIfUserWantsToMatchTheme()
+            ' If the user wants to match the Windows 10 theme, then do so,
+            ' but if not, then the user's chosen theme will be used instead.
+            ' Code moved to its own sub to make editing easier.
+            WindowsThemeSettings.checkIfUserWantsToMatchTheme()
 
-            End If
-            ' Update the fullLauncherCodeString.
-            OfficeLocater.combineStrings()
-            ' Update the text in the main window's titlebar.
-            aaformMainWindow.updateTitlebarText()
-            ' Update main window statusbar label text.
-            aaformMainWindow.updateStatusbarText()
-            ' Tell the user that settings were saved.
-            MessageBox.Show("Settings saved." & vbCrLf &
+        End If
+        ' Update the fullLauncherCodeString.
+        OfficeLocater.combineStrings()
+        ' Update the text in the main window's titlebar.
+        aaformMainWindow.updateTitlebarText()
+        ' Update main window statusbar label text.
+        aaformMainWindow.updateStatusbarText()
+        ' Tell the user that settings were saved.
+        MessageBox.Show("Settings saved." & vbCrLf &
                         "Some settings may require a restart of UXL Launcher, such as enabling or disabling the theme engine.", "Save settings", MessageBoxButtons.OK, MessageBoxIcon.Asterisk)
 #End Region
 
-            ' Saving was successful.
-            ' Return 0.
-            ' Fortunately, this was just to save
-            ' settings, rather than the entire world.
-            Return 0
+        ' Saving was successful.
+        ' Return 0.
+        ' Fortunately, this was just to save
+        ' settings, rather than the entire world.
+        Return 0
         'End If
     End Function
 #End Region

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -89,7 +89,7 @@ Public Class OfficeLocater
             ' This is mostly for Office 2019, but will help for future Office versions that have a different version
             ' folder, such as "Office17".
             fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & pfPathString & "\Microsoft Office\root\Office" &
-                My.Settings.userOfficeVersion.Replace("nomsi", "") & "\"
+                My.Settings.userOfficeVersion.Replace("nomsi", String.Empty) & "\"
         End If
 
 

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -37,9 +37,9 @@ Public Class OfficeLocater
     Public Shared fullLauncherCodeString As String
 
 
-#Region "pfPathString and cpuType sub."
+#Region "pfPathString and pfPath sub."
     ' The cpuType sub is used to give pfPathString data.
-    Public Shared Sub cpuType()
+    Public Shared Sub pfPath()
 
         ' This code looks at My.Settings.pathUsePFxEightySix and if it's set to True, pfPathString is set to " (x86)".
         'However, if My.Settings.pathUsePFxEightySix is set to False, pfPathString is assigned an empty value.
@@ -61,7 +61,7 @@ Public Class OfficeLocater
         ' What this does is take all the other strings above and put them into one string along with the "Program Files"
         ' and "Microsoft Office" directories.
         ' First we need to run the other subs.
-        cpuType()
+        pfPath()
 
         ' Then we need to combine them. First up is the user installed via Office 365/Click-to-Run
         ' and the user doesn't have Office 2013.

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -51,7 +51,7 @@ Public Class OfficeLocater
             cpuTypeString = cpuTypePrivateString
             titlebarBitModeString = "PF-x86"
         ElseIf My.Settings.cpuIsSixtyFourBit = False Then
-            cpuTypePrivateString = ""
+            cpuTypePrivateString = String.Empty
             cpuTypeString = cpuTypePrivateString
             titlebarBitModeString = "PF"
         End If

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -29,27 +29,27 @@
 Public Class OfficeLocater
 #Region "This code is for figuring out where Office should be launched from based on My.Settings."
 
-    ' Create a public, shared string called cpuTypeString. This string is used in the app launch code when the user clicks the buttons.
-    Public Shared cpuTypeString As String
-    ' Create a public, shared string called titlebarBitMode which is used to show whether or not the app is in "64-bit Mode" or "32-bit Mode."
-    Public Shared titlebarBitModeString As String
+    ' Create a public, shared string called pfPathString. This string is used in the app launch code when the user clicks the buttons.
+    Public Shared pfPathString As String
+    ' Create a public, shared string called titlebarProgramFilesModeString which is used to show whether or not the app is in "PF Mode" or "PF-x86 Mode".
+    Public Shared titlebarProgramFilesModeString As String
     ' Create a public, shared string called fullLauncherCodeString which is used to combine all the other launcher code strings into one that's much shorter.
     Public Shared fullLauncherCodeString As String
 
 
-#Region "cpuTypeString and cpuType sub."
-    ' The cpuType sub is used to give cpuTypeString data.
+#Region "pfPathString and cpuType sub."
+    ' The cpuType sub is used to give pfPathString data.
     Public Shared Sub cpuType()
 
-        ' This code looks at My.Settings.cpuIsSixtyFourBit and if it's set to True, userCPUType contains " (x86)" and cpuTypeString is set
+        ' This code looks at My.Settings.pathUsePFxEightySix and if it's set to True, userCPUType contains " (x86)" and pfPathString is set
         ' to the value of userCPUType to work around the inability to create and assign a value to a Public Shared string.
-        'However, if My.Settings.cpuIsSixtyFourBit is set to False, userCPUType is assigned an empty value and so is cpuTypeString.
+        'However, if My.Settings.cpuIsSixtyFourBit is set to False, userCPUType is assigned an empty value and so is pfPathString.
         If My.Settings.pathUsePFxEightySix = True Then
-            cpuTypeString = " (x86)"
-            titlebarBitModeString = "PF-x86"
+            pfPathString = " (x86)"
+            titlebarProgramFilesModeString = "PF-x86"
         ElseIf My.Settings.pathUsePFxEightySix = False Then
-            cpuTypeString = String.Empty
-            titlebarBitModeString = "PF"
+            pfPathString = String.Empty
+            titlebarProgramFilesModeString = "PF"
         End If
     End Sub
 #End Region
@@ -67,19 +67,19 @@ Public Class OfficeLocater
         ' Then we need to combine them. First up is the user installed via Office 365/Click-to-Run
         ' and the user doesn't have Office 2013.
         If My.Settings.userHasOfficeThreeSixFive = True And Not My.Settings.userOfficeVersion = "15" And Not My.Settings.userOfficeVersion.Contains("nomsi") Then
-            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\root\Office" &
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & pfPathString & "\Microsoft Office\root\Office" &
                 My.Settings.userOfficeVersion & "\"
 
             ' If the user installed specifically Office 2013 and they used Office 365/Click-to-Run, then we have a special 
             ' string for that install method.
         ElseIf My.Settings.userOfficeVersion = "15" And My.Settings.userHasOfficeThreeSixFive = True Then
-            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office 15\root\Office15\"
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & pfPathString & "\Microsoft Office 15\root\Office15\"
 
             ' Otherwise, if the user doesn't have Office 365, then create a different string. This string doesn't
             ' rely on the version of Office that's used; just if it's not installed via Office 365/C2R.
             ' Also make sure that "nomsi" isn't in the Office version string.
         ElseIf My.Settings.userHasOfficeThreeSixFive = False And Not My.Settings.userOfficeVersion.Contains("nomsi") Then
-            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\Office" &
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & pfPathString & "\Microsoft Office\Office" &
                 My.Settings.userOfficeVersion & "\"
 
             ' Office 2019 installs to the same folder as Office 2016, but doesn't have MSI installer support, so ignore the
@@ -89,7 +89,7 @@ Public Class OfficeLocater
             ' the "Office(number)" path takes the version and replaces "nomsi" with nothing ("")
             ' This is mostly for Office 2019, but will help for future Office versions that have a different version
             ' folder, such as "Office17".
-            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\root\Office" &
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & pfPathString & "\Microsoft Office\root\Office" &
                 My.Settings.userOfficeVersion.Replace("nomsi", "") & "\"
         End If
 

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -49,11 +49,11 @@ Public Class OfficeLocater
         If My.Settings.cpuIsSixtyFourBit = True Then
             cpuTypePrivateString = " (x86)"
             cpuTypeString = cpuTypePrivateString
-            titlebarBitModeString = "64-bit"
+            titlebarBitModeString = "PF-x86"
         ElseIf My.Settings.cpuIsSixtyFourBit = False Then
             cpuTypePrivateString = ""
             cpuTypeString = cpuTypePrivateString
-            titlebarBitModeString = "32-bit"
+            titlebarBitModeString = "PF"
         End If
     End Sub
 #End Region

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -44,10 +44,10 @@ Public Class OfficeLocater
         ' This code looks at My.Settings.cpuIsSixtyFourBit and if it's set to True, userCPUType contains " (x86)" and cpuTypeString is set
         ' to the value of userCPUType to work around the inability to create and assign a value to a Public Shared string.
         'However, if My.Settings.cpuIsSixtyFourBit is set to False, userCPUType is assigned an empty value and so is cpuTypeString.
-        If My.Settings.cpuIsSixtyFourBit = True Then
+        If My.Settings.pathUsePFxEightySix = True Then
             cpuTypeString = " (x86)"
             titlebarBitModeString = "PF-x86"
-        ElseIf My.Settings.cpuIsSixtyFourBit = False Then
+        ElseIf My.Settings.pathUsePFxEightySix = False Then
             cpuTypeString = String.Empty
             titlebarBitModeString = "PF"
         End If

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -41,9 +41,8 @@ Public Class OfficeLocater
     ' The cpuType sub is used to give pfPathString data.
     Public Shared Sub cpuType()
 
-        ' This code looks at My.Settings.pathUsePFxEightySix and if it's set to True, userCPUType contains " (x86)" and pfPathString is set
-        ' to the value of userCPUType to work around the inability to create and assign a value to a Public Shared string.
-        'However, if My.Settings.cpuIsSixtyFourBit is set to False, userCPUType is assigned an empty value and so is pfPathString.
+        ' This code looks at My.Settings.pathUsePFxEightySix and if it's set to True, pfPathString is set to " (x86)".
+        'However, if My.Settings.pathUsePFxEightySix is set to False, pfPathString is assigned an empty value.
         If My.Settings.pathUsePFxEightySix = True Then
             pfPathString = " (x86)"
             titlebarProgramFilesModeString = "PF-x86"

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -38,7 +38,7 @@ Public Class OfficeLocater
 
 
 #Region "pfPathString and pfPath sub."
-    ' The cpuType sub is used to give pfPathString data.
+    ' The pfPath sub is used to give pfPathString data.
     Public Shared Sub pfPath()
 
         ' This code looks at My.Settings.pathUsePFxEightySix and if it's set to True, pfPathString is set to " (x86)".

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -40,19 +40,15 @@ Public Class OfficeLocater
 #Region "cpuTypeString and cpuType sub."
     ' The cpuType sub is used to give cpuTypeString data.
     Public Shared Sub cpuType()
-        ' Create a string called userCPUType which is only used in this sub.
-        Dim cpuTypePrivateString As String
 
         ' This code looks at My.Settings.cpuIsSixtyFourBit and if it's set to True, userCPUType contains " (x86)" and cpuTypeString is set
         ' to the value of userCPUType to work around the inability to create and assign a value to a Public Shared string.
         'However, if My.Settings.cpuIsSixtyFourBit is set to False, userCPUType is assigned an empty value and so is cpuTypeString.
         If My.Settings.cpuIsSixtyFourBit = True Then
-            cpuTypePrivateString = " (x86)"
-            cpuTypeString = cpuTypePrivateString
+            cpuTypeString = " (x86)"
             titlebarBitModeString = "PF-x86"
         ElseIf My.Settings.cpuIsSixtyFourBit = False Then
-            cpuTypePrivateString = String.Empty
-            cpuTypeString = cpuTypePrivateString
+            cpuTypeString = String.Empty
             titlebarBitModeString = "PF"
         End If
     End Sub

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -58,8 +58,6 @@ Public Class OfficeLocater
 #Region "This code combines all the launcher strings into one string to make modification easier."
     ' With this sub I'll be able to shorten the length of the button_click event strings for the launcher buttons.
     Public Shared Sub combineStrings()
-        ' This string is only used in this sub.
-        Dim fullLauncherCodePrivateString As String
 
         ' What this does is take all the other strings above and put them into one string along with the "Program Files"
         ' and "Microsoft Office" directories.
@@ -69,25 +67,20 @@ Public Class OfficeLocater
         ' Then we need to combine them. First up is the user installed via Office 365/Click-to-Run
         ' and the user doesn't have Office 2013.
         If My.Settings.userHasOfficeThreeSixFive = True And Not My.Settings.userOfficeVersion = "15" And Not My.Settings.userOfficeVersion.Contains("nomsi") Then
-            fullLauncherCodePrivateString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\root\Office" &
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\root\Office" &
                 My.Settings.userOfficeVersion & "\"
-            ' Make the public string equal to the private string.
-            fullLauncherCodeString = fullLauncherCodePrivateString
 
             ' If the user installed specifically Office 2013 and they used Office 365/Click-to-Run, then we have a special 
             ' string for that install method.
         ElseIf My.Settings.userOfficeVersion = "15" And My.Settings.userHasOfficeThreeSixFive = True Then
-            fullLauncherCodePrivateString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office 15\root\Office15\"
-            fullLauncherCodeString = fullLauncherCodePrivateString
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office 15\root\Office15\"
 
             ' Otherwise, if the user doesn't have Office 365, then create a different string. This string doesn't
             ' rely on the version of Office that's used; just if it's not installed via Office 365/C2R.
             ' Also make sure that "nomsi" isn't in the Office version string.
         ElseIf My.Settings.userHasOfficeThreeSixFive = False And Not My.Settings.userOfficeVersion.Contains("nomsi") Then
-            fullLauncherCodePrivateString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\Office" &
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\Office" &
                 My.Settings.userOfficeVersion & "\"
-            ' Make the public string equal to the private string.
-            fullLauncherCodeString = fullLauncherCodePrivateString
 
             ' Office 2019 installs to the same folder as Office 2016, but doesn't have MSI installer support, so ignore the
             ' setting for My.Settings.userHasOfficeThreeSixFive.
@@ -96,10 +89,8 @@ Public Class OfficeLocater
             ' the "Office(number)" path takes the version and replaces "nomsi" with nothing ("")
             ' This is mostly for Office 2019, but will help for future Office versions that have a different version
             ' folder, such as "Office17".
-            fullLauncherCodePrivateString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\root\Office" &
+            fullLauncherCodeString = My.Settings.officeDriveLocation & ":\Program Files" & cpuTypeString & "\Microsoft Office\root\Office" &
                 My.Settings.userOfficeVersion.Replace("nomsi", "") & "\"
-            ' Set the public string to the private string.
-            fullLauncherCodeString = fullLauncherCodePrivateString
         End If
 
 

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -42,7 +42,7 @@ Public Class OfficeLocater
     Public Shared Sub pfPath()
 
         ' This code looks at My.Settings.pathUsePFxEightySix and if it's set to True, pfPathString is set to " (x86)".
-        'However, if My.Settings.pathUsePFxEightySix is set to False, pfPathString is assigned an empty value.
+        ' However, if My.Settings.pathUsePFxEightySix is set to False, pfPathString is assigned an empty value.
         If My.Settings.pathUsePFxEightySix = True Then
             pfPathString = " (x86)"
             titlebarProgramFilesModeString = "PF-x86"

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -58,8 +58,8 @@ Public Class debugmodeStuff
 
         ' Debug label for officeDriveLocation.
         aaformDebugLabels.debugLabelForofficeDriveLocation.Text = "officeDriveLocation: " & My.Settings.officeDriveLocation
-        ' Debug label for cpuTypeString.
-        aaformDebugLabels.debugLabelForcpuTypeString.Text = "cpuTypeString: " & OfficeLocater.cpuTypeString
+        ' Debug label for pfPathString.
+        aaformDebugLabels.debugLabelForcpuTypeString.Text = "pfPathString: " & OfficeLocater.pfPathString
 
         ' Debug label for officeInstallMethodString depending on the value of userHasOfficeThreeSixFive.
         If My.Settings.userHasOfficeThreeSixFive = True Then

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -59,7 +59,7 @@ Public Class debugmodeStuff
         ' Debug label for officeDriveLocation.
         aaformDebugLabels.debugLabelForofficeDriveLocation.Text = "officeDriveLocation: " & My.Settings.officeDriveLocation
         ' Debug label for pfPathString.
-        aaformDebugLabels.debugLabelForcpuTypeString.Text = "pfPathString: " & OfficeLocater.pfPathString
+        aaformDebugLabels.debugLabelForpfPathString.Text = "pfPathString: " & OfficeLocater.pfPathString
 
         ' Debug label for officeInstallMethodString depending on the value of userHasOfficeThreeSixFive.
         If My.Settings.userHasOfficeThreeSixFive = True Then


### PR DESCRIPTION
Many controls in the Options window have had their text changed, and in one case, their functionality completely replaced.

Fixes #183. Fixes #184. Fixes #73.

Changed:
- Switched the tabs for `Bypass configured location` and the Office drive location (now simply `Root drive path`)
- Instead of requiring users to type in the drive letter they installed Office to, they can now select it from a dropdown of all drives that are "ready". If they change the drive letter manually in the config file, it'll show up in the list, but changing it to something else and saving settings will get rid of it. Please be aware that this means arbitrary drive letters can no longer be placed into the drive letter box as only drives Windows determines as "ready" are available. This is what was originally intended, so it's no big loss.
- Controls and groupboxes have been resized and repositioned so they look better.
- Now the `Enable Office 365/Click-to-Run Compatibility` checkbox is hidden if Office 2019 is selected, since it's irrelevant for that version.
- Tab text update:
  - `General` has been renamed to `Versions + Compatibility`
  - `Advanced` has been renamed to `Root Path`
- `Enable Office 365/Click-to-Run Compatibility` checkbox has been changed to `Enable Office 365/Click-to-Run Compatibility [line break]
 (Always enabled for Office 2019 and above)`
- Since 64-bit Office is the default for Office 2019 when downloaded from the Office website, there were changes in the `Root Path` tab:
  - `64-bit Windows` is now `Program Files (x86): 32-bit Office on 64-bit Windows`
  - `32-bit Windows` is now `Program Files: 64-bit Office on 64-bit Windows, [line break]
32-bit Office on 32-bit Windows, or 32-bit Office 2013 from Office 365`
  - `Program Files...` is the new default, since 64-bit Office is now the default download as mentioned above.
  - The description and recommended selection labels have been updated to accommodate this change.
- `My.Settings.cpuIsSixtyFourBit` has been changed to `My.Settings.pathUsePFxEightySix` to reflect what it's really for. For those upgrading from an older version, there will be a thing that migrates this specific setting to the new setting. See #189.
- Instead of using `32-bit Mode` or `64-bit Mode` in the titlebar, we'll now display `PF Mode` or `PF-x86 Mode` since that's more accurate to what's going on.
- Settings defaults changes:
  - Default Office version has been changed to Office 2019/`16nomsi`
  - Default Program Files path setting has been changed to Program Files/`My.Settings.pathUsePFxEightySix = False`
- The strings with "private" in their names that were used in the Office Locater code have been removed and the public strings are being modified instead. This'll help optimize things.

Removed:
- Deleted the future change notice code since it's implemented now.