### PR TITLE
Allowing dark theme for system theme matching to be changed.

### DIFF
--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -45,8 +45,8 @@ Partial Class aaformThemeLoader
         Me.radiobuttonLoadFromXml = New System.Windows.Forms.RadioButton()
         Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
         Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
-        Me.RadioButton1 = New System.Windows.Forms.RadioButton()
-        Me.CheckBox1 = New System.Windows.Forms.CheckBox()
+        Me.radiobuttonMatchSystemTheme = New System.Windows.Forms.RadioButton()
+        Me.checkboxOverrideDefaultDarkTheme = New System.Windows.Forms.CheckBox()
         Me.StatusStrip1.SuspendLayout()
         Me.Panel1.SuspendLayout()
         Me.groupboxContextMenuArea.SuspendLayout()
@@ -149,8 +149,8 @@ Partial Class aaformThemeLoader
         '
         'Panel1
         '
-        Me.Panel1.Controls.Add(Me.CheckBox1)
-        Me.Panel1.Controls.Add(Me.RadioButton1)
+        Me.Panel1.Controls.Add(Me.checkboxOverrideDefaultDarkTheme)
+        Me.Panel1.Controls.Add(Me.radiobuttonMatchSystemTheme)
         Me.Panel1.Controls.Add(Me.groupboxContextMenuArea)
         Me.Panel1.Controls.Add(Me.radiobuttonSelectFromThemeEngine)
         Me.Panel1.Controls.Add(Me.radiobuttonLoadFromXml)
@@ -286,27 +286,27 @@ Partial Class aaformThemeLoader
         Me.checkboxAllowCustomThemes.Text = "Allow custom themes"
         Me.checkboxAllowCustomThemes.UseVisualStyleBackColor = True
         '
-        'RadioButton1
+        'radiobuttonMatchSystemTheme
         '
-        Me.RadioButton1.AutoSize = True
-        Me.RadioButton1.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.RadioButton1.Location = New System.Drawing.Point(186, 148)
-        Me.RadioButton1.Name = "RadioButton1"
-        Me.RadioButton1.Size = New System.Drawing.Size(149, 30)
-        Me.RadioButton1.TabIndex = 10
-        Me.RadioButton1.TabStop = True
-        Me.RadioButton1.Text = "Match Windows 10 theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "settings"
-        Me.RadioButton1.UseVisualStyleBackColor = True
+        Me.radiobuttonMatchSystemTheme.AutoSize = True
+        Me.radiobuttonMatchSystemTheme.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.radiobuttonMatchSystemTheme.Location = New System.Drawing.Point(186, 147)
+        Me.radiobuttonMatchSystemTheme.Name = "radiobuttonMatchSystemTheme"
+        Me.radiobuttonMatchSystemTheme.Size = New System.Drawing.Size(149, 30)
+        Me.radiobuttonMatchSystemTheme.TabIndex = 10
+        Me.radiobuttonMatchSystemTheme.TabStop = True
+        Me.radiobuttonMatchSystemTheme.Text = "Match Windows 10 theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "settings"
+        Me.radiobuttonMatchSystemTheme.UseVisualStyleBackColor = True
         '
-        'CheckBox1
+        'checkboxOverrideDefaultDarkTheme
         '
-        Me.CheckBox1.AutoSize = True
-        Me.CheckBox1.Location = New System.Drawing.Point(202, 184)
-        Me.CheckBox1.Name = "CheckBox1"
-        Me.CheckBox1.Size = New System.Drawing.Size(157, 17)
-        Me.CheckBox1.TabIndex = 11
-        Me.CheckBox1.Text = "Override default dark theme"
-        Me.CheckBox1.UseVisualStyleBackColor = True
+        Me.checkboxOverrideDefaultDarkTheme.AutoSize = True
+        Me.checkboxOverrideDefaultDarkTheme.Location = New System.Drawing.Point(202, 184)
+        Me.checkboxOverrideDefaultDarkTheme.Name = "checkboxOverrideDefaultDarkTheme"
+        Me.checkboxOverrideDefaultDarkTheme.Size = New System.Drawing.Size(157, 17)
+        Me.checkboxOverrideDefaultDarkTheme.TabIndex = 11
+        Me.checkboxOverrideDefaultDarkTheme.Text = "Override default dark theme"
+        Me.checkboxOverrideDefaultDarkTheme.UseVisualStyleBackColor = True
         '
         'aaformThemeLoader
         '
@@ -353,6 +353,6 @@ Partial Class aaformThemeLoader
     Friend WithEvents ToolStripMenuItem2 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem3 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem4 As ToolStripMenuItem
-    Friend WithEvents RadioButton1 As RadioButton
-    Friend WithEvents CheckBox1 As CheckBox
+    Friend WithEvents radiobuttonMatchSystemTheme As RadioButton
+    Friend WithEvents checkboxOverrideDefaultDarkTheme As CheckBox
 End Class

--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -33,6 +33,8 @@ Partial Class aaformThemeLoader
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.ToolStripStatusLabel1 = New System.Windows.Forms.ToolStripStatusLabel()
         Me.Panel1 = New System.Windows.Forms.Panel()
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching = New System.Windows.Forms.CheckBox()
+        Me.radiobuttonMatchSystemTheme = New System.Windows.Forms.RadioButton()
         Me.groupboxContextMenuArea = New System.Windows.Forms.GroupBox()
         Me.panelContextMenuArea = New System.Windows.Forms.Panel()
         Me.ContextMenuStrip1 = New System.Windows.Forms.ContextMenuStrip(Me.components)
@@ -45,8 +47,6 @@ Partial Class aaformThemeLoader
         Me.radiobuttonLoadFromXml = New System.Windows.Forms.RadioButton()
         Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
         Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
-        Me.radiobuttonMatchSystemTheme = New System.Windows.Forms.RadioButton()
-        Me.checkboxSpecifyDefaultDarkTheme = New System.Windows.Forms.CheckBox()
         Me.StatusStrip1.SuspendLayout()
         Me.Panel1.SuspendLayout()
         Me.groupboxContextMenuArea.SuspendLayout()
@@ -59,7 +59,7 @@ Partial Class aaformThemeLoader
         Me.textboxThemePath.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.textboxThemePath.Location = New System.Drawing.Point(9, 23)
-        Me.textboxThemePath.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.textboxThemePath.Margin = New System.Windows.Forms.Padding(2)
         Me.textboxThemePath.Name = "textboxThemePath"
         Me.textboxThemePath.Size = New System.Drawing.Size(353, 20)
         Me.textboxThemePath.TabIndex = 0
@@ -79,7 +79,7 @@ Partial Class aaformThemeLoader
         'buttonLoadTheme
         '
         Me.buttonLoadTheme.Location = New System.Drawing.Point(9, 46)
-        Me.buttonLoadTheme.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.buttonLoadTheme.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonLoadTheme.Name = "buttonLoadTheme"
         Me.buttonLoadTheme.Size = New System.Drawing.Size(90, 26)
         Me.buttonLoadTheme.TabIndex = 1
@@ -103,7 +103,7 @@ Partial Class aaformThemeLoader
         Me.textboxColorTester.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.textboxColorTester.Location = New System.Drawing.Point(10, 257)
-        Me.textboxColorTester.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.textboxColorTester.Margin = New System.Windows.Forms.Padding(2)
         Me.textboxColorTester.Name = "textboxColorTester"
         Me.textboxColorTester.Size = New System.Drawing.Size(353, 20)
         Me.textboxColorTester.TabIndex = 6
@@ -112,7 +112,7 @@ Partial Class aaformThemeLoader
         '
         Me.buttonSetColor.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.buttonSetColor.Location = New System.Drawing.Point(10, 280)
-        Me.buttonSetColor.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.buttonSetColor.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonSetColor.Name = "buttonSetColor"
         Me.buttonSetColor.Size = New System.Drawing.Size(110, 24)
         Me.buttonSetColor.TabIndex = 7
@@ -123,7 +123,7 @@ Partial Class aaformThemeLoader
         '
         Me.buttonResetColor.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
         Me.buttonResetColor.Location = New System.Drawing.Point(126, 280)
-        Me.buttonResetColor.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.buttonResetColor.Margin = New System.Windows.Forms.Padding(2)
         Me.buttonResetColor.Name = "buttonResetColor"
         Me.buttonResetColor.Size = New System.Drawing.Size(86, 24)
         Me.buttonResetColor.TabIndex = 8
@@ -149,7 +149,7 @@ Partial Class aaformThemeLoader
         '
         'Panel1
         '
-        Me.Panel1.Controls.Add(Me.checkboxSpecifyDefaultDarkTheme)
+        Me.Panel1.Controls.Add(Me.checkboxSpecifyDarkThemeForSystemThemeMatching)
         Me.Panel1.Controls.Add(Me.radiobuttonMatchSystemTheme)
         Me.Panel1.Controls.Add(Me.groupboxContextMenuArea)
         Me.Panel1.Controls.Add(Me.radiobuttonSelectFromThemeEngine)
@@ -165,18 +165,41 @@ Partial Class aaformThemeLoader
         Me.Panel1.Controls.Add(Me.textboxColorTester)
         Me.Panel1.Dock = System.Windows.Forms.DockStyle.Fill
         Me.Panel1.Location = New System.Drawing.Point(0, 0)
-        Me.Panel1.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.Panel1.Margin = New System.Windows.Forms.Padding(2)
         Me.Panel1.Name = "Panel1"
         Me.Panel1.Size = New System.Drawing.Size(371, 312)
         Me.Panel1.TabIndex = 8
+        '
+        'checkboxSpecifyDarkThemeForSystemThemeMatching
+        '
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.AutoSize = True
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.Location = New System.Drawing.Point(218, 184)
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.Name = "checkboxSpecifyDarkThemeForSystemThemeMatching"
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.Size = New System.Drawing.Size(117, 17)
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.TabIndex = 11
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.Text = "Specify dark theme"
+        Me.checkboxSpecifyDarkThemeForSystemThemeMatching.UseVisualStyleBackColor = True
+        '
+        'radiobuttonMatchSystemTheme
+        '
+        Me.radiobuttonMatchSystemTheme.AutoSize = True
+        Me.radiobuttonMatchSystemTheme.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.radiobuttonMatchSystemTheme.Location = New System.Drawing.Point(202, 147)
+        Me.radiobuttonMatchSystemTheme.Name = "radiobuttonMatchSystemTheme"
+        Me.radiobuttonMatchSystemTheme.Size = New System.Drawing.Size(149, 30)
+        Me.radiobuttonMatchSystemTheme.TabIndex = 10
+        Me.radiobuttonMatchSystemTheme.TabStop = True
+        Me.radiobuttonMatchSystemTheme.Text = "Match Windows 10 theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "settings"
+        Me.radiobuttonMatchSystemTheme.UseVisualStyleBackColor = True
         '
         'groupboxContextMenuArea
         '
         Me.groupboxContextMenuArea.Controls.Add(Me.panelContextMenuArea)
         Me.groupboxContextMenuArea.Location = New System.Drawing.Point(9, 77)
-        Me.groupboxContextMenuArea.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.groupboxContextMenuArea.Margin = New System.Windows.Forms.Padding(2)
         Me.groupboxContextMenuArea.Name = "groupboxContextMenuArea"
-        Me.groupboxContextMenuArea.Padding = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.groupboxContextMenuArea.Padding = New System.Windows.Forms.Padding(2)
         Me.groupboxContextMenuArea.Size = New System.Drawing.Size(146, 65)
         Me.groupboxContextMenuArea.TabIndex = 9
         Me.groupboxContextMenuArea.TabStop = False
@@ -188,7 +211,7 @@ Partial Class aaformThemeLoader
         Me.panelContextMenuArea.Controls.Add(Me.labelContextMenuColors)
         Me.panelContextMenuArea.Dock = System.Windows.Forms.DockStyle.Fill
         Me.panelContextMenuArea.Location = New System.Drawing.Point(2, 15)
-        Me.panelContextMenuArea.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.panelContextMenuArea.Margin = New System.Windows.Forms.Padding(2)
         Me.panelContextMenuArea.Name = "panelContextMenuArea"
         Me.panelContextMenuArea.Size = New System.Drawing.Size(142, 48)
         Me.panelContextMenuArea.TabIndex = 0
@@ -238,8 +261,8 @@ Partial Class aaformThemeLoader
         '
         Me.radiobuttonSelectFromThemeEngine.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.radiobuttonSelectFromThemeEngine.AutoSize = True
-        Me.radiobuttonSelectFromThemeEngine.Location = New System.Drawing.Point(186, 47)
-        Me.radiobuttonSelectFromThemeEngine.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.radiobuttonSelectFromThemeEngine.Location = New System.Drawing.Point(202, 47)
+        Me.radiobuttonSelectFromThemeEngine.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonSelectFromThemeEngine.Name = "radiobuttonSelectFromThemeEngine"
         Me.radiobuttonSelectFromThemeEngine.Size = New System.Drawing.Size(160, 17)
         Me.radiobuttonSelectFromThemeEngine.TabIndex = 2
@@ -252,8 +275,8 @@ Partial Class aaformThemeLoader
         Me.radiobuttonLoadFromXml.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.radiobuttonLoadFromXml.AutoSize = True
         Me.radiobuttonLoadFromXml.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.radiobuttonLoadFromXml.Location = New System.Drawing.Point(186, 112)
-        Me.radiobuttonLoadFromXml.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.radiobuttonLoadFromXml.Location = New System.Drawing.Point(202, 112)
+        Me.radiobuttonLoadFromXml.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonLoadFromXml.Name = "radiobuttonLoadFromXml"
         Me.radiobuttonLoadFromXml.Size = New System.Drawing.Size(151, 30)
         Me.radiobuttonLoadFromXml.TabIndex = 5
@@ -265,8 +288,8 @@ Partial Class aaformThemeLoader
         '
         Me.radiobuttonIsCustomTheme.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.radiobuttonIsCustomTheme.AutoSize = True
-        Me.radiobuttonIsCustomTheme.Location = New System.Drawing.Point(186, 69)
-        Me.radiobuttonIsCustomTheme.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.radiobuttonIsCustomTheme.Location = New System.Drawing.Point(202, 69)
+        Me.radiobuttonIsCustomTheme.Margin = New System.Windows.Forms.Padding(2)
         Me.radiobuttonIsCustomTheme.Name = "radiobuttonIsCustomTheme"
         Me.radiobuttonIsCustomTheme.Size = New System.Drawing.Size(120, 17)
         Me.radiobuttonIsCustomTheme.TabIndex = 3
@@ -278,36 +301,13 @@ Partial Class aaformThemeLoader
         '
         Me.checkboxAllowCustomThemes.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.checkboxAllowCustomThemes.AutoSize = True
-        Me.checkboxAllowCustomThemes.Location = New System.Drawing.Point(202, 90)
-        Me.checkboxAllowCustomThemes.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.checkboxAllowCustomThemes.Location = New System.Drawing.Point(218, 90)
+        Me.checkboxAllowCustomThemes.Margin = New System.Windows.Forms.Padding(2)
         Me.checkboxAllowCustomThemes.Name = "checkboxAllowCustomThemes"
         Me.checkboxAllowCustomThemes.Size = New System.Drawing.Size(125, 17)
         Me.checkboxAllowCustomThemes.TabIndex = 4
         Me.checkboxAllowCustomThemes.Text = "Allow custom themes"
         Me.checkboxAllowCustomThemes.UseVisualStyleBackColor = True
