### PR TITLE
Themed controls on demand

### DIFF
--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -47,6 +47,7 @@ Partial Class aaformThemeLoader
         Me.radiobuttonLoadFromXml = New System.Windows.Forms.RadioButton()
         Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
         Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
+        Me.Button1 = New System.Windows.Forms.Button()
         Me.StatusStrip1.SuspendLayout()
         Me.Panel1.SuspendLayout()
         Me.groupboxContextMenuArea.SuspendLayout()
@@ -149,6 +150,7 @@ Partial Class aaformThemeLoader
         '
         'Panel1
         '
+        Me.Panel1.Controls.Add(Me.Button1)
         Me.Panel1.Controls.Add(Me.checkboxSpecifyDarkThemeForSystemThemeMatching)
         Me.Panel1.Controls.Add(Me.radiobuttonMatchSystemTheme)
         Me.Panel1.Controls.Add(Me.groupboxContextMenuArea)
@@ -311,6 +313,15 @@ Partial Class aaformThemeLoader
         Me.checkboxAllowCustomThemes.Text = "Allow custom themes"
         Me.checkboxAllowCustomThemes.UseVisualStyleBackColor = True
         '
+        'Button1
+        '
+        Me.Button1.Location = New System.Drawing.Point(13, 148)
+        Me.Button1.Name = "Button1"
+        Me.Button1.Size = New System.Drawing.Size(140, 23)
+        Me.Button1.TabIndex = 12
+        Me.Button1.Text = "new pre-themed button"
+        Me.Button1.UseVisualStyleBackColor = True
+        '
         'aaformThemeLoader
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(96.0!, 96.0!)
@@ -358,4 +369,5 @@ Partial Class aaformThemeLoader
     Friend WithEvents ToolStripMenuItem4 As ToolStripMenuItem
     Friend WithEvents radiobuttonMatchSystemTheme As RadioButton
     Friend WithEvents checkboxSpecifyDarkThemeForSystemThemeMatching As CheckBox
+    Friend WithEvents Button1 As Button
 End Class

--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -326,9 +326,10 @@ Partial Class aaformThemeLoader
         '
         'FlowLayoutPanel1
         '
-        Me.FlowLayoutPanel1.Location = New System.Drawing.Point(13, 178)
+        Me.FlowLayoutPanel1.AutoScroll = True
+        Me.FlowLayoutPanel1.Location = New System.Drawing.Point(11, 178)
         Me.FlowLayoutPanel1.Name = "FlowLayoutPanel1"
-        Me.FlowLayoutPanel1.Size = New System.Drawing.Size(177, 59)
+        Me.FlowLayoutPanel1.Size = New System.Drawing.Size(180, 59)
         Me.FlowLayoutPanel1.TabIndex = 13
         '
         'aaformThemeLoader

--- a/PortableThemeEngineDebugger/Form1.Designer.vb
+++ b/PortableThemeEngineDebugger/Form1.Designer.vb
@@ -33,6 +33,7 @@ Partial Class aaformThemeLoader
         Me.StatusStrip1 = New System.Windows.Forms.StatusStrip()
         Me.ToolStripStatusLabel1 = New System.Windows.Forms.ToolStripStatusLabel()
         Me.Panel1 = New System.Windows.Forms.Panel()
+        Me.Button1 = New System.Windows.Forms.Button()
         Me.checkboxSpecifyDarkThemeForSystemThemeMatching = New System.Windows.Forms.CheckBox()
         Me.radiobuttonMatchSystemTheme = New System.Windows.Forms.RadioButton()
         Me.groupboxContextMenuArea = New System.Windows.Forms.GroupBox()
@@ -47,7 +48,7 @@ Partial Class aaformThemeLoader
         Me.radiobuttonLoadFromXml = New System.Windows.Forms.RadioButton()
         Me.radiobuttonIsCustomTheme = New System.Windows.Forms.RadioButton()
         Me.checkboxAllowCustomThemes = New System.Windows.Forms.CheckBox()
-        Me.Button1 = New System.Windows.Forms.Button()
+        Me.FlowLayoutPanel1 = New System.Windows.Forms.FlowLayoutPanel()
         Me.StatusStrip1.SuspendLayout()
         Me.Panel1.SuspendLayout()
         Me.groupboxContextMenuArea.SuspendLayout()
@@ -150,6 +151,7 @@ Partial Class aaformThemeLoader
         '
         'Panel1
         '
+        Me.Panel1.Controls.Add(Me.FlowLayoutPanel1)
         Me.Panel1.Controls.Add(Me.Button1)
         Me.Panel1.Controls.Add(Me.checkboxSpecifyDarkThemeForSystemThemeMatching)
         Me.Panel1.Controls.Add(Me.radiobuttonMatchSystemTheme)
@@ -171,6 +173,15 @@ Partial Class aaformThemeLoader
         Me.Panel1.Name = "Panel1"
         Me.Panel1.Size = New System.Drawing.Size(371, 312)
         Me.Panel1.TabIndex = 8
+        '
+        'Button1
+        '
+        Me.Button1.Location = New System.Drawing.Point(13, 148)
+        Me.Button1.Name = "Button1"
+        Me.Button1.Size = New System.Drawing.Size(140, 23)
+        Me.Button1.TabIndex = 12
+        Me.Button1.Text = "new pre-themed button"
+        Me.Button1.UseVisualStyleBackColor = True
         '
         'checkboxSpecifyDarkThemeForSystemThemeMatching
         '
@@ -313,14 +324,12 @@ Partial Class aaformThemeLoader
         Me.checkboxAllowCustomThemes.Text = "Allow custom themes"
         Me.checkboxAllowCustomThemes.UseVisualStyleBackColor = True
         '
-        'Button1
+        'FlowLayoutPanel1
         '
-        Me.Button1.Location = New System.Drawing.Point(13, 148)
-        Me.Button1.Name = "Button1"
-        Me.Button1.Size = New System.Drawing.Size(140, 23)
-        Me.Button1.TabIndex = 12
-        Me.Button1.Text = "new pre-themed button"
-        Me.Button1.UseVisualStyleBackColor = True
+        Me.FlowLayoutPanel1.Location = New System.Drawing.Point(13, 178)
+        Me.FlowLayoutPanel1.Name = "FlowLayoutPanel1"
+        Me.FlowLayoutPanel1.Size = New System.Drawing.Size(177, 59)
+        Me.FlowLayoutPanel1.TabIndex = 13
         '
         'aaformThemeLoader
         '
@@ -370,4 +379,5 @@ Partial Class aaformThemeLoader
     Friend WithEvents radiobuttonMatchSystemTheme As RadioButton
     Friend WithEvents checkboxSpecifyDarkThemeForSystemThemeMatching As CheckBox
     Friend WithEvents Button1 As Button
+    Friend WithEvents FlowLayoutPanel1 As FlowLayoutPanel
 End Class

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -127,4 +127,11 @@ Public Class aaformThemeLoader
         ' Reset statusbar backcolor.
         StatusStrip1.BackColor = Nothing
     End Sub
+
+    Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click
+        Dim AddedButton As Button = libportablethemeengine.PreThemedControls.ThemedButton
+        AddedButton.Text = "test"
+
+        Panel1.Controls.Add(AddedButton)
+    End Sub
 End Class

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -132,6 +132,6 @@ Public Class aaformThemeLoader
         Dim AddedButton As Button = libportablethemeengine.PreThemedControls.ThemedButton
         AddedButton.Text = "test"
 
-        Panel1.Controls.Add(AddedButton)
+        FlowLayoutPanel1.Controls.Add(AddedButton)
     End Sub
 End Class

--- a/PortableThemeEngineDebugger/Form1.vb
+++ b/PortableThemeEngineDebugger/Form1.vb
@@ -1,5 +1,5 @@
 ﻿'PortableThemeEngineDebugger - Simple application used to test PortableThemeEngine.
-'Copyright (C) 2020 Drew Naylor. Licensed under Gnu GPLv3+.
+'Copyright (C) 2020-2021 Drew Naylor. Licensed under Gnu GPLv3+.
 'Any companies mentioned own their respective copyrights/trademarks.
 '(Note that the copyright years include the years left out by the hyphen.)
 '