-        '
-        'radiobuttonMatchSystemTheme
-        '
-        Me.radiobuttonMatchSystemTheme.AutoSize = True
-        Me.radiobuttonMatchSystemTheme.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.radiobuttonMatchSystemTheme.Location = New System.Drawing.Point(186, 147)
-        Me.radiobuttonMatchSystemTheme.Name = "radiobuttonMatchSystemTheme"
-        Me.radiobuttonMatchSystemTheme.Size = New System.Drawing.Size(149, 30)
-        Me.radiobuttonMatchSystemTheme.TabIndex = 10
-        Me.radiobuttonMatchSystemTheme.TabStop = True
-        Me.radiobuttonMatchSystemTheme.Text = "Match Windows 10 theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "settings"
-        Me.radiobuttonMatchSystemTheme.UseVisualStyleBackColor = True
-        '
-        'checkboxSpecifyDefaultDarkTheme
-        '
-        Me.checkboxSpecifyDefaultDarkTheme.AutoSize = True
-        Me.checkboxSpecifyDefaultDarkTheme.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.checkboxSpecifyDefaultDarkTheme.Location = New System.Drawing.Point(202, 184)
-        Me.checkboxSpecifyDefaultDarkTheme.Name = "checkboxSpecifyDefaultDarkTheme"
-        Me.checkboxSpecifyDefaultDarkTheme.Size = New System.Drawing.Size(152, 17)
-        Me.checkboxSpecifyDefaultDarkTheme.TabIndex = 11
-        Me.checkboxSpecifyDefaultDarkTheme.Text = "Specify default dark theme"
-        Me.checkboxSpecifyDefaultDarkTheme.UseVisualStyleBackColor = True
         '
         'aaformThemeLoader
         '
@@ -316,7 +316,7 @@ Partial Class aaformThemeLoader
         Me.ClientSize = New System.Drawing.Size(371, 334)
         Me.Controls.Add(Me.Panel1)
         Me.Controls.Add(Me.StatusStrip1)
-        Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.Margin = New System.Windows.Forms.Padding(2)
         Me.Name = "aaformThemeLoader"
         Me.Text = "Form1"
         Me.StatusStrip1.ResumeLayout(False)
@@ -355,5 +355,5 @@ Partial Class aaformThemeLoader
     Friend WithEvents ToolStripMenuItem3 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem4 As ToolStripMenuItem
     Friend WithEvents radiobuttonMatchSystemTheme As RadioButton
-    Friend WithEvents checkboxSpecifyDefaultDarkTheme As CheckBox
+    Friend WithEvents checkboxSpecifyDarkThemeForSystemThemeMatching As CheckBox
 End Class

--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -33,18 +33,20 @@ Partial Class aaformThemeLoader
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.ToolStripStatusLabel1 = New System.Windows.Forms.ToolStripStatusLabel()
         Me.Panel1 = New System.Windows.Forms.Panel()
-        Me.radiobuttonSelectFromThemeEngine = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonLoadFromXml = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
-        Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
         Me.groupboxContextMenuArea = New System.Windows.Forms.GroupBox()
         Me.panelContextMenuArea = New System.Windows.Forms.Panel()
-        Me.labelContextMenuColors = New System.Windows.Forms.Label()
         Me.ContextMenuStrip1 = New System.Windows.Forms.ContextMenuStrip(Me.components)
         Me.ToolStripMenuItem1 = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripMenuItem2 = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripMenuItem3 = New System.Windows.Forms.ToolStripMenuItem()
         Me.ToolStripMenuItem4 = New System.Windows.Forms.ToolStripMenuItem()
+        Me.labelContextMenuColors = New System.Windows.Forms.Label()
+        Me.radiobuttonSelectFromThemeEngine = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonLoadFromXml = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
+        Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
+        Me.RadioButton1 = New System.Windows.Forms.RadioButton()
+        Me.CheckBox1 = New System.Windows.Forms.CheckBox()
         Me.StatusStrip1.SuspendLayout()
         Me.Panel1.SuspendLayout()
         Me.groupboxContextMenuArea.SuspendLayout()
@@ -56,9 +58,10 @@ Partial Class aaformThemeLoader
         '
         Me.textboxThemePath.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.textboxThemePath.Location = New System.Drawing.Point(11, 29)
+        Me.textboxThemePath.Location = New System.Drawing.Point(9, 23)
+        Me.textboxThemePath.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.textboxThemePath.Name = "textboxThemePath"
-        Me.textboxThemePath.Size = New System.Drawing.Size(440, 22)
+        Me.textboxThemePath.Size = New System.Drawing.Size(353, 20)
         Me.textboxThemePath.TabIndex = 0
         Me.textboxThemePath.Text = "C:\Users\drewn\Documents\0GitHub\UXL-Launcher\PortableUXLLauncher_ThemeEngine\The" &
     "mes\TE2DotX_TenDarkTheme_XML.xml"
@@ -66,17 +69,19 @@ Partial Class aaformThemeLoader
         'labelPathDescription
         '
         Me.labelPathDescription.AutoSize = True
-        Me.labelPathDescription.Location = New System.Drawing.Point(12, 9)
+        Me.labelPathDescription.Location = New System.Drawing.Point(10, 7)
+        Me.labelPathDescription.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelPathDescription.Name = "labelPathDescription"
-        Me.labelPathDescription.Size = New System.Drawing.Size(88, 17)
+        Me.labelPathDescription.Size = New System.Drawing.Size(67, 13)
         Me.labelPathDescription.TabIndex = 1
         Me.labelPathDescription.Text = "Theme path:"
         '
         'buttonLoadTheme
         '
-        Me.buttonLoadTheme.Location = New System.Drawing.Point(11, 58)
+        Me.buttonLoadTheme.Location = New System.Drawing.Point(9, 46)
+        Me.buttonLoadTheme.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.buttonLoadTheme.Name = "buttonLoadTheme"
-        Me.buttonLoadTheme.Size = New System.Drawing.Size(113, 32)
+        Me.buttonLoadTheme.Size = New System.Drawing.Size(90, 26)
         Me.buttonLoadTheme.TabIndex = 1
         Me.buttonLoadTheme.Text = "Load theme"
         Me.buttonLoadTheme.UseVisualStyleBackColor = True
@@ -86,9 +91,10 @@ Partial Class aaformThemeLoader
         Me.labelColorTester.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.labelColorTester.AutoSize = True
-        Me.labelColorTester.Location = New System.Drawing.Point(12, 223)
+        Me.labelColorTester.Location = New System.Drawing.Point(10, 227)
+        Me.labelColorTester.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelColorTester.Name = "labelColorTester"
-        Me.labelColorTester.Size = New System.Drawing.Size(85, 17)
+        Me.labelColorTester.Size = New System.Drawing.Size(63, 13)
         Me.labelColorTester.TabIndex = 3
         Me.labelColorTester.Text = "Color tester:"
         '
@@ -96,17 +102,19 @@ Partial Class aaformThemeLoader
         '
         Me.textboxColorTester.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.textboxColorTester.Location = New System.Drawing.Point(12, 244)
+        Me.textboxColorTester.Location = New System.Drawing.Point(10, 244)
+        Me.textboxColorTester.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.textboxColorTester.Name = "textboxColorTester"
-        Me.textboxColorTester.Size = New System.Drawing.Size(440, 22)
+        Me.textboxColorTester.Size = New System.Drawing.Size(353, 20)
         Me.textboxColorTester.TabIndex = 6
         '
         'buttonSetColor
         '
         Me.buttonSetColor.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.buttonSetColor.Location = New System.Drawing.Point(12, 273)
+        Me.buttonSetColor.Location = New System.Drawing.Point(10, 267)
+        Me.buttonSetColor.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.buttonSetColor.Name = "buttonSetColor"
-        Me.buttonSetColor.Size = New System.Drawing.Size(138, 30)
+        Me.buttonSetColor.Size = New System.Drawing.Size(110, 24)
         Me.buttonSetColor.TabIndex = 7
         Me.buttonSetColor.Text = "Set statusbar color"
         Me.buttonSetColor.UseVisualStyleBackColor = True
@@ -114,9 +122,10 @@ Partial Class aaformThemeLoader
         'buttonResetColor
         '
         Me.buttonResetColor.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.buttonResetColor.Location = New System.Drawing.Point(157, 273)
+        Me.buttonResetColor.Location = New System.Drawing.Point(126, 267)
+        Me.buttonResetColor.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.buttonResetColor.Name = "buttonResetColor"
-        Me.buttonResetColor.Size = New System.Drawing.Size(108, 30)
+        Me.buttonResetColor.Size = New System.Drawing.Size(86, 24)
         Me.buttonResetColor.TabIndex = 8
         Me.buttonResetColor.Text = "Reset color"
         Me.buttonResetColor.UseVisualStyleBackColor = True
@@ -125,20 +134,23 @@ Partial Class aaformThemeLoader
         '
         Me.StatusStrip1.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripStatusLabel1})
-        Me.StatusStrip1.Location = New System.Drawing.Point(0, 312)
+        Me.StatusStrip1.Location = New System.Drawing.Point(0, 299)
         Me.StatusStrip1.Name = "StatusStrip1"
-        Me.StatusStrip1.Size = New System.Drawing.Size(464, 25)
+        Me.StatusStrip1.Padding = New System.Windows.Forms.Padding(1, 0, 11, 0)
+        Me.StatusStrip1.Size = New System.Drawing.Size(371, 22)
         Me.StatusStrip1.TabIndex = 7
         Me.StatusStrip1.Text = "StatusStrip1"
         '
         'ToolStripStatusLabel1
         '
         Me.ToolStripStatusLabel1.Name = "ToolStripStatusLabel1"
-        Me.ToolStripStatusLabel1.Size = New System.Drawing.Size(153, 20)
+        Me.ToolStripStatusLabel1.Size = New System.Drawing.Size(119, 17)
         Me.ToolStripStatusLabel1.Text = "ToolStripStatusLabel1"
         '
         'Panel1
         '
+        Me.Panel1.Controls.Add(Me.CheckBox1)
+        Me.Panel1.Controls.Add(Me.RadioButton1)
         Me.Panel1.Controls.Add(Me.groupboxContextMenuArea)
         Me.Panel1.Controls.Add(Me.radiobuttonSelectFromThemeEngine)
         Me.Panel1.Controls.Add(Me.radiobuttonLoadFromXml)
@@ -153,63 +165,19 @@ Partial Class aaformThemeLoader
         Me.Panel1.Controls.Add(Me.textboxColorTester)
         Me.Panel1.Dock = System.Windows.Forms.DockStyle.Fill
         Me.Panel1.Location = New System.Drawing.Point(0, 0)
+        Me.Panel1.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.Panel1.Name = "Panel1"
-        Me.Panel1.Size = New System.Drawing.Size(464, 312)
+        Me.Panel1.Size = New System.Drawing.Size(371, 299)
         Me.Panel1.TabIndex = 8
-        '
-        'radiobuttonSelectFromThemeEngine
-        '
-        Me.radiobuttonSelectFromThemeEngine.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.radiobuttonSelectFromThemeEngine.AutoSize = True
-        Me.radiobuttonSelectFromThemeEngine.Location = New System.Drawing.Point(240, 58)
-        Me.radiobuttonSelectFromThemeEngine.Name = "radiobuttonSelectFromThemeEngine"
-        Me.radiobuttonSelectFromThemeEngine.Size = New System.Drawing.Size(211, 21)
-        Me.radiobuttonSelectFromThemeEngine.TabIndex = 2
-        Me.radiobuttonSelectFromThemeEngine.TabStop = True
-        Me.radiobuttonSelectFromThemeEngine.Text = "Select theme (theme engine)"
-        Me.radiobuttonSelectFromThemeEngine.UseVisualStyleBackColor = True
-        '
-        'radiobuttonLoadFromXml
-        '
-        Me.radiobuttonLoadFromXml.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.radiobuttonLoadFromXml.AutoSize = True
-        Me.radiobuttonLoadFromXml.Location = New System.Drawing.Point(240, 139)
-        Me.radiobuttonLoadFromXml.Name = "radiobuttonLoadFromXml"
-        Me.radiobuttonLoadFromXml.Size = New System.Drawing.Size(199, 38)
-        Me.radiobuttonLoadFromXml.TabIndex = 5
-        Me.radiobuttonLoadFromXml.TabStop = True
-        Me.radiobuttonLoadFromXml.Text = "Load from XML (debugger;" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "forces ReturnOfNight)"
-        Me.radiobuttonLoadFromXml.UseVisualStyleBackColor = True
-        '
-        'radiobuttonIsCustomTheme
-        '
-        Me.radiobuttonIsCustomTheme.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.radiobuttonIsCustomTheme.AutoSize = True
-        Me.radiobuttonIsCustomTheme.Location = New System.Drawing.Point(240, 85)
-        Me.radiobuttonIsCustomTheme.Name = "radiobuttonIsCustomTheme"
-        Me.radiobuttonIsCustomTheme.Size = New System.Drawing.Size(156, 21)
-        Me.radiobuttonIsCustomTheme.TabIndex = 3
-        Me.radiobuttonIsCustomTheme.TabStop = True
-        Me.radiobuttonIsCustomTheme.Text = "Apply custom theme"
-        Me.radiobuttonIsCustomTheme.UseVisualStyleBackColor = True
-        '
-        'checkboxAllowCustomThemes
-        '
-        Me.checkboxAllowCustomThemes.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.checkboxAllowCustomThemes.AutoSize = True
-        Me.checkboxAllowCustomThemes.Location = New System.Drawing.Point(240, 112)
-        Me.checkboxAllowCustomThemes.Name = "checkboxAllowCustomThemes"
-        Me.checkboxAllowCustomThemes.Size = New System.Drawing.Size(161, 21)
-        Me.checkboxAllowCustomThemes.TabIndex = 4
-        Me.checkboxAllowCustomThemes.Text = "Allow custom themes"
-        Me.checkboxAllowCustomThemes.UseVisualStyleBackColor = True
         '
         'groupboxContextMenuArea
         '
         Me.groupboxContextMenuArea.Controls.Add(Me.panelContextMenuArea)
-        Me.groupboxContextMenuArea.Location = New System.Drawing.Point(11, 96)
+        Me.groupboxContextMenuArea.Location = New System.Drawing.Point(9, 77)
+        Me.groupboxContextMenuArea.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.groupboxContextMenuArea.Name = "groupboxContextMenuArea"
-        Me.groupboxContextMenuArea.Size = New System.Drawing.Size(183, 81)
+        Me.groupboxContextMenuArea.Padding = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.groupboxContextMenuArea.Size = New System.Drawing.Size(146, 65)
         Me.groupboxContextMenuArea.TabIndex = 9
         Me.groupboxContextMenuArea.TabStop = False
         Me.groupboxContextMenuArea.Text = "Context menu test area"
@@ -219,58 +187,135 @@ Partial Class aaformThemeLoader
         Me.panelContextMenuArea.ContextMenuStrip = Me.ContextMenuStrip1
         Me.panelContextMenuArea.Controls.Add(Me.labelContextMenuColors)
         Me.panelContextMenuArea.Dock = System.Windows.Forms.DockStyle.Fill
-        Me.panelContextMenuArea.Location = New System.Drawing.Point(3, 18)
+        Me.panelContextMenuArea.Location = New System.Drawing.Point(2, 15)
+        Me.panelContextMenuArea.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.panelContextMenuArea.Name = "panelContextMenuArea"
-        Me.panelContextMenuArea.Size = New System.Drawing.Size(177, 60)
+        Me.panelContextMenuArea.Size = New System.Drawing.Size(142, 48)
         Me.panelContextMenuArea.TabIndex = 0
-        '
-        'labelContextMenuColors
-        '
-        Me.labelContextMenuColors.AutoSize = True
-        Me.labelContextMenuColors.Location = New System.Drawing.Point(4, 4)
-        Me.labelContextMenuColors.Name = "labelContextMenuColors"
-        Me.labelContextMenuColors.Size = New System.Drawing.Size(146, 51)
-        Me.labelContextMenuColors.TabIndex = 0
-        Me.labelContextMenuColors.Text = "Right-click anwhere in" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "here to test context" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "menu colors."
         '
         'ContextMenuStrip1
         '
         Me.ContextMenuStrip1.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.ContextMenuStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripMenuItem1, Me.ToolStripMenuItem2, Me.ToolStripMenuItem3, Me.ToolStripMenuItem4})
         Me.ContextMenuStrip1.Name = "ContextMenuStrip1"
-        Me.ContextMenuStrip1.Size = New System.Drawing.Size(214, 100)
+        Me.ContextMenuStrip1.Size = New System.Drawing.Size(182, 92)
         '
         'ToolStripMenuItem1
         '
         Me.ToolStripMenuItem1.Name = "ToolStripMenuItem1"
-        Me.ToolStripMenuItem1.Size = New System.Drawing.Size(213, 24)
+        Me.ToolStripMenuItem1.Size = New System.Drawing.Size(181, 22)
         Me.ToolStripMenuItem1.Text = "ToolStripMenuItem1"
         '
         'ToolStripMenuItem2
         '
         Me.ToolStripMenuItem2.Name = "ToolStripMenuItem2"
-        Me.ToolStripMenuItem2.Size = New System.Drawing.Size(213, 24)
+        Me.ToolStripMenuItem2.Size = New System.Drawing.Size(181, 22)
         Me.ToolStripMenuItem2.Text = "ToolStripMenuItem2"
         '
         'ToolStripMenuItem3
         '
         Me.ToolStripMenuItem3.Name = "ToolStripMenuItem3"
-        Me.ToolStripMenuItem3.Size = New System.Drawing.Size(213, 24)
+        Me.ToolStripMenuItem3.Size = New System.Drawing.Size(181, 22)
         Me.ToolStripMenuItem3.Text = "ToolStripMenuItem3"
         '
         'ToolStripMenuItem4
         '
         Me.ToolStripMenuItem4.Name = "ToolStripMenuItem4"
-        Me.ToolStripMenuItem4.Size = New System.Drawing.Size(213, 24)
+        Me.ToolStripMenuItem4.Size = New System.Drawing.Size(181, 22)
         Me.ToolStripMenuItem4.Text = "ToolStripMenuItem4"