--- a/PortableThemeEngineDebugger/My Project/AssemblyInfo.vb
+++ b/PortableThemeEngineDebugger/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("PortableThemeEngineDebugger")>
-<Assembly: AssemblyCopyright("Copyright (C) 2020 Drew Naylor. Licensed under Gnu GPLv3+.")>
+<Assembly: AssemblyCopyright("Copyright (C) 2020-2021 Drew Naylor. Licensed under Gnu GPLv3+.")>
 <Assembly: AssemblyTrademark("")>
 
 <Assembly: ComVisible(False)>

--- a/PortableUXLLauncher_ThemeEngine/My Project/AssemblyInfo.vb
+++ b/PortableUXLLauncher_ThemeEngine/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("Portable theme engine based on UXL Launcher Theme Engine for Windows Forms applications.")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("libportablethemeengine")>
-<Assembly: AssemblyCopyright("Copyright (C) 2019-2020 Drew Naylor. Licensed under Apache License 2.0.")>
+<Assembly: AssemblyCopyright("Copyright (C) 2019-2021 Drew Naylor. Licensed under Apache License 2.0.")>
 <Assembly: AssemblyTrademark("")> 
 
 <Assembly: ComVisible(False)>

--- a/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
+++ b/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
@@ -1,4 +1,31 @@
-﻿Imports System.Drawing
+﻿' PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
+' Can be used with standard Windows Forms applications.
+' Copyright (C) 2019-2021 Drew Naylor.
+' Microsoft Windows and all related words are copyright
+' and trademark Microsoft Corporation.
+' Microsoft is not affiliated with either PortableThemeEngine or Drew Naylor
+' and does not endorse this software.
+' Any other companies mentioned own their respective copyrights/trademarks.
+' (Note that the copyright years include the years left out by the hyphen.)
+'
+' This file is part of PortableThemeEngine.
+'
+'
+'   Licensed under the Apache License, Version 2.0 (the "License");
+'   you may not use this file except in compliance with the License.
+'   You may obtain a copy of the License at
+'
+'     http://www.apache.org/licenses/LICENSE-2.0
+'
+'   Unless required by applicable law or agreed to in writing, software
+'   distributed under the License is distributed on an "AS IS" BASIS,
+'   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+'   See the License for the specific language governing permissions and
+'   limitations under the License.
+
+
+
+Imports System.Drawing
 
 Public Class PreThemedControls
 

--- a/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
+++ b/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
@@ -17,12 +17,14 @@ Public Class PreThemedControls
             ThemeProperties.flatappearanceButtonMouseOverBackColor = Nothing
         End If
 
+        ' Assign the pre-themed button properties.
         PreThemedButton.BackColor = ThemeProperties.colorButtonBackColor
         PreThemedButton.ForeColor = ThemeProperties.colorButtonForeColor
         PreThemedButton.FlatStyle = ThemeProperties.flatstyleButtonFlatStyle
         'Windows.Forms.MessageBox.Show(ThemeProperties.flatstyleButtonFlatStyle.ToString)
         'Windows.Forms.MessageBox.Show(ThemeProperties.themeSheet.OuterXml.ToString)
         If PreThemedButton.FlatStyle = Windows.Forms.FlatStyle.Flat Then
+            ' If it's meant to be flat, do the flat appearance stuff.
             PreThemedButton.FlatAppearance.BorderColor = ThemeProperties.flatappearanceButtonBorderColor
             PreThemedButton.FlatAppearance.MouseDownBackColor = ThemeProperties.flatappearanceButtonMouseDownBackColor
             PreThemedButton.FlatAppearance.MouseOverBackColor = ThemeProperties.flatappearanceButtonMouseOverBackColor