+        '
+        'labelContextMenuColors
+        '
+        Me.labelContextMenuColors.AutoSize = True
+        Me.labelContextMenuColors.Location = New System.Drawing.Point(3, 3)
+        Me.labelContextMenuColors.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
+        Me.labelContextMenuColors.Name = "labelContextMenuColors"
+        Me.labelContextMenuColors.Size = New System.Drawing.Size(112, 39)
+        Me.labelContextMenuColors.TabIndex = 0
+        Me.labelContextMenuColors.Text = "Right-click anwhere in" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "here to test context" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "menu colors."
+        '
+        'radiobuttonSelectFromThemeEngine
+        '
+        Me.radiobuttonSelectFromThemeEngine.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.radiobuttonSelectFromThemeEngine.AutoSize = True
+        Me.radiobuttonSelectFromThemeEngine.Location = New System.Drawing.Point(186, 47)
+        Me.radiobuttonSelectFromThemeEngine.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.radiobuttonSelectFromThemeEngine.Name = "radiobuttonSelectFromThemeEngine"
+        Me.radiobuttonSelectFromThemeEngine.Size = New System.Drawing.Size(160, 17)
+        Me.radiobuttonSelectFromThemeEngine.TabIndex = 2
+        Me.radiobuttonSelectFromThemeEngine.TabStop = True
+        Me.radiobuttonSelectFromThemeEngine.Text = "Select theme (theme engine)"
+        Me.radiobuttonSelectFromThemeEngine.UseVisualStyleBackColor = True
+        '
+        'radiobuttonLoadFromXml
+        '
+        Me.radiobuttonLoadFromXml.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.radiobuttonLoadFromXml.AutoSize = True
+        Me.radiobuttonLoadFromXml.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.radiobuttonLoadFromXml.Location = New System.Drawing.Point(186, 112)
+        Me.radiobuttonLoadFromXml.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.radiobuttonLoadFromXml.Name = "radiobuttonLoadFromXml"
+        Me.radiobuttonLoadFromXml.Size = New System.Drawing.Size(151, 30)
+        Me.radiobuttonLoadFromXml.TabIndex = 5
+        Me.radiobuttonLoadFromXml.TabStop = True
+        Me.radiobuttonLoadFromXml.Text = "Load from XML (debugger;" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "forces ReturnOfNight)"
+        Me.radiobuttonLoadFromXml.UseVisualStyleBackColor = True
+        '
+        'radiobuttonIsCustomTheme
+        '
+        Me.radiobuttonIsCustomTheme.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.radiobuttonIsCustomTheme.AutoSize = True
+        Me.radiobuttonIsCustomTheme.Location = New System.Drawing.Point(186, 69)
+        Me.radiobuttonIsCustomTheme.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.radiobuttonIsCustomTheme.Name = "radiobuttonIsCustomTheme"
+        Me.radiobuttonIsCustomTheme.Size = New System.Drawing.Size(120, 17)
+        Me.radiobuttonIsCustomTheme.TabIndex = 3
+        Me.radiobuttonIsCustomTheme.TabStop = True
+        Me.radiobuttonIsCustomTheme.Text = "Apply custom theme"
+        Me.radiobuttonIsCustomTheme.UseVisualStyleBackColor = True
+        '
+        'checkboxAllowCustomThemes
+        '
+        Me.checkboxAllowCustomThemes.Anchor = CType((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.checkboxAllowCustomThemes.AutoSize = True
+        Me.checkboxAllowCustomThemes.Location = New System.Drawing.Point(202, 90)
+        Me.checkboxAllowCustomThemes.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
+        Me.checkboxAllowCustomThemes.Name = "checkboxAllowCustomThemes"
+        Me.checkboxAllowCustomThemes.Size = New System.Drawing.Size(125, 17)
+        Me.checkboxAllowCustomThemes.TabIndex = 4
+        Me.checkboxAllowCustomThemes.Text = "Allow custom themes"
+        Me.checkboxAllowCustomThemes.UseVisualStyleBackColor = True
+        '
+        'RadioButton1
+        '
+        Me.RadioButton1.AutoSize = True
+        Me.RadioButton1.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.RadioButton1.Location = New System.Drawing.Point(186, 148)
+        Me.RadioButton1.Name = "RadioButton1"
+        Me.RadioButton1.Size = New System.Drawing.Size(149, 30)
+        Me.RadioButton1.TabIndex = 10
+        Me.RadioButton1.TabStop = True
+        Me.RadioButton1.Text = "Match Windows 10 theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "settings"
+        Me.RadioButton1.UseVisualStyleBackColor = True
+        '
+        'CheckBox1
+        '
+        Me.CheckBox1.AutoSize = True
+        Me.CheckBox1.Location = New System.Drawing.Point(202, 184)
+        Me.CheckBox1.Name = "CheckBox1"
+        Me.CheckBox1.Size = New System.Drawing.Size(157, 17)
+        Me.CheckBox1.TabIndex = 11
+        Me.CheckBox1.Text = "Override default dark theme"
+        Me.CheckBox1.UseVisualStyleBackColor = True
         '
         'aaformThemeLoader
         '
-        Me.AutoScaleDimensions = New System.Drawing.SizeF(120.0!, 120.0!)
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(464, 337)
+        Me.ClientSize = New System.Drawing.Size(371, 321)
         Me.Controls.Add(Me.Panel1)
         Me.Controls.Add(Me.StatusStrip1)
+        Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.Name = "aaformThemeLoader"
         Me.Text = "Form1"
         Me.StatusStrip1.ResumeLayout(False)
@@ -308,4 +353,6 @@ Partial Class aaformThemeLoader
     Friend WithEvents ToolStripMenuItem2 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem3 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem4 As ToolStripMenuItem
+    Friend WithEvents RadioButton1 As RadioButton
+    Friend WithEvents CheckBox1 As CheckBox
 End Class

--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -46,7 +46,7 @@ Partial Class aaformThemeLoader
         Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
         Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
         Me.radiobuttonMatchSystemTheme = New System.Windows.Forms.RadioButton()
-        Me.checkboxOverrideDefaultDarkTheme = New System.Windows.Forms.CheckBox()
+        Me.checkboxSpecifyDefaultDarkTheme = New System.Windows.Forms.CheckBox()
         Me.StatusStrip1.SuspendLayout()
         Me.Panel1.SuspendLayout()
         Me.groupboxContextMenuArea.SuspendLayout()
@@ -91,7 +91,7 @@ Partial Class aaformThemeLoader
         Me.labelColorTester.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
         Me.labelColorTester.AutoSize = True
-        Me.labelColorTester.Location = New System.Drawing.Point(10, 227)
+        Me.labelColorTester.Location = New System.Drawing.Point(10, 240)
         Me.labelColorTester.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelColorTester.Name = "labelColorTester"
         Me.labelColorTester.Size = New System.Drawing.Size(63, 13)
@@ -102,7 +102,7 @@ Partial Class aaformThemeLoader
         '
         Me.textboxColorTester.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) _
             Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
-        Me.textboxColorTester.Location = New System.Drawing.Point(10, 244)
+        Me.textboxColorTester.Location = New System.Drawing.Point(10, 257)
         Me.textboxColorTester.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.textboxColorTester.Name = "textboxColorTester"
         Me.textboxColorTester.Size = New System.Drawing.Size(353, 20)
@@ -111,7 +111,7 @@ Partial Class aaformThemeLoader
         'buttonSetColor
         '
         Me.buttonSetColor.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.buttonSetColor.Location = New System.Drawing.Point(10, 267)
+        Me.buttonSetColor.Location = New System.Drawing.Point(10, 280)
         Me.buttonSetColor.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.buttonSetColor.Name = "buttonSetColor"
         Me.buttonSetColor.Size = New System.Drawing.Size(110, 24)
@@ -122,7 +122,7 @@ Partial Class aaformThemeLoader
         'buttonResetColor
         '
         Me.buttonResetColor.Anchor = CType((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left), System.Windows.Forms.AnchorStyles)
-        Me.buttonResetColor.Location = New System.Drawing.Point(126, 267)
+        Me.buttonResetColor.Location = New System.Drawing.Point(126, 280)
         Me.buttonResetColor.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.buttonResetColor.Name = "buttonResetColor"
         Me.buttonResetColor.Size = New System.Drawing.Size(86, 24)
@@ -134,7 +134,7 @@ Partial Class aaformThemeLoader
         '
         Me.StatusStrip1.ImageScalingSize = New System.Drawing.Size(20, 20)
         Me.StatusStrip1.Items.AddRange(New System.Windows.Forms.ToolStripItem() {Me.ToolStripStatusLabel1})
-        Me.StatusStrip1.Location = New System.Drawing.Point(0, 299)
+        Me.StatusStrip1.Location = New System.Drawing.Point(0, 312)
         Me.StatusStrip1.Name = "StatusStrip1"
         Me.StatusStrip1.Padding = New System.Windows.Forms.Padding(1, 0, 11, 0)
         Me.StatusStrip1.Size = New System.Drawing.Size(371, 22)
@@ -149,7 +149,7 @@ Partial Class aaformThemeLoader
         '
         'Panel1
         '
-        Me.Panel1.Controls.Add(Me.checkboxOverrideDefaultDarkTheme)
+        Me.Panel1.Controls.Add(Me.checkboxSpecifyDefaultDarkTheme)
         Me.Panel1.Controls.Add(Me.radiobuttonMatchSystemTheme)
         Me.Panel1.Controls.Add(Me.groupboxContextMenuArea)
         Me.Panel1.Controls.Add(Me.radiobuttonSelectFromThemeEngine)
@@ -167,7 +167,7 @@ Partial Class aaformThemeLoader
         Me.Panel1.Location = New System.Drawing.Point(0, 0)
         Me.Panel1.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
         Me.Panel1.Name = "Panel1"
-        Me.Panel1.Size = New System.Drawing.Size(371, 299)
+        Me.Panel1.Size = New System.Drawing.Size(371, 312)
         Me.Panel1.TabIndex = 8
         '
         'groupboxContextMenuArea
@@ -298,21 +298,22 @@ Partial Class aaformThemeLoader
         Me.radiobuttonMatchSystemTheme.Text = "Match Windows 10 theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "settings"
         Me.radiobuttonMatchSystemTheme.UseVisualStyleBackColor = True
         '
-        'checkboxOverrideDefaultDarkTheme
+        'checkboxSpecifyDefaultDarkTheme
         '
-        Me.checkboxOverrideDefaultDarkTheme.AutoSize = True
-        Me.checkboxOverrideDefaultDarkTheme.Location = New System.Drawing.Point(202, 184)
-        Me.checkboxOverrideDefaultDarkTheme.Name = "checkboxOverrideDefaultDarkTheme"
-        Me.checkboxOverrideDefaultDarkTheme.Size = New System.Drawing.Size(157, 17)
-        Me.checkboxOverrideDefaultDarkTheme.TabIndex = 11
-        Me.checkboxOverrideDefaultDarkTheme.Text = "Override default dark theme"
-        Me.checkboxOverrideDefaultDarkTheme.UseVisualStyleBackColor = True
+        Me.checkboxSpecifyDefaultDarkTheme.AutoSize = True
+        Me.checkboxSpecifyDefaultDarkTheme.CheckAlign = System.Drawing.ContentAlignment.TopLeft
+        Me.checkboxSpecifyDefaultDarkTheme.Location = New System.Drawing.Point(202, 184)
+        Me.checkboxSpecifyDefaultDarkTheme.Name = "checkboxSpecifyDefaultDarkTheme"
+        Me.checkboxSpecifyDefaultDarkTheme.Size = New System.Drawing.Size(161, 43)
+        Me.checkboxSpecifyDefaultDarkTheme.TabIndex = 11
+        Me.checkboxSpecifyDefaultDarkTheme.Text = "Specify default dark theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "(changes default dark theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "for this session)"
+        Me.checkboxSpecifyDefaultDarkTheme.UseVisualStyleBackColor = True
         '
         'aaformThemeLoader
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
         Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi
-        Me.ClientSize = New System.Drawing.Size(371, 321)
+        Me.ClientSize = New System.Drawing.Size(371, 334)
         Me.Controls.Add(Me.Panel1)
         Me.Controls.Add(Me.StatusStrip1)
         Me.Margin = New System.Windows.Forms.Padding(2, 2, 2, 2)
@@ -354,5 +355,5 @@ Partial Class aaformThemeLoader
     Friend WithEvents ToolStripMenuItem3 As ToolStripMenuItem
     Friend WithEvents ToolStripMenuItem4 As ToolStripMenuItem
     Friend WithEvents radiobuttonMatchSystemTheme As RadioButton
-    Friend WithEvents checkboxOverrideDefaultDarkTheme As CheckBox
+    Friend WithEvents checkboxSpecifyDefaultDarkTheme As CheckBox
 End Class

--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -304,9 +304,9 @@ Partial Class aaformThemeLoader
         Me.checkboxSpecifyDefaultDarkTheme.CheckAlign = System.Drawing.ContentAlignment.TopLeft
         Me.checkboxSpecifyDefaultDarkTheme.Location = New System.Drawing.Point(202, 184)
         Me.checkboxSpecifyDefaultDarkTheme.Name = "checkboxSpecifyDefaultDarkTheme"
-        Me.checkboxSpecifyDefaultDarkTheme.Size = New System.Drawing.Size(161, 43)
+        Me.checkboxSpecifyDefaultDarkTheme.Size = New System.Drawing.Size(152, 17)
         Me.checkboxSpecifyDefaultDarkTheme.TabIndex = 11
-        Me.checkboxSpecifyDefaultDarkTheme.Text = "Specify default dark theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "(changes default dark theme" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "for this session)"
+        Me.checkboxSpecifyDefaultDarkTheme.Text = "Specify default dark theme"
         Me.checkboxSpecifyDefaultDarkTheme.UseVisualStyleBackColor = True
         '
         'aaformThemeLoader

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -78,7 +78,7 @@ Public Class aaformThemeLoader
             ' Show debug output.
             libportablethemeengine.ThemeEngine.ShowThemeEngineDebuggingOutput = True
 
-            If checkboxSpecifyDefaultDarkTheme.Checked = False Then
+            If checkboxSpecifyDarkThemeForSystemThemeMatching.Checked = False Then
                 ' Don't override the default but do match the theme.
                 libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
                 libportablethemeengine.ThemeEngine.SelectTheme("This should be optional in case the user wants to match the theme.", Me, Me.components)
@@ -86,7 +86,7 @@ Public Class aaformThemeLoader
                 ' User wants to match the theme and override the default, so
                 ' we'll do that.
                 libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
-                libportablethemeengine.ThemeEngine.DefaultDarkTheme = textboxThemePath.Text
+                libportablethemeengine.ThemeEngine.DarkThemeForSystemThemeMatching = textboxThemePath.Text
                 libportablethemeengine.ThemeEngine.SelectTheme("This shouldn't matter, either.", Me, Me.components)
             End If
 

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -79,9 +79,12 @@ Public Class aaformThemeLoader
             libportablethemeengine.ThemeEngine.ShowThemeEngineDebuggingOutput = True
 
             If checkboxSpecifyDefaultDarkTheme.Checked = False Then
+                ' Don't override the default but do match the theme.
                 libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
                 libportablethemeengine.ThemeEngine.SelectTheme("This should be optional in case the user wants to match the theme.", Me, Me.components)
             Else
+                ' User wants to match the theme and override the default, so
+                ' we'll do that.
                 libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
                 libportablethemeengine.ThemeEngine.DefaultDarkTheme = textboxThemePath.Text
                 libportablethemeengine.ThemeEngine.SelectTheme("This shouldn't matter, either.", Me, Me.components)

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -79,7 +79,8 @@ Public Class aaformThemeLoader
                 libportablethemeengine.ThemeEngine.SelectTheme("This should be optional in case the user wants to match the theme.", Me, Me.components)
             Else
                 libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
-                libportablethemeengine.ThemeEngine.SelectTheme(textboxThemePath.Text, Me, Me.components)
+                libportablethemeengine.ThemeEngine.DefaultDarkTheme = textboxThemePath.Text
+                libportablethemeengine.ThemeEngine.SelectTheme("This shouldn't matter, either.", Me, Me.components)
             End If
 
         End If

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -70,6 +70,18 @@ Public Class aaformThemeLoader
             ' Be sure to apply it to the context menu, which is part of the form's components ("Me.components").
             libportablethemeengine.ThemeEngine.LoadThemeFromXML(My.Resources.ReturnOfNightTheme_XML, Me, Me.components)
 
+        ElseIf radiobuttonMatchSystemTheme.Checked = True Then
+
+            ' If the radiobutton for matching the system theme is checked,
+            ' we'll match the system theme.
+            If checkboxOverrideDefaultDarkTheme.Checked = False Then
+                libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
+                libportablethemeengine.ThemeEngine.SelectTheme("This should be optional in case the user wants to match the theme.", Me, Me.components)
+            Else
+                libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
+                libportablethemeengine.ThemeEngine.SelectTheme(textboxThemePath.Text, Me, Me.components)
+            End If
+
         End If
 
         ' Get the end date for calculating how long it took to run.

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -74,7 +74,11 @@ Public Class aaformThemeLoader
 
             ' If the radiobutton for matching the system theme is checked,
             ' we'll match the system theme.
-            If checkboxOverrideDefaultDarkTheme.Checked = False Then
+
+            ' Show debug output.
+            libportablethemeengine.ThemeEngine.ShowThemeEngineDebuggingOutput = True
+
+            If checkboxSpecifyDefaultDarkTheme.Checked = False Then
                 libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = True
                 libportablethemeengine.ThemeEngine.SelectTheme("This should be optional in case the user wants to match the theme.", Me, Me.components)
             Else
@@ -82,6 +86,9 @@ Public Class aaformThemeLoader
                 libportablethemeengine.ThemeEngine.DefaultDarkTheme = textboxThemePath.Text
                 libportablethemeengine.ThemeEngine.SelectTheme("This shouldn't matter, either.", Me, Me.components)
             End If
+
+            ' Turn off matching system theme settings in case the user chooses another option.
+            libportablethemeengine.ThemeEngine.MatchWindows10ThemeSettings = False
 
         End If
 

--- a/PortableUXLLauncher_ThemeEngine/My Project/AssemblyInfo.vb
+++ b/PortableUXLLauncher_ThemeEngine/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2.0.0.0")>
-<Assembly: AssemblyFileVersion("2.0.0.0")>
+<Assembly: AssemblyVersion("2.1.0.0")>
+<Assembly: AssemblyFileVersion("2.1.0.0")>

--- a/PortableUXLLauncher_ThemeEngine/My Project/Resources.Designer.vb
+++ b/PortableUXLLauncher_ThemeEngine/My Project/Resources.Designer.vb
@@ -71,6 +71,15 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Maudern,ProDark,TenDark.
+        '''</summary>
+        Friend ReadOnly Property darkthemesList() As String
+            Get
+                Return ResourceManager.GetString("darkthemesList", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Default Theme&lt;/Title&gt;
         '''  &lt;Description&gt;Default is the theme UXL Launcher ships with.&lt;/Description&gt;

--- a/PortableUXLLauncher_ThemeEngine/My Project/Resources.resx
+++ b/PortableUXLLauncher_ThemeEngine/My Project/Resources.resx
@@ -637,4 +637,8 @@
   <data name="ProDarkTheme_XML" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\themes\prodarktheme_xml.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="darkthemesList" xml:space="preserve">
+    <value>Maudern,ProDark,TenDark</value>
+    <comment>Dark themes available in case the developer wants to allow changing the default dark theme.</comment>
+  </data>
 </root>

--- a/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
+++ b/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
@@ -124,10 +124,6 @@ Public Class ThemeProperties
     Private Shared _propertyStatusLabelBorderStyle As Border3DStyle
 #End Region
 
-#Region "Theme engine properties that can be set from the calling app."
-
-#End Region
-
 #Region "Theme properties."
 #Region "Theme info."
     ' Theme XML file.

--- a/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
+++ b/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
@@ -422,13 +422,13 @@ Public Class ThemeEngine
 
                 ' Otherwise, load the default dark theme.
                 Case "Dark"
-                    ' Check if the theme specified in My.Settings.defaultDarkTheme is in the
+                    ' Check if the theme specified in ThemeEngine.darkthemeForSystemThemeMatching is in the
                     ' list of available dark themes.
-                    If My.Resources.darkthemesList.Contains(DefaultDarkTheme.ToString) AndAlso My.Resources.ResourceManager.GetString(DefaultDarkTheme & "Theme_XML") IsNot Nothing Then
-                        ThemeProperties.themeSheet.LoadXml(My.Resources.ResourceManager.GetString(DefaultDarkTheme & "Theme_XML"))
+                    If My.Resources.darkthemesList.Contains(DarkThemeForSystemThemeMatching.ToString) AndAlso My.Resources.ResourceManager.GetString(DarkThemeForSystemThemeMatching & "Theme_XML") IsNot Nothing Then
+                        ThemeProperties.themeSheet.LoadXml(My.Resources.ResourceManager.GetString(DarkThemeForSystemThemeMatching & "Theme_XML"))
                         ' Reset default dark theme back to ProDark in case an application wanted to override it but might not
                         ' in the future in the same session.
-                        DefaultDarkTheme = "ProDark"
+                        DarkThemeForSystemThemeMatching = "ProDark"
                     Else
                         ' If we can't find the specified theme, we'll just use ProDark,
                         ' which is the new default in version 2.1.
@@ -1082,7 +1082,7 @@ Public Class ThemeEngine
     ' Whether the calling app wants to match the Windows 10 theme or not.
     Private Shared _matchWindows10ThemeSettings As Boolean = False
     ' Default dark theme when the calling app wants to match the Windows 10 theme settings.
-    Private Shared _defaultDarkTheme As String = "ProDark"
+    Private Shared _darkthemeForSystemThemeMatching As String = "ProDark"
 
     ' Safe color validation.
     Public Shared Property UseSafeColorValidation() As Boolean
@@ -1138,12 +1138,12 @@ Public Class ThemeEngine
     End Property
 
     ' Default dark theme.
-    Public Shared Property DefaultDarkTheme() As String
+    Public Shared Property DarkThemeForSystemThemeMatching() As String
         Get
-            Return _defaultDarkTheme
+            Return _darkthemeForSystemThemeMatching
         End Get
         Set(value As String)
-            _defaultDarkTheme = value
+            _darkthemeForSystemThemeMatching = value
         End Set
     End Property
 

--- a/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
+++ b/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
@@ -426,6 +426,9 @@ Public Class ThemeEngine
                     ' list of available dark themes.
                     If My.Resources.darkthemesList.Contains(DefaultDarkTheme.ToString) AndAlso My.Resources.ResourceManager.GetString(DefaultDarkTheme & "Theme_XML") IsNot Nothing Then
                         ThemeProperties.themeSheet.LoadXml(My.Resources.ResourceManager.GetString(DefaultDarkTheme & "Theme_XML"))
+                        ' Reset default dark theme back to ProDark in case an application wanted to override it but might not
+                        ' in the future in the same session.
+                        DefaultDarkTheme = "ProDark"
                     Else
                         ' If we can't find the specified theme, we'll just use ProDark,
                         ' which is the new default in version 2.1.

--- a/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
+++ b/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
@@ -420,9 +420,17 @@ Public Class ThemeEngine
                 Case "Light"
                     ThemeProperties.themeSheet.LoadXml(My.Resources.DefaultTheme_XML)
 
-                ' Otherwise, load TenDark.
+                ' Otherwise, load the default dark theme.
                 Case "Dark"
-                    ThemeProperties.themeSheet.LoadXml(My.Resources.TenDarkTheme_XML)
+                    ' Check if the theme specified in My.Settings.defaultDarkTheme is in the
+                    ' list of available dark themes.
+                    If My.Resources.darkthemesList.Contains(DefaultDarkTheme.ToString) AndAlso My.Resources.ResourceManager.GetString(DefaultDarkTheme & "Theme_XML") IsNot Nothing Then
+                        ThemeProperties.themeSheet.LoadXml(My.Resources.ResourceManager.GetString(DefaultDarkTheme & "Theme_XML"))
+                    Else
+                        ' If we can't find the specified theme, we'll just use ProDark,
+                        ' which is the new default in version 2.1.
+                        ThemeProperties.themeSheet.LoadXml(My.Resources.ProDarkTheme_XML)
+                    End If
             End Select
 
             ' If the calling app doesn't want to match the Windows 10 theme,
@@ -1070,6 +1078,8 @@ Public Class ThemeEngine
     Private Shared _themeengineAllowCustomThemes As Boolean = True
     ' Whether the calling app wants to match the Windows 10 theme or not.
     Private Shared _matchWindows10ThemeSettings As Boolean = False
+    ' Default dark theme when the calling app wants to match the Windows 10 theme settings.
+    Private Shared _defaultDarkTheme As String = "ProDark"
 
     ' Safe color validation.
     Public Shared Property UseSafeColorValidation() As Boolean
@@ -1121,6 +1131,16 @@ Public Class ThemeEngine
         End Get
         Set(value As Boolean)
             _matchWindows10ThemeSettings = value
+        End Set
+    End Property
+
+    ' Default dark theme.
+    Public Shared Property DefaultDarkTheme() As String
+        Get
+            Return _defaultDarkTheme
+        End Get
+        Set(value As String)
+            _defaultDarkTheme = value
         End Set
     End Property
 

--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -72,7 +72,7 @@
       <setting name="autoupgradeUserSettings" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="defaultDarkTheme" serializeAs="String">
+      <setting name="darkthemeForSystemThemeMatching" serializeAs="String">
         <value>ProDark</value>
       </setting>
     </UXL_Launcher.My.MySettings>

--- a/UXL-Launcher/My Project/Resources.Designer.vb
+++ b/UXL-Launcher/My Project/Resources.Designer.vb
@@ -129,7 +129,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 2020-09-27T00:12:12
+        '''  Looks up a localized string similar to 2020-09-27T00:12:43
         '''.
         '''</summary>
         Public ReadOnly Property BuildDate() As String
@@ -159,7 +159,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to ProDark,TenDark,Maudern.
+        '''  Looks up a localized string similar to Maudern,ProDark,TenDark.
         '''</summary>
         Public ReadOnly Property darkthemesList() As String
             Get

--- a/UXL-Launcher/My Project/Resources.Designer.vb
+++ b/UXL-Launcher/My Project/Resources.Designer.vb
@@ -129,7 +129,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 2020-09-26T08:20:44
+        '''  Looks up a localized string similar to 2020-09-27T00:12:12
         '''.
         '''</summary>
         Public ReadOnly Property BuildDate() As String
@@ -159,7 +159,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to ProDark,TenDark.
+        '''  Looks up a localized string similar to ProDark,TenDark,Maudern.
         '''</summary>
         Public ReadOnly Property darkthemesList() As String
             Get

--- a/UXL-Launcher/My Project/Resources.Designer.vb
+++ b/UXL-Launcher/My Project/Resources.Designer.vb
@@ -129,7 +129,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 2020-09-27T00:12:43
+        '''  Looks up a localized string similar to 2020-09-27T00:51:14
         '''.
         '''</summary>
         Public ReadOnly Property BuildDate() As String
@@ -614,7 +614,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 1.03.
+        '''  Looks up a localized string similar to 1.04.
         '''</summary>
         Public ReadOnly Property themeEngineVersion() As String
             Get

--- a/UXL-Launcher/My Project/Resources.Designer.vb
+++ b/UXL-Launcher/My Project/Resources.Designer.vb
@@ -129,7 +129,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 2020-07-26T20:07:21
+        '''  Looks up a localized string similar to 2020-09-26T08:20:44
         '''.
         '''</summary>
         Public ReadOnly Property BuildDate() As String
@@ -155,6 +155,15 @@ Namespace My.Resources
             Get
                 Dim obj As Object = ResourceManager.GetObject("DARK_UXL_Launcher_Banner", resourceCulture)
                 Return CType(obj,System.Drawing.Bitmap)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to ProDark,TenDark.
+        '''</summary>
+        Public ReadOnly Property darkthemesList() As String
+            Get
+                Return ResourceManager.GetString("darkthemesList", resourceCulture)
             End Get
         End Property
         
@@ -433,16 +442,12 @@ Namespace My.Resources
         
         '''<summary>
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
-        '''  &lt;Title&gt;Pro Dark&lt;/Title&gt;
-        '''  &lt;Description&gt;Dark theme meant to resemble Office 2019&apos;s &quot;Black&quot; theme.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.0&lt;/Version&gt;
-        '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
+        '''	  &lt;Title&gt;Pro Dark&lt;/Title&gt;
+        '''	  &lt;Description&gt;Dark theme meant to resemble Office 2019&apos;s &quot;Black&quot; theme. The colors may not match exactly as they were eyeballed from the colors used in Word 2019. This theme is not associated with Microsoft, and Microsoft Office is a copyright and trademark/registered trademark of Microsoft Corporation in the United States and other countries.&lt;/Description&gt;
+        '''	  &lt;Version&gt;v1.0&lt;/Version&gt;
+        '''	  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
-        '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
-        '''  UXL Launcher Theme Engine to use in case there are changes in newer
-        '''  versions of the theme engine that designers or developers don&apos;t want
-        '''  to use. Version 1.01 is the oldest version number available and anything
-        '''  smaller than that will  [rest of string was truncated]&quot;;.
+        '''	  &lt;!-- &quot;UseThemeEngineVersion&quot; is u [rest of string was truncated]&quot;;.
         '''</summary>
         Public ReadOnly Property ProDarkTheme_XML() As String
             Get

--- a/UXL-Launcher/My Project/Resources.resx
+++ b/UXL-Launcher/My Project/Resources.resx
@@ -1792,7 +1792,7 @@ This decimal is to be used for the About window when talking about what version 
     <value>..\vb code-behind\themes\prodarktheme_xml.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="darkthemesList" xml:space="preserve">
-    <value>ProDark,TenDark,Maudern</value>
+    <value>Maudern,ProDark,TenDark</value>
     <comment>Dark themes available in the "default dark theme" dropdown in the Theme tab.</comment>
   </data>
 </root>

--- a/UXL-Launcher/My Project/Resources.resx
+++ b/UXL-Launcher/My Project/Resources.resx
@@ -1791,4 +1791,8 @@ This decimal is to be used for the About window when talking about what version 
   <data name="ProDarkTheme_XML" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\vb code-behind\themes\prodarktheme_xml.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
+  <data name="darkthemesList" xml:space="preserve">
+    <value>ProDark,TenDark</value>
+    <comment>Dark themes available in the "default dark theme" dropdown in the Theme tab.</comment>
+  </data>
 </root>

--- a/UXL-Launcher/My Project/Resources.resx
+++ b/UXL-Launcher/My Project/Resources.resx
@@ -1792,7 +1792,7 @@ This decimal is to be used for the About window when talking about what version 
     <value>..\vb code-behind\themes\prodarktheme_xml.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="darkthemesList" xml:space="preserve">
-    <value>ProDark,TenDark</value>
+    <value>ProDark,TenDark,Maudern</value>
     <comment>Dark themes available in the "default dark theme" dropdown in the Theme tab.</comment>
   </data>
 </root>

--- a/UXL-Launcher/My Project/Resources.resx
+++ b/UXL-Launcher/My Project/Resources.resx
@@ -128,7 +128,7 @@
     <value>..\vb code-behind\themes\defaulttheme_xml.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>
   <data name="themeEngineVersion" xml:space="preserve">
-    <value>1.03</value>
+    <value>1.04</value>
     <comment>This is the version of the UXL Launcher Theme Engine included with this version of UXL Launcher. The first version of the theme engine that's available is version 1.01 and debuted in UXL Launcher Version 3.1. When anything changes in the UXL Launcher Theme Engine, the "y-value" (1.01; x.y; 1=x, 01=y) will be increased. When a breaking change is implemented into the theme engine, the "x-value" will be increased.
 
 This decimal number exists just in case themes want to specify a version of the theme engine they're compatible with. By doing this, certain features can be used by the theme if those features were introduced in newer versions of the theme engine and might change how the theme behaves when that change is used.

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -285,12 +285,12 @@ Namespace My
         <Global.System.Configuration.UserScopedSettingAttribute(),  _
          Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
          Global.System.Configuration.DefaultSettingValueAttribute("ProDark")>  _
-        Public Property defaultDarkTheme() As String
+        Public Property darkthemeForSystemThemeMatching() As String
             Get
-                Return CType(Me("defaultDarkTheme"),String)
+                Return CType(Me("darkthemeForSystemThemeMatching"),String)
             End Get
             Set
-                Me("defaultDarkTheme") = value
+                Me("darkthemeForSystemThemeMatching") = value
             End Set
         End Property
     End Class

--- a/UXL-Launcher/My Project/Settings.settings
+++ b/UXL-Launcher/My Project/Settings.settings
@@ -59,7 +59,7 @@
     <Setting Name="autoupgradeUserSettings" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="defaultDarkTheme" Type="System.String" Scope="User">
+    <Setting Name="darkthemeForSystemThemeMatching" Type="System.String" Scope="User">
       <Value Profile="(Default)">ProDark</Value>
     </Setting>
   </Settings>

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -35,6 +35,7 @@ Partial Class aaformOptionsWindow
         Me.radiobuttonDontBypassConfiguredLocation = New System.Windows.Forms.RadioButton()
         Me.labelBypassConfiguredLocation = New System.Windows.Forms.Label()
         Me.groupboxOfficeVersion = New System.Windows.Forms.GroupBox()
+        Me.labelOffice365Compatibility = New System.Windows.Forms.Label()
         Me.checkboxO365InstallMethod = New System.Windows.Forms.CheckBox()
         Me.labelUserHasThisOfficeVersion = New System.Windows.Forms.Label()
         Me.comboboxOfficeVersionSelector = New System.Windows.Forms.ComboBox()
@@ -50,6 +51,9 @@ Partial Class aaformOptionsWindow
         Me.radiobuttonUseProgramFiles = New System.Windows.Forms.RadioButton()
         Me.labelPFPathDescription = New System.Windows.Forms.Label()
         Me.tabpagePersonalization = New System.Windows.Forms.TabPage()
+        Me.groupboxDefaultDarkTheme = New System.Windows.Forms.GroupBox()
+        Me.comboboxDefaultDarkThemesList = New System.Windows.Forms.ComboBox()
+        Me.labelDefaultDarkThemeDescription = New System.Windows.Forms.Label()
         Me.groupboxAppearance = New System.Windows.Forms.GroupBox()
         Me.checkboxMatchWindows10ThemeSettings = New System.Windows.Forms.CheckBox()
         Me.labelCustomThemePath = New System.Windows.Forms.Label()
@@ -74,9 +78,6 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
-        Me.groupboxDefaultDarkTheme = New System.Windows.Forms.GroupBox()
-        Me.labelDefaultDarkThemeDescription = New System.Windows.Forms.Label()
-        Me.comboboxDefaultDarkThemesList = New System.Windows.Forms.ComboBox()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -86,10 +87,10 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeLocation.SuspendLayout()
         Me.groupboxCPUType.SuspendLayout()
         Me.tabpagePersonalization.SuspendLayout()
+        Me.groupboxDefaultDarkTheme.SuspendLayout()
         Me.groupboxAppearance.SuspendLayout()
         Me.tabpageStatusbar.SuspendLayout()
         Me.groupboxStatusbar.SuspendLayout()
-        Me.groupboxDefaultDarkTheme.SuspendLayout()
         Me.SuspendLayout()
         '
         'tableLayoutPanelOptionsWindow
@@ -226,6 +227,7 @@ Partial Class aaformOptionsWindow
         '
         'groupboxOfficeVersion
         '
+        Me.groupboxOfficeVersion.Controls.Add(Me.labelOffice365Compatibility)
         Me.groupboxOfficeVersion.Controls.Add(Me.checkboxO365InstallMethod)
         Me.groupboxOfficeVersion.Controls.Add(Me.labelUserHasThisOfficeVersion)
         Me.groupboxOfficeVersion.Controls.Add(Me.comboboxOfficeVersionSelector)
@@ -238,11 +240,21 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeVersion.TabStop = False
         Me.groupboxOfficeVersion.Text = "Microsoft Office versions + C2R"
         '
+        'labelOffice365Compatibility
+        '
+        Me.labelOffice365Compatibility.AutoSize = True
+        Me.labelOffice365Compatibility.Location = New System.Drawing.Point(76, 64)
+        Me.labelOffice365Compatibility.Name = "labelOffice365Compatibility"
+        Me.labelOffice365Compatibility.Size = New System.Drawing.Size(272, 26)
+        Me.labelOffice365Compatibility.TabIndex = 6
+        Me.labelOffice365Compatibility.Text = "Most people install Office from Office 365/Microsoft 365," & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "so you may need to che" &
+    "ck this box:"
+        '
         'checkboxO365InstallMethod
         '
         Me.checkboxO365InstallMethod.AutoSize = True
         Me.checkboxO365InstallMethod.CheckAlign = System.Drawing.ContentAlignment.TopLeft
-        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(79, 81)
+        Me.checkboxO365InstallMethod.Location = New System.Drawing.Point(79, 92)
         Me.checkboxO365InstallMethod.Margin = New System.Windows.Forms.Padding(2)
         Me.checkboxO365InstallMethod.Name = "checkboxO365InstallMethod"
         Me.checkboxO365InstallMethod.Size = New System.Drawing.Size(235, 30)
@@ -255,7 +267,7 @@ Partial Class aaformOptionsWindow
         'labelUserHasThisOfficeVersion
         '
         Me.labelUserHasThisOfficeVersion.AutoSize = True
-        Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(76, 27)
+        Me.labelUserHasThisOfficeVersion.Location = New System.Drawing.Point(76, 16)
         Me.labelUserHasThisOfficeVersion.Margin = New System.Windows.Forms.Padding(2, 0, 2, 0)
         Me.labelUserHasThisOfficeVersion.Name = "labelUserHasThisOfficeVersion"
         Me.labelUserHasThisOfficeVersion.Size = New System.Drawing.Size(263, 13)
@@ -266,7 +278,7 @@ Partial Class aaformOptionsWindow
         '
         Me.comboboxOfficeVersionSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
         Me.comboboxOfficeVersionSelector.FormattingEnabled = True
-        Me.comboboxOfficeVersionSelector.Location = New System.Drawing.Point(79, 42)
+        Me.comboboxOfficeVersionSelector.Location = New System.Drawing.Point(79, 31)
         Me.comboboxOfficeVersionSelector.Margin = New System.Windows.Forms.Padding(2)
         Me.comboboxOfficeVersionSelector.Name = "comboboxOfficeVersionSelector"
         Me.comboboxOfficeVersionSelector.Size = New System.Drawing.Size(138, 21)
@@ -413,6 +425,35 @@ Partial Class aaformOptionsWindow
         Me.tabpagePersonalization.TabIndex = 2
         Me.tabpagePersonalization.Text = "Theme"
         Me.tabpagePersonalization.UseVisualStyleBackColor = True
+        '
+        'groupboxDefaultDarkTheme
+        '
+        Me.groupboxDefaultDarkTheme.Controls.Add(Me.comboboxDefaultDarkThemesList)
+        Me.groupboxDefaultDarkTheme.Controls.Add(Me.labelDefaultDarkThemeDescription)
+        Me.groupboxDefaultDarkTheme.Location = New System.Drawing.Point(4, 194)
+        Me.groupboxDefaultDarkTheme.Name = "groupboxDefaultDarkTheme"
+        Me.groupboxDefaultDarkTheme.Size = New System.Drawing.Size(415, 127)
+        Me.groupboxDefaultDarkTheme.TabIndex = 1
+        Me.groupboxDefaultDarkTheme.TabStop = False
+        Me.groupboxDefaultDarkTheme.Text = "Default dark theme"
+        '
+        'comboboxDefaultDarkThemesList
+        '
+        Me.comboboxDefaultDarkThemesList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDefaultDarkThemesList.FormattingEnabled = True
+        Me.comboboxDefaultDarkThemesList.Location = New System.Drawing.Point(15, 61)
+        Me.comboboxDefaultDarkThemesList.Name = "comboboxDefaultDarkThemesList"
+        Me.comboboxDefaultDarkThemesList.Size = New System.Drawing.Size(195, 21)
+        Me.comboboxDefaultDarkThemesList.TabIndex = 1
+        '
+        'labelDefaultDarkThemeDescription
+        '
+        Me.labelDefaultDarkThemeDescription.AutoSize = True
+        Me.labelDefaultDarkThemeDescription.Location = New System.Drawing.Point(12, 44)
+        Me.labelDefaultDarkThemeDescription.Name = "labelDefaultDarkThemeDescription"
+        Me.labelDefaultDarkThemeDescription.Size = New System.Drawing.Size(390, 13)
+        Me.labelDefaultDarkThemeDescription.TabIndex = 0
+        Me.labelDefaultDarkThemeDescription.Text = "When matching Windows 10 theme settings is enabled, we'll use this dark theme:"
         '
         'groupboxAppearance
         '
@@ -646,35 +687,6 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
-        'groupboxDefaultDarkTheme
-        '
-        Me.groupboxDefaultDarkTheme.Controls.Add(Me.comboboxDefaultDarkThemesList)
-        Me.groupboxDefaultDarkTheme.Controls.Add(Me.labelDefaultDarkThemeDescription)
-        Me.groupboxDefaultDarkTheme.Location = New System.Drawing.Point(4, 194)
-        Me.groupboxDefaultDarkTheme.Name = "groupboxDefaultDarkTheme"
-        Me.groupboxDefaultDarkTheme.Size = New System.Drawing.Size(415, 127)
-        Me.groupboxDefaultDarkTheme.TabIndex = 1
-        Me.groupboxDefaultDarkTheme.TabStop = False
-        Me.groupboxDefaultDarkTheme.Text = "Default dark theme"
-        '
-        'labelDefaultDarkThemeDescription
-        '
-        Me.labelDefaultDarkThemeDescription.AutoSize = True
-        Me.labelDefaultDarkThemeDescription.Location = New System.Drawing.Point(12, 44)
-        Me.labelDefaultDarkThemeDescription.Name = "labelDefaultDarkThemeDescription"
-        Me.labelDefaultDarkThemeDescription.Size = New System.Drawing.Size(390, 13)
-        Me.labelDefaultDarkThemeDescription.TabIndex = 0
-        Me.labelDefaultDarkThemeDescription.Text = "When matching Windows 10 theme settings is enabled, we'll use this dark theme:"
-        '
-        'comboboxDefaultDarkThemesList
-        '
-        Me.comboboxDefaultDarkThemesList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-        Me.comboboxDefaultDarkThemesList.FormattingEnabled = True
-        Me.comboboxDefaultDarkThemesList.Location = New System.Drawing.Point(15, 61)
-        Me.comboboxDefaultDarkThemesList.Name = "comboboxDefaultDarkThemesList"
-        Me.comboboxDefaultDarkThemesList.Size = New System.Drawing.Size(195, 21)
-        Me.comboboxDefaultDarkThemesList.TabIndex = 1
-        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -704,13 +716,13 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType.ResumeLayout(False)
         Me.groupboxCPUType.PerformLayout()
         Me.tabpagePersonalization.ResumeLayout(False)
+        Me.groupboxDefaultDarkTheme.ResumeLayout(False)
+        Me.groupboxDefaultDarkTheme.PerformLayout()
         Me.groupboxAppearance.ResumeLayout(False)
         Me.groupboxAppearance.PerformLayout()
         Me.tabpageStatusbar.ResumeLayout(False)
         Me.groupboxStatusbar.ResumeLayout(False)
         Me.groupboxStatusbar.PerformLayout()
-        Me.groupboxDefaultDarkTheme.ResumeLayout(False)
-        Me.groupboxDefaultDarkTheme.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -768,4 +780,5 @@ Partial Class aaformOptionsWindow
     Friend WithEvents groupboxDefaultDarkTheme As GroupBox
     Friend WithEvents labelDefaultDarkThemeDescription As Label
     Friend WithEvents comboboxDefaultDarkThemesList As ComboBox
+    Friend WithEvents labelOffice365Compatibility As Label
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -50,13 +50,6 @@ Partial Class aaformOptionsWindow
         Me.radiobuttonUseProgramFiles = New System.Windows.Forms.RadioButton()
         Me.labelPFPathDescription = New System.Windows.Forms.Label()
         Me.tabpagePersonalization = New System.Windows.Forms.TabPage()
-        Me.groupboxStatusbar = New System.Windows.Forms.GroupBox()
-        Me.buttonClearFirstname = New System.Windows.Forms.Button()
-        Me.labelFirstName = New System.Windows.Forms.Label()
-        Me.textboxFirstname = New System.Windows.Forms.TextBox()
-        Me.radiobuttonCustomStatusbarGreeting = New System.Windows.Forms.RadioButton()
-        Me.radiobuttonDefaultStatusbarGreeting = New System.Windows.Forms.RadioButton()
-        Me.labelCustomStatusbarGreeting = New System.Windows.Forms.Label()
         Me.groupboxAppearance = New System.Windows.Forms.GroupBox()
         Me.checkboxMatchWindows10ThemeSettings = New System.Windows.Forms.CheckBox()
         Me.labelCustomThemePath = New System.Windows.Forms.Label()
@@ -73,6 +66,14 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
+        Me.tabpageStatusbar = New System.Windows.Forms.TabPage()
+        Me.groupboxStatusbar = New System.Windows.Forms.GroupBox()
+        Me.buttonClearFirstname = New System.Windows.Forms.Button()
+        Me.labelFirstName = New System.Windows.Forms.Label()
+        Me.textboxFirstname = New System.Windows.Forms.TextBox()
+        Me.radiobuttonCustomStatusbarGreeting = New System.Windows.Forms.RadioButton()
+        Me.radiobuttonDefaultStatusbarGreeting = New System.Windows.Forms.RadioButton()
+        Me.labelCustomStatusbarGreeting = New System.Windows.Forms.Label()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -82,8 +83,9 @@ Partial Class aaformOptionsWindow
         Me.groupboxOfficeLocation.SuspendLayout()
         Me.groupboxCPUType.SuspendLayout()
         Me.tabpagePersonalization.SuspendLayout()
-        Me.groupboxStatusbar.SuspendLayout()
         Me.groupboxAppearance.SuspendLayout()
+        Me.tabpageStatusbar.SuspendLayout()
+        Me.groupboxStatusbar.SuspendLayout()
         Me.SuspendLayout()
         '
         'tableLayoutPanelOptionsWindow
@@ -140,6 +142,7 @@ Partial Class aaformOptionsWindow
         Me.tabcontrolOptionsWindow.Controls.Add(Me.tabpageGeneral)
         Me.tabcontrolOptionsWindow.Controls.Add(Me.tabpageAdvanced)
         Me.tabcontrolOptionsWindow.Controls.Add(Me.tabpagePersonalization)
+        Me.tabcontrolOptionsWindow.Controls.Add(Me.tabpageStatusbar)
         Me.tabcontrolOptionsWindow.Dock = System.Windows.Forms.DockStyle.Fill
         Me.tabcontrolOptionsWindow.Location = New System.Drawing.Point(8, 8)
         Me.tabcontrolOptionsWindow.Margin = New System.Windows.Forms.Padding(8, 8, 8, 2)
@@ -396,7 +399,6 @@ Partial Class aaformOptionsWindow
         '
         'tabpagePersonalization
         '
-        Me.tabpagePersonalization.Controls.Add(Me.groupboxStatusbar)
         Me.tabpagePersonalization.Controls.Add(Me.groupboxAppearance)
         Me.tabpagePersonalization.Location = New System.Drawing.Point(4, 22)
         Me.tabpagePersonalization.Margin = New System.Windows.Forms.Padding(2)
@@ -404,81 +406,8 @@ Partial Class aaformOptionsWindow
         Me.tabpagePersonalization.Padding = New System.Windows.Forms.Padding(2)
         Me.tabpagePersonalization.Size = New System.Drawing.Size(422, 326)
         Me.tabpagePersonalization.TabIndex = 2
-        Me.tabpagePersonalization.Text = "Personalization"
+        Me.tabpagePersonalization.Text = "Theme"
         Me.tabpagePersonalization.UseVisualStyleBackColor = True
-        '
-        'groupboxStatusbar
-        '
-        Me.groupboxStatusbar.Controls.Add(Me.buttonClearFirstname)
-        Me.groupboxStatusbar.Controls.Add(Me.labelFirstName)
-        Me.groupboxStatusbar.Controls.Add(Me.textboxFirstname)
-        Me.groupboxStatusbar.Controls.Add(Me.radiobuttonCustomStatusbarGreeting)
-        Me.groupboxStatusbar.Controls.Add(Me.radiobuttonDefaultStatusbarGreeting)
-        Me.groupboxStatusbar.Controls.Add(Me.labelCustomStatusbarGreeting)
-        Me.groupboxStatusbar.Location = New System.Drawing.Point(4, 192)
-        Me.groupboxStatusbar.Margin = New System.Windows.Forms.Padding(2)
-        Me.groupboxStatusbar.Name = "groupboxStatusbar"
-        Me.groupboxStatusbar.Size = New System.Drawing.Size(415, 130)
-        Me.groupboxStatusbar.TabIndex = 1
-        Me.groupboxStatusbar.TabStop = False
-        Me.groupboxStatusbar.Text = "Statusbar"
-        '
-        'buttonClearFirstname
-        '
-        Me.buttonClearFirstname.Location = New System.Drawing.Point(339, 100)
-        Me.buttonClearFirstname.Name = "buttonClearFirstname"
-        Me.buttonClearFirstname.Size = New System.Drawing.Size(55, 23)
-        Me.buttonClearFirstname.TabIndex = 5
-        Me.buttonClearFirstname.Text = "Clear"
-        Me.buttonClearFirstname.UseVisualStyleBackColor = True
-        '
-        'labelFirstName
-        '
-        Me.labelFirstName.AutoSize = True
-        Me.labelFirstName.Location = New System.Drawing.Point(25, 105)
-        Me.labelFirstName.Name = "labelFirstName"
-        Me.labelFirstName.Size = New System.Drawing.Size(106, 13)
-        Me.labelFirstName.TabIndex = 4
-        Me.labelFirstName.Text = "Firstname/nickname:"
-        '
-        'textboxFirstname
-        '
-        Me.textboxFirstname.Location = New System.Drawing.Point(140, 102)
-        Me.textboxFirstname.Name = "textboxFirstname"
-        Me.textboxFirstname.Size = New System.Drawing.Size(193, 20)
-        Me.textboxFirstname.TabIndex = 3
-        '
-        'radiobuttonCustomStatusbarGreeting
-        '
-        Me.radiobuttonCustomStatusbarGreeting.AutoSize = True
-        Me.radiobuttonCustomStatusbarGreeting.Location = New System.Drawing.Point(26, 79)
-        Me.radiobuttonCustomStatusbarGreeting.Name = "radiobuttonCustomStatusbarGreeting"
-        Me.radiobuttonCustomStatusbarGreeting.Size = New System.Drawing.Size(193, 17)
-        Me.radiobuttonCustomStatusbarGreeting.TabIndex = 2
-        Me.radiobuttonCustomStatusbarGreeting.TabStop = True
-        Me.radiobuttonCustomStatusbarGreeting.Text = "Use personalized statusbar greeting"
-        Me.radiobuttonCustomStatusbarGreeting.UseVisualStyleBackColor = True
-        '
-        'radiobuttonDefaultStatusbarGreeting
-        '
-        Me.radiobuttonDefaultStatusbarGreeting.AutoSize = True
-        Me.radiobuttonDefaultStatusbarGreeting.Location = New System.Drawing.Point(26, 56)
-        Me.radiobuttonDefaultStatusbarGreeting.Name = "radiobuttonDefaultStatusbarGreeting"
-        Me.radiobuttonDefaultStatusbarGreeting.Size = New System.Drawing.Size(166, 17)
-        Me.radiobuttonDefaultStatusbarGreeting.TabIndex = 1
-        Me.radiobuttonDefaultStatusbarGreeting.TabStop = True
-        Me.radiobuttonDefaultStatusbarGreeting.Text = "Use default statusbar greeting"
-        Me.radiobuttonDefaultStatusbarGreeting.UseVisualStyleBackColor = True
-        '
-        'labelCustomStatusbarGreeting
-        '
-        Me.labelCustomStatusbarGreeting.AutoSize = True
-        Me.labelCustomStatusbarGreeting.Location = New System.Drawing.Point(10, 15)
-        Me.labelCustomStatusbarGreeting.Name = "labelCustomStatusbarGreeting"
-        Me.labelCustomStatusbarGreeting.Size = New System.Drawing.Size(369, 26)
-        Me.labelCustomStatusbarGreeting.TabIndex = 0
-        Me.labelCustomStatusbarGreeting.Text = "You can choose to use a statusbar greeting personalized with your firstname" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "or n" &
-    "ickname, or to use the default. Your name will not be used to identify you."
         '
         'groupboxAppearance
         '
@@ -628,6 +557,90 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
+        'tabpageStatusbar
+        '
+        Me.tabpageStatusbar.Controls.Add(Me.groupboxStatusbar)
+        Me.tabpageStatusbar.Location = New System.Drawing.Point(4, 22)
+        Me.tabpageStatusbar.Name = "tabpageStatusbar"
+        Me.tabpageStatusbar.Padding = New System.Windows.Forms.Padding(3)
+        Me.tabpageStatusbar.Size = New System.Drawing.Size(422, 326)
+        Me.tabpageStatusbar.TabIndex = 3
+        Me.tabpageStatusbar.Text = "Statusbar"
+        Me.tabpageStatusbar.UseVisualStyleBackColor = True
+        '
+        'groupboxStatusbar
+        '
+        Me.groupboxStatusbar.Controls.Add(Me.buttonClearFirstname)
+        Me.groupboxStatusbar.Controls.Add(Me.labelFirstName)
+        Me.groupboxStatusbar.Controls.Add(Me.textboxFirstname)
+        Me.groupboxStatusbar.Controls.Add(Me.radiobuttonCustomStatusbarGreeting)
+        Me.groupboxStatusbar.Controls.Add(Me.radiobuttonDefaultStatusbarGreeting)
+        Me.groupboxStatusbar.Controls.Add(Me.labelCustomStatusbarGreeting)
+        Me.groupboxStatusbar.Location = New System.Drawing.Point(4, 4)
+        Me.groupboxStatusbar.Margin = New System.Windows.Forms.Padding(2)
+        Me.groupboxStatusbar.Name = "groupboxStatusbar"
+        Me.groupboxStatusbar.Size = New System.Drawing.Size(415, 130)
+        Me.groupboxStatusbar.TabIndex = 2
+        Me.groupboxStatusbar.TabStop = False
+        Me.groupboxStatusbar.Text = "Statusbar"
+        '
+        'buttonClearFirstname
+        '
+        Me.buttonClearFirstname.Location = New System.Drawing.Point(339, 100)
+        Me.buttonClearFirstname.Name = "buttonClearFirstname"
+        Me.buttonClearFirstname.Size = New System.Drawing.Size(55, 23)
+        Me.buttonClearFirstname.TabIndex = 5
+        Me.buttonClearFirstname.Text = "Clear"
+        Me.buttonClearFirstname.UseVisualStyleBackColor = True
+        '
+        'labelFirstName
+        '
+        Me.labelFirstName.AutoSize = True
+        Me.labelFirstName.Location = New System.Drawing.Point(25, 105)
+        Me.labelFirstName.Name = "labelFirstName"
+        Me.labelFirstName.Size = New System.Drawing.Size(106, 13)
+        Me.labelFirstName.TabIndex = 4
+        Me.labelFirstName.Text = "Firstname/nickname:"
+        '
+        'textboxFirstname
+        '
+        Me.textboxFirstname.Location = New System.Drawing.Point(140, 102)
+        Me.textboxFirstname.Name = "textboxFirstname"
+        Me.textboxFirstname.Size = New System.Drawing.Size(193, 20)
+        Me.textboxFirstname.TabIndex = 3
+        '
+        'radiobuttonCustomStatusbarGreeting
+        '
+        Me.radiobuttonCustomStatusbarGreeting.AutoSize = True
+        Me.radiobuttonCustomStatusbarGreeting.Location = New System.Drawing.Point(26, 79)
+        Me.radiobuttonCustomStatusbarGreeting.Name = "radiobuttonCustomStatusbarGreeting"
+        Me.radiobuttonCustomStatusbarGreeting.Size = New System.Drawing.Size(193, 17)
+        Me.radiobuttonCustomStatusbarGreeting.TabIndex = 2
+        Me.radiobuttonCustomStatusbarGreeting.TabStop = True
+        Me.radiobuttonCustomStatusbarGreeting.Text = "Use personalized statusbar greeting"
+        Me.radiobuttonCustomStatusbarGreeting.UseVisualStyleBackColor = True
+        '
+        'radiobuttonDefaultStatusbarGreeting
+        '
+        Me.radiobuttonDefaultStatusbarGreeting.AutoSize = True
+        Me.radiobuttonDefaultStatusbarGreeting.Location = New System.Drawing.Point(26, 56)
+        Me.radiobuttonDefaultStatusbarGreeting.Name = "radiobuttonDefaultStatusbarGreeting"
+        Me.radiobuttonDefaultStatusbarGreeting.Size = New System.Drawing.Size(166, 17)
+        Me.radiobuttonDefaultStatusbarGreeting.TabIndex = 1
+        Me.radiobuttonDefaultStatusbarGreeting.TabStop = True
+        Me.radiobuttonDefaultStatusbarGreeting.Text = "Use default statusbar greeting"
+        Me.radiobuttonDefaultStatusbarGreeting.UseVisualStyleBackColor = True
+        '
+        'labelCustomStatusbarGreeting
+        '
+        Me.labelCustomStatusbarGreeting.AutoSize = True
+        Me.labelCustomStatusbarGreeting.Location = New System.Drawing.Point(10, 15)
+        Me.labelCustomStatusbarGreeting.Name = "labelCustomStatusbarGreeting"
+        Me.labelCustomStatusbarGreeting.Size = New System.Drawing.Size(369, 26)
+        Me.labelCustomStatusbarGreeting.TabIndex = 0
+        Me.labelCustomStatusbarGreeting.Text = "You can choose to use a statusbar greeting personalized with your firstname" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "or n" &
+    "ickname, or to use the default. Your name will not be used to identify you."
+        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -657,10 +670,11 @@ Partial Class aaformOptionsWindow
         Me.groupboxCPUType.ResumeLayout(False)
         Me.groupboxCPUType.PerformLayout()
         Me.tabpagePersonalization.ResumeLayout(False)
-        Me.groupboxStatusbar.ResumeLayout(False)
-        Me.groupboxStatusbar.PerformLayout()
         Me.groupboxAppearance.ResumeLayout(False)
         Me.groupboxAppearance.PerformLayout()
+        Me.tabpageStatusbar.ResumeLayout(False)
+        Me.groupboxStatusbar.ResumeLayout(False)
+        Me.groupboxStatusbar.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -693,13 +707,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents buttonCustomThemesBrowse As Button
     Friend WithEvents textboxCustomThemePath As TextBox
     Friend WithEvents labelCustomThemePath As Label
-    Friend WithEvents groupboxStatusbar As GroupBox
-    Friend WithEvents labelCustomStatusbarGreeting As Label
-    Friend WithEvents radiobuttonCustomStatusbarGreeting As RadioButton
-    Friend WithEvents radiobuttonDefaultStatusbarGreeting As RadioButton
-    Friend WithEvents textboxFirstname As TextBox
-    Friend WithEvents labelFirstName As Label
-    Friend WithEvents buttonClearFirstname As Button
     Friend WithEvents openfiledialogBrowseCustomThemeFile As OpenFileDialog
     Friend WithEvents labelRecommendedWindowsEdition As Label
     Friend WithEvents tooltipCustomThemePath As ToolTip
@@ -714,4 +721,12 @@ Partial Class aaformOptionsWindow
     Friend WithEvents comboboxDriveSelector As ComboBox
     Friend WithEvents labelDriveTextboxLabel As Label
     Friend WithEvents labelOfficeInstalledToDrive As Label
+    Friend WithEvents tabpageStatusbar As TabPage
+    Friend WithEvents groupboxStatusbar As GroupBox
+    Friend WithEvents buttonClearFirstname As Button
+    Friend WithEvents labelFirstName As Label
+    Friend WithEvents textboxFirstname As TextBox
+    Friend WithEvents radiobuttonCustomStatusbarGreeting As RadioButton
+    Friend WithEvents radiobuttonDefaultStatusbarGreeting As RadioButton
+    Friend WithEvents labelCustomStatusbarGreeting As Label
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -52,7 +52,7 @@ Partial Class aaformOptionsWindow
         Me.labelPFPathDescription = New System.Windows.Forms.Label()
         Me.tabpagePersonalization = New System.Windows.Forms.TabPage()
         Me.groupboxDefaultDarkTheme = New System.Windows.Forms.GroupBox()
-        Me.comboboxDefaultDarkThemesList = New System.Windows.Forms.ComboBox()
+        Me.comboboxDarkThemesForSystemThemeMatchingList = New System.Windows.Forms.ComboBox()
         Me.labelDefaultDarkThemeDescription = New System.Windows.Forms.Label()
         Me.groupboxAppearance = New System.Windows.Forms.GroupBox()
         Me.checkboxMatchWindows10ThemeSettings = New System.Windows.Forms.CheckBox()
@@ -428,23 +428,23 @@ Partial Class aaformOptionsWindow
         '
         'groupboxDefaultDarkTheme
         '
-        Me.groupboxDefaultDarkTheme.Controls.Add(Me.comboboxDefaultDarkThemesList)
+        Me.groupboxDefaultDarkTheme.Controls.Add(Me.comboboxDarkThemesForSystemThemeMatchingList)
         Me.groupboxDefaultDarkTheme.Controls.Add(Me.labelDefaultDarkThemeDescription)
         Me.groupboxDefaultDarkTheme.Location = New System.Drawing.Point(4, 194)
         Me.groupboxDefaultDarkTheme.Name = "groupboxDefaultDarkTheme"
         Me.groupboxDefaultDarkTheme.Size = New System.Drawing.Size(415, 127)
         Me.groupboxDefaultDarkTheme.TabIndex = 1
         Me.groupboxDefaultDarkTheme.TabStop = False
-        Me.groupboxDefaultDarkTheme.Text = "Default dark theme"
+        Me.groupboxDefaultDarkTheme.Text = "Dark theme for system theme matching"
         '
-        'comboboxDefaultDarkThemesList
+        'comboboxDarkThemesForSystemThemeMatchingList
         '
-        Me.comboboxDefaultDarkThemesList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
-        Me.comboboxDefaultDarkThemesList.FormattingEnabled = True
-        Me.comboboxDefaultDarkThemesList.Location = New System.Drawing.Point(15, 61)
-        Me.comboboxDefaultDarkThemesList.Name = "comboboxDefaultDarkThemesList"
-        Me.comboboxDefaultDarkThemesList.Size = New System.Drawing.Size(195, 21)
-        Me.comboboxDefaultDarkThemesList.TabIndex = 1
+        Me.comboboxDarkThemesForSystemThemeMatchingList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDarkThemesForSystemThemeMatchingList.FormattingEnabled = True
+        Me.comboboxDarkThemesForSystemThemeMatchingList.Location = New System.Drawing.Point(15, 61)
+        Me.comboboxDarkThemesForSystemThemeMatchingList.Name = "comboboxDarkThemesForSystemThemeMatchingList"
+        Me.comboboxDarkThemesForSystemThemeMatchingList.Size = New System.Drawing.Size(195, 21)
+        Me.comboboxDarkThemesForSystemThemeMatchingList.TabIndex = 1
         '
         'labelDefaultDarkThemeDescription
         '
@@ -779,6 +779,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents labelCustomStatusbarGreeting As Label
     Friend WithEvents groupboxDefaultDarkTheme As GroupBox
     Friend WithEvents labelDefaultDarkThemeDescription As Label
-    Friend WithEvents comboboxDefaultDarkThemesList As ComboBox
+    Friend WithEvents comboboxDarkThemesForSystemThemeMatchingList As ComboBox
     Friend WithEvents labelOffice365Compatibility As Label
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -74,6 +74,7 @@ Partial Class aaformOptionsWindow
         Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
+        Me.groupboxDefaultDarkTheme = New System.Windows.Forms.GroupBox()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -399,6 +400,7 @@ Partial Class aaformOptionsWindow
         '
         'tabpagePersonalization
         '
+        Me.tabpagePersonalization.Controls.Add(Me.groupboxDefaultDarkTheme)
         Me.tabpagePersonalization.Controls.Add(Me.groupboxAppearance)
         Me.tabpagePersonalization.Location = New System.Drawing.Point(4, 22)
         Me.tabpagePersonalization.Margin = New System.Windows.Forms.Padding(2)
@@ -641,6 +643,15 @@ Partial Class aaformOptionsWindow
         Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
         Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
+        'groupboxDefaultDarkTheme
+        '
+        Me.groupboxDefaultDarkTheme.Location = New System.Drawing.Point(4, 194)
+        Me.groupboxDefaultDarkTheme.Name = "groupboxDefaultDarkTheme"
+        Me.groupboxDefaultDarkTheme.Size = New System.Drawing.Size(415, 127)
+        Me.groupboxDefaultDarkTheme.TabIndex = 1
+        Me.groupboxDefaultDarkTheme.TabStop = False
+        Me.groupboxDefaultDarkTheme.Text = "Default dark theme"
+        '
         'aaformOptionsWindow
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -729,4 +740,5 @@ Partial Class aaformOptionsWindow
     Friend WithEvents radiobuttonCustomStatusbarGreeting As RadioButton
     Friend WithEvents radiobuttonDefaultStatusbarGreeting As RadioButton
     Friend WithEvents labelCustomStatusbarGreeting As Label
+    Friend WithEvents groupboxDefaultDarkTheme As GroupBox
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -75,6 +75,8 @@ Partial Class aaformOptionsWindow
         Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
         Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
         Me.groupboxDefaultDarkTheme = New System.Windows.Forms.GroupBox()
+        Me.labelDefaultDarkThemeDescription = New System.Windows.Forms.Label()
+        Me.comboboxDefaultDarkThemesList = New System.Windows.Forms.ComboBox()
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -87,6 +89,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxAppearance.SuspendLayout()
         Me.tabpageStatusbar.SuspendLayout()
         Me.groupboxStatusbar.SuspendLayout()
+        Me.groupboxDefaultDarkTheme.SuspendLayout()
         Me.SuspendLayout()
         '
         'tableLayoutPanelOptionsWindow
@@ -645,12 +648,32 @@ Partial Class aaformOptionsWindow
         '
         'groupboxDefaultDarkTheme
         '
+        Me.groupboxDefaultDarkTheme.Controls.Add(Me.comboboxDefaultDarkThemesList)
+        Me.groupboxDefaultDarkTheme.Controls.Add(Me.labelDefaultDarkThemeDescription)
         Me.groupboxDefaultDarkTheme.Location = New System.Drawing.Point(4, 194)
         Me.groupboxDefaultDarkTheme.Name = "groupboxDefaultDarkTheme"
         Me.groupboxDefaultDarkTheme.Size = New System.Drawing.Size(415, 127)
         Me.groupboxDefaultDarkTheme.TabIndex = 1
         Me.groupboxDefaultDarkTheme.TabStop = False
         Me.groupboxDefaultDarkTheme.Text = "Default dark theme"
+        '
+        'labelDefaultDarkThemeDescription
+        '
+        Me.labelDefaultDarkThemeDescription.AutoSize = True
+        Me.labelDefaultDarkThemeDescription.Location = New System.Drawing.Point(12, 44)
+        Me.labelDefaultDarkThemeDescription.Name = "labelDefaultDarkThemeDescription"
+        Me.labelDefaultDarkThemeDescription.Size = New System.Drawing.Size(390, 13)
+        Me.labelDefaultDarkThemeDescription.TabIndex = 0
+        Me.labelDefaultDarkThemeDescription.Text = "When matching Windows 10 theme settings is enabled, we'll use this dark theme:"
+        '
+        'comboboxDefaultDarkThemesList
+        '
+        Me.comboboxDefaultDarkThemesList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
+        Me.comboboxDefaultDarkThemesList.FormattingEnabled = True
+        Me.comboboxDefaultDarkThemesList.Location = New System.Drawing.Point(15, 61)
+        Me.comboboxDefaultDarkThemesList.Name = "comboboxDefaultDarkThemesList"
+        Me.comboboxDefaultDarkThemesList.Size = New System.Drawing.Size(195, 21)
+        Me.comboboxDefaultDarkThemesList.TabIndex = 1
         '
         'aaformOptionsWindow
         '
@@ -686,6 +709,8 @@ Partial Class aaformOptionsWindow
         Me.tabpageStatusbar.ResumeLayout(False)
         Me.groupboxStatusbar.ResumeLayout(False)
         Me.groupboxStatusbar.PerformLayout()
+        Me.groupboxDefaultDarkTheme.ResumeLayout(False)
+        Me.groupboxDefaultDarkTheme.PerformLayout()
         Me.ResumeLayout(False)
 
     End Sub
@@ -741,4 +766,6 @@ Partial Class aaformOptionsWindow
     Friend WithEvents radiobuttonDefaultStatusbarGreeting As RadioButton
     Friend WithEvents labelCustomStatusbarGreeting As Label
     Friend WithEvents groupboxDefaultDarkTheme As GroupBox
+    Friend WithEvents labelDefaultDarkThemeDescription As Label
+    Friend WithEvents comboboxDefaultDarkThemesList As ComboBox
 End Class

--- a/UXL-Launcher/OptionsWindow.Designer.vb
+++ b/UXL-Launcher/OptionsWindow.Designer.vb
@@ -59,13 +59,6 @@ Partial Class aaformOptionsWindow
         Me.comboboxThemeList = New System.Windows.Forms.ComboBox()
         Me.textboxThemeInfo = New System.Windows.Forms.TextBox()
         Me.checkboxEnableThemeEngine = New System.Windows.Forms.CheckBox()
-        Me.buttonTestSettings = New System.Windows.Forms.Button()
-        Me.buttonDefaultSettings = New System.Windows.Forms.Button()
-        Me.tooltipO365InstallMethod = New System.Windows.Forms.ToolTip(Me.components)
-        Me.tooltipSystemInfo = New System.Windows.Forms.ToolTip(Me.components)
-        Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
-        Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
-        Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
         Me.tabpageStatusbar = New System.Windows.Forms.TabPage()
         Me.groupboxStatusbar = New System.Windows.Forms.GroupBox()
         Me.buttonClearFirstname = New System.Windows.Forms.Button()
@@ -74,6 +67,13 @@ Partial Class aaformOptionsWindow
         Me.radiobuttonCustomStatusbarGreeting = New System.Windows.Forms.RadioButton()
         Me.radiobuttonDefaultStatusbarGreeting = New System.Windows.Forms.RadioButton()
         Me.labelCustomStatusbarGreeting = New System.Windows.Forms.Label()
+        Me.buttonTestSettings = New System.Windows.Forms.Button()
+        Me.buttonDefaultSettings = New System.Windows.Forms.Button()
+        Me.tooltipO365InstallMethod = New System.Windows.Forms.ToolTip(Me.components)
+        Me.tooltipSystemInfo = New System.Windows.Forms.ToolTip(Me.components)
+        Me.openfiledialogBrowseCustomThemeFile = New System.Windows.Forms.OpenFileDialog()
+        Me.tooltipCustomThemePath = New System.Windows.Forms.ToolTip(Me.components)
+        Me.tooltipMatchWindows10ThemeSettings = New System.Windows.Forms.ToolTip(Me.components)
         Me.tableLayoutPanelOptionsWindow.SuspendLayout()
         Me.tabcontrolOptionsWindow.SuspendLayout()
         Me.tabpageGeneral.SuspendLayout()
@@ -510,53 +510,6 @@ Partial Class aaformOptionsWindow
         Me.checkboxEnableThemeEngine.Text = "Enable UXL Launcher Theme Engine (requires application restart)"
         Me.checkboxEnableThemeEngine.UseVisualStyleBackColor = True
         '
-        'buttonTestSettings
-        '
-        Me.buttonTestSettings.Anchor = System.Windows.Forms.AnchorStyles.Right
-        Me.buttonTestSettings.AutoSize = True
-        Me.buttonTestSettings.Location = New System.Drawing.Point(71, 364)
-        Me.buttonTestSettings.Margin = New System.Windows.Forms.Padding(2)
-        Me.buttonTestSettings.Name = "buttonTestSettings"
-        Me.buttonTestSettings.Size = New System.Drawing.Size(79, 28)
-        Me.buttonTestSettings.TabIndex = 7
-        Me.buttonTestSettings.Text = "Test settings"
-        Me.buttonTestSettings.UseVisualStyleBackColor = True
-        '
-        'buttonDefaultSettings
-        '
-        Me.buttonDefaultSettings.Anchor = System.Windows.Forms.AnchorStyles.Right
-        Me.buttonDefaultSettings.AutoSize = True
-        Me.buttonDefaultSettings.Location = New System.Drawing.Point(2, 364)
-        Me.buttonDefaultSettings.Margin = New System.Windows.Forms.Padding(2)
-        Me.buttonDefaultSettings.Name = "buttonDefaultSettings"
-        Me.buttonDefaultSettings.Size = New System.Drawing.Size(65, 28)
-        Me.buttonDefaultSettings.TabIndex = 6
-        Me.buttonDefaultSettings.Text = "Defaults"
-        Me.buttonDefaultSettings.UseVisualStyleBackColor = True
-        '
-        'tooltipO365InstallMethod
-        '
-        Me.tooltipO365InstallMethod.AutoPopDelay = 32766
-        Me.tooltipO365InstallMethod.InitialDelay = 500
-        Me.tooltipO365InstallMethod.ReshowDelay = 100
-        '
-        'openfiledialogBrowseCustomThemeFile
-        '
-        Me.openfiledialogBrowseCustomThemeFile.Filter = "XML Files (*.xml)|*.xml|Text Files (*.txt)|*.txt|All Files (*.*)|*.*"
-        Me.openfiledialogBrowseCustomThemeFile.Title = "Browse for a custom theme"
-        '
-        'tooltipCustomThemePath
-        '
-        Me.tooltipCustomThemePath.AutoPopDelay = 5000
-        Me.tooltipCustomThemePath.InitialDelay = 500
-        Me.tooltipCustomThemePath.ReshowDelay = 100
-        '
-        'tooltipMatchWindows10ThemeSettings
-        '
-        Me.tooltipMatchWindows10ThemeSettings.AutoPopDelay = 10000
-        Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
-        Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
-        '
         'tabpageStatusbar
         '
         Me.tabpageStatusbar.Controls.Add(Me.groupboxStatusbar)
@@ -582,7 +535,7 @@ Partial Class aaformOptionsWindow
         Me.groupboxStatusbar.Size = New System.Drawing.Size(415, 130)
         Me.groupboxStatusbar.TabIndex = 2
         Me.groupboxStatusbar.TabStop = False
-        Me.groupboxStatusbar.Text = "Statusbar"
+        Me.groupboxStatusbar.Text = "Greeting"
         '
         'buttonClearFirstname
         '
@@ -640,6 +593,53 @@ Partial Class aaformOptionsWindow
         Me.labelCustomStatusbarGreeting.TabIndex = 0
         Me.labelCustomStatusbarGreeting.Text = "You can choose to use a statusbar greeting personalized with your firstname" & Global.Microsoft.VisualBasic.ChrW(13) & Global.Microsoft.VisualBasic.ChrW(10) & "or n" &
     "ickname, or to use the default. Your name will not be used to identify you."
+        '
+        'buttonTestSettings
+        '
+        Me.buttonTestSettings.Anchor = System.Windows.Forms.AnchorStyles.Right
+        Me.buttonTestSettings.AutoSize = True
+        Me.buttonTestSettings.Location = New System.Drawing.Point(71, 364)
+        Me.buttonTestSettings.Margin = New System.Windows.Forms.Padding(2)
+        Me.buttonTestSettings.Name = "buttonTestSettings"
+        Me.buttonTestSettings.Size = New System.Drawing.Size(79, 28)
+        Me.buttonTestSettings.TabIndex = 7
+        Me.buttonTestSettings.Text = "Test settings"
+        Me.buttonTestSettings.UseVisualStyleBackColor = True
+        '
+        'buttonDefaultSettings
+        '
+        Me.buttonDefaultSettings.Anchor = System.Windows.Forms.AnchorStyles.Right
+        Me.buttonDefaultSettings.AutoSize = True
+        Me.buttonDefaultSettings.Location = New System.Drawing.Point(2, 364)
+        Me.buttonDefaultSettings.Margin = New System.Windows.Forms.Padding(2)
+        Me.buttonDefaultSettings.Name = "buttonDefaultSettings"
+        Me.buttonDefaultSettings.Size = New System.Drawing.Size(65, 28)
+        Me.buttonDefaultSettings.TabIndex = 6
+        Me.buttonDefaultSettings.Text = "Defaults"
+        Me.buttonDefaultSettings.UseVisualStyleBackColor = True
+        '
+        'tooltipO365InstallMethod
+        '
+        Me.tooltipO365InstallMethod.AutoPopDelay = 32766
+        Me.tooltipO365InstallMethod.InitialDelay = 500
+        Me.tooltipO365InstallMethod.ReshowDelay = 100
+        '
+        'openfiledialogBrowseCustomThemeFile
+        '
+        Me.openfiledialogBrowseCustomThemeFile.Filter = "XML Files (*.xml)|*.xml|Text Files (*.txt)|*.txt|All Files (*.*)|*.*"
+        Me.openfiledialogBrowseCustomThemeFile.Title = "Browse for a custom theme"
+        '
+        'tooltipCustomThemePath
+        '
+        Me.tooltipCustomThemePath.AutoPopDelay = 5000
+        Me.tooltipCustomThemePath.InitialDelay = 500
+        Me.tooltipCustomThemePath.ReshowDelay = 100
+        '
+        'tooltipMatchWindows10ThemeSettings
+        '
+        Me.tooltipMatchWindows10ThemeSettings.AutoPopDelay = 10000
+        Me.tooltipMatchWindows10ThemeSettings.InitialDelay = 500
+        Me.tooltipMatchWindows10ThemeSettings.ReshowDelay = 100
         '
         'aaformOptionsWindow
         '

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -156,19 +156,10 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>629, 23</value>
   </metadata>
-  <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>22, 23</value>
-  </metadata>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>214, 23</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
-  </metadata>
-  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>629, 23</value>
-  </metadata>
-  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.resx
+++ b/UXL-Launcher/OptionsWindow.resx
@@ -156,10 +156,19 @@ will be applied on app startup or when applying themes.</value>
   <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>629, 23</value>
   </metadata>
+  <metadata name="tooltipO365InstallMethod.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>22, 23</value>
+  </metadata>
   <metadata name="tooltipSystemInfo.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>214, 23</value>
   </metadata>
   <metadata name="openfiledialogBrowseCustomThemeFile.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>362, 23</value>
+  </metadata>
+  <metadata name="tooltipCustomThemePath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>629, 23</value>
+  </metadata>
+  <metadata name="tooltipMatchWindows10ThemeSettings.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>820, 23</value>
   </metadata>
 </root>

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -165,8 +165,17 @@ Public Class aaformOptionsWindow
 #End Region
 #Region "Default dark theme."
         ' Load in the settings for default dark theme.
+        Dim DarkThemesListString As String = My.Resources.darkthemesList
+        Dim DarkThemesListStringSplit() As String = DarkThemesListString.Split(delimiter)
+        For Each DarkTheme As String In DarkThemesListStringSplit
+            comboboxDefaultDarkThemesList.Items.Add(DarkTheme)
+        Next
         If Not My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) Then
-            ' If the specified dark theme isn't in the list, then set the 
+            ' If the specified dark theme isn't in the list, then set the selected dark theme
+            ' to ProDark, since that's the default.
+            comboboxDefaultDarkThemesList.SelectedItem = "ProDark"
+        Else
+            comboboxDefaultDarkThemesList.SelectedItem = My.Settings.defaultDarkTheme
         End If
 #End Region
 #Region "Custom statusbar greeting."

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -175,11 +175,13 @@ Public Class aaformOptionsWindow
             ' Look in the list of dark themes and add them to the list.
             comboboxDefaultDarkThemesList.Items.Add(DarkTheme)
         Next
-        If Not My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) Then
+
+        If Not comboboxDefaultDarkThemesList.Items.Contains(My.Settings.defaultDarkTheme.ToString) Then
             ' If the specified dark theme isn't in the list, then set the selected dark theme
             ' to ProDark, since that's the default.
             comboboxDefaultDarkThemesList.SelectedItem = "ProDark"
         Else
+            ' Otherwise it's in the list, so select it.
             comboboxDefaultDarkThemesList.SelectedItem = My.Settings.defaultDarkTheme
         End If
 #End Region

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -165,9 +165,14 @@ Public Class aaformOptionsWindow
 #End Region
 #Region "Default dark theme."
         ' Load in the settings for default dark theme.
-        Dim DarkThemesListString As String = My.Resources.darkthemesList
-        Dim DarkThemesListStringSplit() As String = DarkThemesListString.Split(delimiter)
-        For Each DarkTheme As String In DarkThemesListStringSplit
+        ' Get the list of dark themes from My.Resources.
+        Dim DarkThemesListString() As String = My.Resources.darkthemesList.Split(delimiter)
+
+        ' Clear the dark theme list.
+        comboboxDefaultDarkThemesList.Items.Clear()
+
+        For Each DarkTheme As String In DarkThemesListString
+            ' Look in the list of dark themes and add them to the list.
             comboboxDefaultDarkThemesList.Items.Add(DarkTheme)
         Next
         If Not My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) Then

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -414,6 +414,9 @@ Public Class aaformOptionsWindow
         ' Set My.Settings.matchWindows10ThemeSettings to True or False based on the checkbox.
         My.Settings.matchWindows10ThemeSettings = checkboxMatchWindows10ThemeSettings.Checked
 