--- a/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
+++ b/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
@@ -1,0 +1,28 @@
+﻿Public Class PreThemedControls
+
+    Public Shared Function ThemedButton() As Windows.Forms.Button
+
+        Dim PreThemedButton As New Windows.Forms.Button
+
+        ' Make sure a theme is loaded.
+        If ThemeProperties.themeSheet.OuterXml.Length = 0 Then
+
+        End If
+
+        PreThemedButton.BackColor = ThemeProperties.colorButtonBackColor
+        PreThemedButton.ForeColor = ThemeProperties.colorButtonForeColor
+        PreThemedButton.FlatStyle = ThemeProperties.flatstyleButtonFlatStyle
+        Windows.Forms.MessageBox.Show(ThemeProperties.flatstyleButtonFlatStyle.ToString)
+        Windows.Forms.MessageBox.Show(ThemeProperties.themeSheet.OuterXml.ToString)
+        If PreThemedButton.FlatStyle = Windows.Forms.FlatStyle.Flat Then
+            PreThemedButton.FlatAppearance.BorderColor = ThemeProperties.flatappearanceButtonBorderColor
+            PreThemedButton.FlatAppearance.MouseDownBackColor = ThemeProperties.flatappearanceButtonMouseDownBackColor
+            PreThemedButton.FlatAppearance.MouseOverBackColor = ThemeProperties.flatappearanceButtonMouseOverBackColor
+        End If
+
+        Return PreThemedButton
+
+    End Function
+
+
+End Class

--- a/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
+++ b/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
@@ -1,4 +1,6 @@
-﻿Public Class PreThemedControls
+﻿Imports System.Drawing
+
+Public Class PreThemedControls
 
     Public Shared Function ThemedButton() As Windows.Forms.Button
 
@@ -6,7 +8,13 @@
 
         ' Make sure a theme is loaded.
         If ThemeProperties.themeSheet.OuterXml.Length = 0 Then
-
+            ' If it's not, load the default button properties.
+            ThemeProperties.colorButtonBackColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "BackColor"))
+            ThemeProperties.colorButtonForeColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "ForeColor"))
+            ThemeProperties.flatstyleButtonFlatStyle = CType(TE2DotXLoader.GetDefaultValue("Button", "FlatStyle"), Windows.Forms.FlatStyle)
+            ThemeProperties.flatappearanceButtonBorderColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "FlatAppearance/BorderColor"))
+            ThemeProperties.flatappearanceButtonMouseDownBackColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "FlatAppearance/MouseDownBackColor"))
+            ThemeProperties.flatappearanceButtonMouseOverBackColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "FlatAppearance/MouseOverBackColor"))
         End If
 
         PreThemedButton.BackColor = ThemeProperties.colorButtonBackColor

--- a/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
+++ b/PortableUXLLauncher_ThemeEngine/PreThemedControls.vb
@@ -11,17 +11,17 @@ Public Class PreThemedControls
             ' If it's not, load the default button properties.
             ThemeProperties.colorButtonBackColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "BackColor"))
             ThemeProperties.colorButtonForeColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "ForeColor"))
-            ThemeProperties.flatstyleButtonFlatStyle = CType(TE2DotXLoader.GetDefaultValue("Button", "FlatStyle"), Windows.Forms.FlatStyle)
-            ThemeProperties.flatappearanceButtonBorderColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "FlatAppearance/BorderColor"))
-            ThemeProperties.flatappearanceButtonMouseDownBackColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "FlatAppearance/MouseDownBackColor"))
-            ThemeProperties.flatappearanceButtonMouseOverBackColor = ColorTranslator.FromHtml(TE2DotXLoader.GetDefaultValue("Button", "FlatAppearance/MouseOverBackColor"))
+            ThemeProperties.flatstyleButtonFlatStyle = Windows.Forms.FlatStyle.Standard
+            ThemeProperties.flatappearanceButtonBorderColor = Nothing
+            ThemeProperties.flatappearanceButtonMouseDownBackColor = Nothing
+            ThemeProperties.flatappearanceButtonMouseOverBackColor = Nothing
         End If
 
         PreThemedButton.BackColor = ThemeProperties.colorButtonBackColor
         PreThemedButton.ForeColor = ThemeProperties.colorButtonForeColor
         PreThemedButton.FlatStyle = ThemeProperties.flatstyleButtonFlatStyle
-        Windows.Forms.MessageBox.Show(ThemeProperties.flatstyleButtonFlatStyle.ToString)
-        Windows.Forms.MessageBox.Show(ThemeProperties.themeSheet.OuterXml.ToString)
+        'Windows.Forms.MessageBox.Show(ThemeProperties.flatstyleButtonFlatStyle.ToString)
+        'Windows.Forms.MessageBox.Show(ThemeProperties.themeSheet.OuterXml.ToString)
         If PreThemedButton.FlatStyle = Windows.Forms.FlatStyle.Flat Then
             PreThemedButton.FlatAppearance.BorderColor = ThemeProperties.flatappearanceButtonBorderColor
             PreThemedButton.FlatAppearance.MouseDownBackColor = ThemeProperties.flatappearanceButtonMouseDownBackColor

--- a/PortableUXLLauncher_ThemeEngine/TE2DotXLoader.vb
+++ b/PortableUXLLauncher_ThemeEngine/TE2DotXLoader.vb
@@ -1,6 +1,6 @@
 ﻿' PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
 ' Can be used with standard Windows Forms applications.
-' Copyright (C) 2019-2020 Drew Naylor.
+' Copyright (C) 2019-2021 Drew Naylor.
 ' Microsoft Windows and all related words are copyright
 ' and trademark Microsoft Corporation.
 ' Microsoft is not affiliated with either PortableThemeEngine or Drew Naylor

--- a/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
+++ b/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
@@ -742,10 +742,4 @@ Public Class ThemeProperties
     Friend Shared ReadOnly defaultThemeAuthor As String = "(No author specified)"
     Friend Shared ReadOnly defaultThemeVersion As String = "(No version specified)"
 #End Region
-
-#Region "Load default properties into the specific properties to access from elsewhere."
-    Friend Shared Sub LoadDefaultProperty(Control As String)
-
-    End Sub
-#End Region
 End Class

--- a/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
+++ b/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
@@ -1,6 +1,6 @@
 ﻿' PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
 ' Can be used with standard Windows Forms applications.
-' Copyright (C) 2019-2020 Drew Naylor.
+' Copyright (C) 2019-2021 Drew Naylor.
 ' Microsoft Windows and all related words are copyright
 ' and trademark Microsoft Corporation.
 ' Microsoft is not affiliated with either PortableThemeEngine or Drew Naylor

--- a/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
+++ b/PortableUXLLauncher_ThemeEngine/ThemeProperties.vb
@@ -742,4 +742,10 @@ Public Class ThemeProperties
     Friend Shared ReadOnly defaultThemeAuthor As String = "(No author specified)"
     Friend Shared ReadOnly defaultThemeVersion As String = "(No version specified)"
 #End Region
+
+#Region "Load default properties into the specific properties to access from elsewhere."
+    Friend Shared Sub LoadDefaultProperty(Control As String)
+
+    End Sub
+#End Region
 End Class

--- a/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
+++ b/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vb
@@ -1,6 +1,6 @@
 ﻿' PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
 ' Can be used with standard Windows Forms applications.
-' Copyright (C) 2019-2020 Drew Naylor.
+' Copyright (C) 2019-2021 Drew Naylor.
 ' Microsoft Windows and all related words are copyright
 ' and trademark Microsoft Corporation.
 ' Microsoft is not affiliated with either PortableThemeEngine or Drew Naylor

--- a/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vbproj
+++ b/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vbproj
@@ -90,6 +90,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="PreThemedControls.vb" />
     <Compile Include="TE1DotXLoaderShim.vb" />
     <Compile Include="TE2DotXLoader.vb" />
     <Compile Include="ThemeProperties.vb" />


### PR DESCRIPTION
Very basic themed controls on demand. For now this only covers buttons. To use this, simply create a new button and assign it to the return value of the themed button function, like so:

`Dim AddedButton As Button = libportablethemeengine.PreThemedControls.ThemedButton`

There might be a lot of work involved to make pre-themed controls as usable as the rest of the theme engine, so that'll take time. Not really in the mood to work on that right now. You can see the pre-themed controls by using the portable theme engine debugger project and clicking the "new pre-themed button" button. Changing themes then clicking this button again will add a new button with the current theme properties to the flowlayoutpanel below the button. When a theme isn't applied, the default theme properties will be applied instead.

Will have to make sure to test this against purposefully-bad themes to make sure it doesn't break. Checking the OuterXml length to see if it's 0 might not be the best way to guard against stuff not being there.

Updated copyright years for the project files involved in this pull request as well.

Fixes #203.