+        ' Save default dark theme setting.
+        My.Settings.defaultDarkTheme = comboboxDefaultDarkThemesList.Text
+
         ' Set My.Settings.userChosenTheme to the text in the theme list dropdown box.
         My.Settings.userChosenTheme = comboboxThemeList.Text
 

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -169,20 +169,20 @@ Public Class aaformOptionsWindow
         Dim DarkThemesListString() As String = My.Resources.darkthemesList.Split(delimiter)
 
         ' Clear the dark theme list.
-        comboboxDefaultDarkThemesList.Items.Clear()
+        comboboxDarkThemesForSystemThemeMatchingList.Items.Clear()
 
         For Each DarkTheme As String In DarkThemesListString
             ' Look in the list of dark themes and add them to the list.
-            comboboxDefaultDarkThemesList.Items.Add(DarkTheme)
+            comboboxDarkThemesForSystemThemeMatchingList.Items.Add(DarkTheme)
         Next
 
-        If Not comboboxDefaultDarkThemesList.Items.Contains(My.Settings.defaultDarkTheme.ToString) Then
+        If Not comboboxDarkThemesForSystemThemeMatchingList.Items.Contains(My.Settings.darkthemeForSystemThemeMatching.ToString) Then
             ' If the specified dark theme isn't in the list, then set the selected dark theme
             ' to ProDark, since that's the default.
-            comboboxDefaultDarkThemesList.SelectedItem = "ProDark"
+            comboboxDarkThemesForSystemThemeMatchingList.SelectedItem = "ProDark"
         Else
             ' Otherwise it's in the list, so select it.
-            comboboxDefaultDarkThemesList.SelectedItem = My.Settings.defaultDarkTheme
+            comboboxDarkThemesForSystemThemeMatchingList.SelectedItem = My.Settings.darkthemeForSystemThemeMatching
         End If
 #End Region
 #Region "Custom statusbar greeting."
@@ -281,7 +281,7 @@ Public Class aaformOptionsWindow
         checkboxMatchWindows10ThemeSettings.Checked = False
 
         ' Reset the default dark theme dropdown to ProDark.
-        comboboxDefaultDarkThemesList.SelectedItem = "ProDark"
+        comboboxDarkThemesForSystemThemeMatchingList.SelectedItem = "ProDark"
 
         ' Reset the personalized statusbar firstname/nickname
         ' textbox to empty.
@@ -414,8 +414,8 @@ Public Class aaformOptionsWindow
         ' Set My.Settings.matchWindows10ThemeSettings to True or False based on the checkbox.
         My.Settings.matchWindows10ThemeSettings = checkboxMatchWindows10ThemeSettings.Checked
 
-        ' Save default dark theme setting.
-        My.Settings.defaultDarkTheme = comboboxDefaultDarkThemesList.Text
+        ' Save dark theme for system theme matching setting.
+        My.Settings.darkthemeForSystemThemeMatching = comboboxDarkThemesForSystemThemeMatchingList.Text
 
         ' Set My.Settings.userChosenTheme to the text in the theme list dropdown box.
         My.Settings.userChosenTheme = comboboxThemeList.Text

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -280,6 +280,9 @@ Public Class aaformOptionsWindow
         ' Reset the match Windows 10 theme settings checkbox to unchecked.
         checkboxMatchWindows10ThemeSettings.Checked = False
 
+        ' Reset the default dark theme dropdown to ProDark.
+        comboboxDefaultDarkThemesList.SelectedItem = "ProDark"
+
         ' Reset the personalized statusbar firstname/nickname
         ' textbox to empty.
         textboxFirstname.Clear()

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -163,6 +163,12 @@ Public Class aaformOptionsWindow
         ' Next, enable (or disable, based on user settings) and update the controls.
         enableOrDisableThemeEngineOptionsWindowControls()
 #End Region
+#Region "Default dark theme."
+        ' Load in the settings for default dark theme.
+        If Not My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) Then
+            ' If the specified dark theme isn't in the list, then set the 
+        End If
+#End Region
 #Region "Custom statusbar greeting."
         If My.Settings.userUseCustomStatusbarGreeting = True Then
             ' If the settings are configured to use a custom statusbar greeting,
@@ -791,10 +797,12 @@ Public Class aaformOptionsWindow
         If comboboxOfficeVersionSelector.SelectedIndex = 3 Then
             ' Office versions newer than 2016 don't support MSI
             ' and default to C2R, so this checkbox is not necessary.
+            labelOffice365Compatibility.Hide()
             checkboxO365InstallMethod.Hide()
         Else
             ' Office versions older than 2019 support MSI
             ' so this checkbox may be necessary.
+            labelOffice365Compatibility.Show()
             checkboxO365InstallMethod.Show()
         End If
     End Sub

--- a/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
@@ -64,13 +64,13 @@ Public Class WindowsThemeSettings
                 UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.DefaultTheme_XML)
                 aaformMainWindow.themeApplier()
 
-                ' Otherwise, load the default dark theme.
+                ' Otherwise, load the dark theme for system theme matching.
                 ' This falls back to ProDark if we can't find it.
             ElseIf getWindowsThemeSettings = "Dark" Then
-                ' Check if the theme specified in My.Settings.defaultDarkTheme is in the
+                ' Check if the theme specified in My.Settings.darkthemeForSystemThemeMatching is in the
                 ' list of available dark themes.
-                If My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) AndAlso My.Resources.ResourceManager.GetString(My.Settings.defaultDarkTheme & "Theme_XML") IsNot Nothing Then
-                    UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ResourceManager.GetString(My.Settings.defaultDarkTheme & "Theme_XML"))
+                If My.Resources.darkthemesList.Contains(My.Settings.darkthemeForSystemThemeMatching.ToString) AndAlso My.Resources.ResourceManager.GetString(My.Settings.darkthemeForSystemThemeMatching & "Theme_XML") IsNot Nothing Then
+                    UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ResourceManager.GetString(My.Settings.darkthemeForSystemThemeMatching & "Theme_XML"))
                 Else
                     UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ProDarkTheme_XML)
                 End If

--- a/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
@@ -69,7 +69,7 @@ Public Class WindowsThemeSettings
             ElseIf getWindowsThemeSettings = "Dark" Then
                 ' Check if the theme specified in My.Settings.defaultDarkTheme is in the
                 ' list of available dark themes.
-                If My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) Then
+                If My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) AndAlso My.Resources.ResourceManager.GetString(My.Settings.defaultDarkTheme & "Theme_XML") IsNot Nothing Then
                     UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ResourceManager.GetString(My.Settings.defaultDarkTheme & "Theme_XML"))
                 Else
                     UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ProDarkTheme_XML)

--- a/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
@@ -64,12 +64,19 @@ Public Class WindowsThemeSettings
                 UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.DefaultTheme_XML)
                 aaformMainWindow.themeApplier()
 
-                ' Otherwise, load TenDark.
+                ' Otherwise, load the default dark theme.
+                ' This falls back to ProDark if we can't find it.
             ElseIf getWindowsThemeSettings = "Dark" Then
-                UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.TenDarkTheme_XML)
+                ' Check if the theme specified in My.Settings.defaultDarkTheme is in the
+                ' list of available dark themes.
+                If My.Resources.darkthemesList.Contains(My.Settings.defaultDarkTheme.ToString) Then
+                    UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ResourceManager.GetString(My.Settings.defaultDarkTheme & "Theme_XML"))
+                Else
+                    UXLLauncher_ThemeEngine.userTheme.LoadXml(My.Resources.ProDarkTheme_XML)
+                End If
                 aaformMainWindow.themeApplier()
-            End If
-        Else
+                End If
+            Else
 
             ' If the user doesn't want to match the Windows 10 theme,
             ' just move on.


### PR DESCRIPTION
Now the dark theme to apply when the user wants to match the system theme can be changed from the new default of `ProDark` back to `TenDark` or to `Maudern`. This list of dark themes is stored in the Resources and can be updated at any time. Please be aware that unlike the theme list, specifying an unrecognized dark theme in the config file won't add it to the list of dark themes.

Additional changes in this PR:
- `ProDark` is the new default dark theme.
- Changing the dark theme used for matching the system theme:
  - A new setting has been added for this:
    - `darkthemeForSystemThemeMatching`: String; defaults to `ProDark`
    - This setting determines which dark theme is used when matching the system theme is enabled. Valid options at the moment are `Maudern`, `ProDark`, and `TenDark`.
    - These changes have been added to `PortableThemeEngine` as well. In that case, calling applications would change the `libportablethemeengine.ThemeEngine.DarkThemeForSystemThemeMatching` property. After applying a dark theme in this way, this property will be overwritten with `ProDark` again in case the calling app wants to use the default after changing it to a different theme.
  - The `Personalization` tab has been renamed to `Theme` and the statusbar options have been moved to their own tab to allow the dark theme for system theme matching settings to go on the `Theme` tab.
  - The dark theme for system theme matching can be selected from `Tools>Options...>Theme`, then change the dark theme dropdown below the main `Appearance` groupbox to what you want, and click `OK`. Please be aware that this setting won't take effect unless the `Match Windows 10 theme settings` checkbox is checked and the theme engine is running.
  - If an unrecognized theme is specified for `My.Settings.darkthemeForSystemThemeMatching`, then `ProDark` will be used instead and will be what the Options window displays in the dropdown.
  - `PortableThemeEngineDebugger` now supports matching the system theme, and changing to one of the three available dark themes if desired.
  - Updated version numbers for `UXLLauncher_ThemeEngine` and `PortableThemeEngine` to 1.04 and 2.1, respectively.
- Office 365/Click-to-Run compatibility checkbox label has been re-added since it would be confusing and feel weird without it.