### PR TITLE
.NET Framework 4.8 migration

### DIFF
--- a/PortableThemeEngineDebugger/App.config
+++ b/PortableThemeEngineDebugger/App.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <appSettings>
-    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
-    <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true"/>
+    <add key="ClientSettingsProvider.ServiceUri" value=""/>
   </appSettings>
 </configuration>

--- a/PortableThemeEngineDebugger/My Project/Resources.Designer.vb
+++ b/PortableThemeEngineDebugger/My Project/Resources.Designer.vb
@@ -22,7 +22,7 @@ Namespace My.Resources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _
@@ -64,7 +64,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Return of the Night&lt;/Title&gt;
         '''  &lt;Description&gt;Based on the Test2 theme, &quot;Return of the Night&quot; is a purple theme best suited for those who like proper day/night cycles.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the

--- a/PortableThemeEngineDebugger/My Project/Settings.Designer.vb
+++ b/PortableThemeEngineDebugger/My Project/Settings.Designer.vb
@@ -13,42 +13,42 @@ Option Explicit On
 
 
 Namespace My
-
-    <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(), _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0"), _
-     Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
+    
+    <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0"),  _
+     Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
-
-        Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings), MySettings)
-
+        
+        Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings()),MySettings)
+        
 #Region "My.Settings Auto-Save Functionality"
 #If _MyType = "WindowsForms" Then
-        Private Shared addedHandler As Boolean
+    Private Shared addedHandler As Boolean
 
-        Private Shared addedHandlerLockObject As New Object
+    Private Shared addedHandlerLockObject As New Object
 
-        <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
-        Private Shared Sub AutoSaveSettings(ByVal sender As Global.System.Object, ByVal e As Global.System.EventArgs)
-            If My.Application.SaveMySettingsOnExit Then
-                My.Settings.Save()
-            End If
-        End Sub
+    <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
+    Private Shared Sub AutoSaveSettings(sender As Global.System.Object, e As Global.System.EventArgs)
+        If My.Application.SaveMySettingsOnExit Then
+            My.Settings.Save()
+        End If
+    End Sub
 #End If
 #End Region
-
+        
         Public Shared ReadOnly Property [Default]() As MySettings
             Get
-
+                
 #If _MyType = "WindowsForms" Then
-                   If Not addedHandler Then
-                        SyncLock addedHandlerLockObject
-                            If Not addedHandler Then
-                                AddHandler My.Application.Shutdown, AddressOf AutoSaveSettings
-                                addedHandler = True
-                            End If
-                        End SyncLock
-                    End If
+               If Not addedHandler Then
+                    SyncLock addedHandlerLockObject
+                        If Not addedHandler Then
+                            AddHandler My.Application.Shutdown, AddressOf AutoSaveSettings
+                            addedHandler = True
+                        End If
+                    End SyncLock
+                End If
 #End If
                 Return defaultInstance
             End Get
@@ -57,13 +57,13 @@ Namespace My
 End Namespace
 
 Namespace My
-
-    <Global.Microsoft.VisualBasic.HideModuleNameAttribute(), _
-     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), _
-     Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()> _
+    
+    <Global.Microsoft.VisualBasic.HideModuleNameAttribute(),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()>  _
     Friend Module MySettingsProperty
-
-        <Global.System.ComponentModel.Design.HelpKeywordAttribute("My.Settings")> _
+        
+        <Global.System.ComponentModel.Design.HelpKeywordAttribute("My.Settings")>  _
         Friend ReadOnly Property Settings() As Global.PortableThemeEngineDebugger.My.MySettings
             Get
                 Return Global.PortableThemeEngineDebugger.My.MySettings.Default

--- a/PortableThemeEngineDebugger/PortableThemeEngineDebugger.vbproj
+++ b/PortableThemeEngineDebugger/PortableThemeEngineDebugger.vbproj
@@ -11,8 +11,9 @@
     <AssemblyName>PortableThemeEngineDebugger</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>WindowsForms</MyType>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -94,6 +95,7 @@
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="My Project\Resources.Designer.vb">
       <AutoGen>True</AutoGen>

--- a/PortableUXLLauncher_ThemeEngine/My Project/AssemblyInfo.vb
+++ b/PortableUXLLauncher_ThemeEngine/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("2.1.0.0")>
-<Assembly: AssemblyFileVersion("2.1.0.0")>
+<Assembly: AssemblyVersion("3.0.0.0")>
+<Assembly: AssemblyFileVersion("3.0.0.0")>

--- a/PortableUXLLauncher_ThemeEngine/My Project/Resources.Designer.vb
+++ b/PortableUXLLauncher_ThemeEngine/My Project/Resources.Designer.vb
@@ -22,7 +22,7 @@ Namespace My.Resources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _
@@ -83,7 +83,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Default Theme&lt;/Title&gt;
         '''  &lt;Description&gt;Default is the theme UXL Launcher ships with.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -102,7 +102,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Eyesore 2&lt;/Title&gt;
         '''  &lt;Description&gt;Originally a test theme for UXL Launcher, Eyesore 2 is meant to be a spiritual successor to the Windows 3.1 Hotdog Stand theme, but worse.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -131,7 +131,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Maudern Classic&lt;/Title&gt;
         '''  &lt;Description&gt;Maudern Classic is basically Maudern v1.0 plus a few extra things supported in TE1.03, in case anyone preferred that version&apos;s general appearance over Maudern v1.1.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.0&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -148,7 +148,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Maudern&lt;/Title&gt;
         '''  &lt;Description&gt;Maudern is a simple, flat theme with a grey color scheme similar in appearance to rock coloration.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -167,7 +167,7 @@ Namespace My.Resources
         '''  &lt;Title&gt;Mitty Theme&lt;/Title&gt;
         '''  &lt;Description&gt;Most of the work for version 3.2 was done while my calico cat, Mitty, was still around, so it felt like a good idea to make this theme for her. I miss her.
         '''    &quot;...if you meant something to someone, if you helped someone, or loved someone, if even a single person remembers you, then maybe you never really die...&quot; - The Machine&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''  
         '''    &lt;!-- &quot;UseThemeEngineVersion&quot; is u [rest of string was truncated]&quot;;.
@@ -197,7 +197,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Return of the Night&lt;/Title&gt;
         '''  &lt;Description&gt;Based on the Test2 theme, &quot;Return of the Night&quot; is a purple theme best suited for those who like proper day/night cycles.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -215,7 +215,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Arr G. Bee&lt;/Title&gt;
         '''  &lt;Description&gt;Arr G. Bee is a theme that&apos;s influenced by the UXL Launcher logo.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -234,7 +234,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Arr G. Bee&lt;/Title&gt;
         '''  &lt;Description&gt;Arr G. Bee is a theme that&apos;s influenced by the UXL Launcher logo.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -255,7 +255,7 @@ Namespace My.Resources
         '''       XML InnerText, kinda like what HTML does. --&gt;
         '''  &lt;Title&gt;Ten Dark&lt;/Title&gt;
         '''  &lt;Description&gt;A dark theme similar to Windows 10&apos;s &quot;Dark Mode&quot;.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the
@@ -272,7 +272,7 @@ Namespace My.Resources
         '''  Looks up a localized string similar to &lt;UXL_Launcher_Theme&gt;
         '''  &lt;Title&gt;Ten Dark&lt;/Title&gt;
         '''  &lt;Description&gt;A dark theme similar to Windows 10&apos;s &quot;Dark Mode&quot;.&lt;/Description&gt;
-        '''  &lt;Version&gt;v1.1&lt;/Version&gt;
+        '''  &lt;Version&gt;v1.2&lt;/Version&gt;
         '''  &lt;Author&gt;Drew Naylor&lt;/Author&gt;
         '''
         '''  &lt;!-- &quot;UseThemeEngineVersion&quot; is used to specify the version of the

--- a/PortableUXLLauncher_ThemeEngine/My Project/Settings.Designer.vb
+++ b/PortableUXLLauncher_ThemeEngine/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -29,7 +29,7 @@ Namespace My
     Private Shared addedHandlerLockObject As New Object
 
     <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
-    Private Shared Sub AutoSaveSettings(ByVal sender As Global.System.Object, ByVal e As Global.System.EventArgs)
+    Private Shared Sub AutoSaveSettings(sender As Global.System.Object, e As Global.System.EventArgs)
         If My.Application.SaveMySettingsOnExit Then
             My.Settings.Save()
         End If

--- a/PortableUXLLauncher_ThemeEngine/TE1DotXLoaderShim.vb
+++ b/PortableUXLLauncher_ThemeEngine/TE1DotXLoaderShim.vb
@@ -1,6 +1,6 @@
 ﻿' PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
 ' Can be used with standard Windows Forms applications.
-' Copyright (C) 2019-2020 Drew Naylor.
+' Copyright (C) 2019-2021 Drew Naylor.
 ' Microsoft Windows and all related words are copyright
 ' and trademark Microsoft Corporation.
 ' Microsoft is not affiliated with either PortableThemeEngine or Drew Naylor

--- a/PortableUXLLauncher_ThemeEngine/Themes/WindowsThemeSettings.vb
+++ b/PortableUXLLauncher_ThemeEngine/Themes/WindowsThemeSettings.vb
@@ -1,23 +1,27 @@
-﻿'PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
-'Can be used with standard Windows Forms applications with a few small changes.
-'Copyright (C) 2019-2020 Drew Naylor. Licensed under Gnu GPLv3+.
-'Any companies mentioned own their respective copyrights/trademarks.
-'(Note that the copyright years include the years left out by the hyphen.)
+﻿' PortableThemeEngine - Theme engine based off the UXL Launcher Theme Engine.
+' Can be used with standard Windows Forms applications.
+' Copyright (C) 2019-2021 Drew Naylor.
+' Microsoft Windows and all related words are copyright
+' and trademark Microsoft Corporation.
+' Microsoft is not affiliated with either PortableThemeEngine or Drew Naylor
+' and does not endorse this software.
+' Any other companies mentioned own their respective copyrights/trademarks.
+' (Note that the copyright years include the years left out by the hyphen.)
 '
-'This file is part of PortableThemeEngine.
+' This file is part of PortableThemeEngine.
 '
-'PortableThemeEngine is free software: you can redistribute it and/or modify
-'it under the terms of the GNU General Public License as published by
-'the Free Software Foundation, either version 3 of the License, or
-'(at your option) any later version.
 '
-'PortableThemeEngine is distributed in the hope that it will be useful,
-'but WITHOUT ANY WARRANTY; without even the implied warranty of
-'MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-'GNU General Public License for more details.
+'   Licensed under the Apache License, Version 2.0 (the "License");
+'   you may not use this file except in compliance with the License.
+'   You may obtain a copy of the License at
 '
-'You should have received a copy of the GNU General Public License
-'along with PortableThemeEngine.  If not, see <http://www.gnu.org/licenses/>.
+'     http://www.apache.org/licenses/LICENSE-2.0
+'
+'   Unless required by applicable law or agreed to in writing, software
+'   distributed under the License is distributed on an "AS IS" BASIS,
+'   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+'   See the License for the specific language governing permissions and
+'   limitations under the License.
 
 
 

--- a/PortableUXLLauncher_ThemeEngine/app.config
+++ b/PortableUXLLauncher_ThemeEngine/app.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
     </configSections>
@@ -14,14 +14,12 @@
             </source>
         </sources>
         <switches>
-            <add name="DefaultSwitch" value="Information" />
+            <add name="DefaultSwitch" value="Information"/>
         </switches>
         <sharedListeners>
-            <add name="FileLog"
-                 type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL"
-                 initializeData="FileLogWriter"/>
+            <add name="FileLog" type="Microsoft.VisualBasic.Logging.FileLogTraceListener, Microsoft.VisualBasic, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" initializeData="FileLogWriter"/>
             <!-- Uncomment the below section and replace APPLICATION_NAME with the name of your application to write to the Application Event Log -->
             <!--<add name="EventLog" type="System.Diagnostics.EventLogTraceListener" initializeData="APPLICATION_NAME"/> -->
         </sharedListeners>
     </system.diagnostics>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vbproj
+++ b/PortableUXLLauncher_ThemeEngine/libportablethemeengine.vbproj
@@ -10,7 +10,8 @@
     <AssemblyName>libportablethemeengine</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Windows</MyType>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -74,6 +75,7 @@
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="My Project\Resources.Designer.vb">
       <AutoGen>True</AutoGen>

--- a/UXL-Launcher/AboutWindow.vb
+++ b/UXL-Launcher/AboutWindow.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/App.config
+++ b/UXL-Launcher/App.config
@@ -1,17 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
     <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="UXL_Launcher.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+      <section name="UXL_Launcher.My.MySettings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
     </sectionGroup>
   </configSections>
-  <connectionStrings />
+  <connectionStrings/>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
   <appSettings>
-    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
-    <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true"/>
+    <add key="ClientSettingsProvider.ServiceUri" value=""/>
   </appSettings>
   <userSettings>
     <UXL_Launcher.My.MySettings>
@@ -46,7 +46,7 @@
         <value>False</value>
       </setting>
       <setting name="userCustomThemePath" serializeAs="String">
-        <value />
+        <value/>
       </setting>
       <setting name="allowCustomThemes" serializeAs="String">
         <value>True</value>
@@ -55,7 +55,7 @@
         <value>False</value>
       </setting>
       <setting name="userFirstNameForCustomStatusbarGreeting" serializeAs="String">
-        <value />
+        <value/>
       </setting>
       <setting name="bypassConfiguredLocationForDeprecatedApps" serializeAs="String">
         <value>False</value>
@@ -79,18 +79,18 @@
   </userSettings>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<probing privatePath="lib" />
+			<probing privatePath="lib"/>
 		</assemblyBinding>
 	</runtime>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">
       <providers>
-        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" />
+        <add name="ClientAuthenticationMembershipProvider" type="System.Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri=""/>
       </providers>
     </membership>
     <roleManager defaultProvider="ClientRoleProvider" enabled="true">
       <providers>
-        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400" />
+        <add name="ClientRoleProvider" type="System.Web.ClientServices.Providers.ClientRoleProvider, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" serviceUri="" cacheTimeout="86400"/>
       </providers>
     </roleManager>
   </system.web>

--- a/UXL-Launcher/DebugLabelsWindow.vb
+++ b/UXL-Launcher/DebugLabelsWindow.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/MainWindow.vb
+++ b/UXL-Launcher/MainWindow.vb
@@ -1,5 +1,5 @@
 'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/My Project/AssemblyInfo.vb
+++ b/UXL-Launcher/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("UXL Launcher provides launchers for most Microsoft Office apps in one place. This app is not associated with Microsoft Corporation. Microsoft Office and all related trademarks and words belong to Microsoft Corporation.")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("UXL Launcher - Unified eXecutable Launcher")>
-<Assembly: AssemblyCopyright("Copyright © 2013-2020 Drew Naylor. Licensed under the Gnu GPL v3+.")>
+<Assembly: AssemblyCopyright("Copyright © 2013-2021 Drew Naylor. Licensed under the Gnu GPL v3+.")>
 <Assembly: AssemblyTrademark("")>
 
 <Assembly: ComVisible(False)>
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("4.0.0.0")>
-<Assembly: AssemblyFileVersion("4.0.0.0")>
+<Assembly: AssemblyVersion("5.0.0.0")>
+<Assembly: AssemblyFileVersion("5.0.0.0")>

--- a/UXL-Launcher/My Project/Resources.Designer.vb
+++ b/UXL-Launcher/My Project/Resources.Designer.vb
@@ -120,7 +120,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to  - Codename &quot;Changeth Arrangeth&quot;.
+        '''  Looks up a localized string similar to  - Codename &quot;Burdened No Longer&quot;.
         '''</summary>
         Public ReadOnly Property appVersionCodename() As String
             Get
@@ -129,7 +129,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 2020-07-27T22:17:16
+        '''  Looks up a localized string similar to 2021-06-06T12:04:52
         '''.
         '''</summary>
         Public ReadOnly Property BuildDate() As String
@@ -281,7 +281,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Stable.
+        '''  Looks up a localized string similar to Dev.
         '''</summary>
         Public ReadOnly Property isStable() As String
             Get

--- a/UXL-Launcher/My Project/Resources.Designer.vb
+++ b/UXL-Launcher/My Project/Resources.Designer.vb
@@ -22,7 +22,7 @@ Namespace My.Resources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _
@@ -129,7 +129,7 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to 2020-10-08T07:45:33
+        '''  Looks up a localized string similar to 2020-07-27T22:17:16
         '''.
         '''</summary>
         Public ReadOnly Property BuildDate() As String

--- a/UXL-Launcher/My Project/Resources.resx
+++ b/UXL-Launcher/My Project/Resources.resx
@@ -626,8 +626,8 @@ This decimal is to be used for the About window when talking about what version 
     <comment>About window banner</comment>
   </data>
   <data name="isStable" xml:space="preserve">
-    <value>Stable</value>
-    <comment>This value is used for the titlebar to tell the user if this app is stable or not. "Git" means that it's in development. "Alpha" means it's an alpha. "Beta" means it's a beta. "Release Candidate" means Release Candidate, plus any numbers. "Stable" means a stable release. There may be other values to represent the current state of development on the project.</comment>
+    <value>Dev</value>
+    <comment>This value is used for the titlebar to tell the user if this app is stable or not. "Dev" means that it's in development. "Alpha" means it's an alpha. "Beta" means it's a beta. "Release Candidate" means Release Candidate, plus any numbers. "Stable" means a stable release. There may be other values to represent the current state of development on the project.</comment>
   </data>
   <data name="Eyesore2Theme_XML" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\VB Code-behind\Themes\Eyesore2Theme_XML.xml;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
@@ -662,7 +662,7 @@ This decimal is to be used for the About window when talking about what version 
     <comment>This is the theme list used in the Options window.</comment>
   </data>
   <data name="appVersionCodename" xml:space="preserve">
-    <value> - Codename "Changeth Arrangeth"</value>
+    <value> - Codename "Burdened No Longer"</value>
     <comment>Codename for this version of UXL Launcher. Will be shown in the About window. Make sure to include the " - Codename " for consistency with UXL Launcher releases. If you set the codename string to blank, it won't show up in the About window.</comment>
   </data>
   <data name="supportedOfficeVersionList" xml:space="preserve">

--- a/UXL-Launcher/My Project/Settings.Designer.vb
+++ b/UXL-Launcher/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -29,7 +29,7 @@ Namespace My
     Private Shared addedHandlerLockObject As New Object
 
     <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
-    Private Shared Sub AutoSaveSettings(ByVal sender As Global.System.Object, ByVal e As Global.System.EventArgs)
+    Private Shared Sub AutoSaveSettings(sender As Global.System.Object, e As Global.System.EventArgs)
         If My.Application.SaveMySettingsOnExit Then
             My.Settings.Save()
         End If

--- a/UXL-Launcher/OptionsWindow.vb
+++ b/UXL-Launcher/OptionsWindow.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/Resources/ThemeEngineInfo_TXT.txt
+++ b/UXL-Launcher/Resources/ThemeEngineInfo_TXT.txt
@@ -16,6 +16,6 @@ You should have received a copy of the GNU General Public License along with UXL
 
 Drew is not intending on infringing on Microsoft's copyrights, so UXL Launcher is only a shortcut application.
 
-Copyright notice: Windows, Microsoft Windows, Office, Microsoft Office, Word, Excel, PowerPoint, and all related words and trademarks/registered trademarks owned by Microsoft in the United States and/or other countries are Copyright 2020 Microsoft Corporation. All Rights Reserved to Microsoft for Microsoft's copyrights, trademarks, and registered trademarks.
+Copyright notice: Windows, Microsoft Windows, Office, Microsoft Office, Word, Excel, PowerPoint, and all related words and trademarks/registered trademarks owned by Microsoft in the United States and/or other countries are Copyright Microsoft Corporation. All Rights Reserved to Microsoft for Microsoft's copyrights, trademarks, and registered trademarks.
 Any other companies mentioned own their respective copyrights/trademarks.
 Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor and does not endorse this software.

--- a/UXL-Launcher/Resources/ThemeEngineInfo_TXT.txt
+++ b/UXL-Launcher/Resources/ThemeEngineInfo_TXT.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2020 Drew Naylor. Licensed under Gnu GPLv3+.
+Copyright (C) 2013-2021 Drew Naylor. Licensed under Gnu GPLv3+.
 The copyright and license info is the same for the theme engine as it is for UXL Launcher itself as the theme engine is built into the same file as UXL Launcher.
 
 The UXL Launcher Theme Engine can make the UXL Launcher main window look slightly better and can also use custom themes.

--- a/UXL-Launcher/Resources/UXLLauncherInfo_TXT.txt
+++ b/UXL-Launcher/Resources/UXLLauncherInfo_TXT.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2013-2020 Drew Naylor. Licensed under Gnu GPLv3+.
+Copyright (C) 2013-2021 Drew Naylor. Licensed under Gnu GPLv3+.
 
 UXL Launcher provides launchers for most Microsoft Office apps in one place.
 Please be aware that UXL Launcher is unofficial and not made by Microsoft.

--- a/UXL-Launcher/Resources/UXLLauncherInfo_TXT.txt
+++ b/UXL-Launcher/Resources/UXLLauncherInfo_TXT.txt
@@ -15,6 +15,6 @@ You should have received a copy of the GNU General Public License along with UXL
 
 Drew is not intending on infringing on Microsoft's copyrights, so UXL Launcher is only a shortcut application.
 
-Copyright notice: Windows, Microsoft Windows, Office, Microsoft Office, Word, Excel, PowerPoint, and all related words and trademarks/registered trademarks owned by Microsoft in the United States and/or other countries are Copyright 2020 Microsoft Corporation. All Rights Reserved to Microsoft for Microsoft's copyrights, trademarks, and registered trademarks.
+Copyright notice: Windows, Microsoft Windows, Office, Microsoft Office, Word, Excel, PowerPoint, and all related words and trademarks/registered trademarks owned by Microsoft in the United States and/or other countries are Copyright Microsoft Corporation. All Rights Reserved to Microsoft for Microsoft's copyrights, trademarks, and registered trademarks.
 Any other companies mentioned own their respective copyrights/trademarks.
 Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor and does not endorse this software.

--- a/UXL-Launcher/UXL-Launcher.vbproj
+++ b/UXL-Launcher/UXL-Launcher.vbproj
@@ -14,6 +14,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
+    <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
     <InstallFrom>Disk</InstallFrom>
@@ -28,10 +29,9 @@
     <ProductName>UXL Launcher</ProductName>
     <PublisherName>Drew Naylor</PublisherName>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>4.0.0.%2a</ApplicationVersion>
+    <ApplicationVersion>5.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/UXL-Launcher/UXL-Launcher.vbproj
+++ b/UXL-Launcher/UXL-Launcher.vbproj
@@ -11,7 +11,7 @@
     <AssemblyName>UXL-Launcher</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>WindowsForms</MyType>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <PublishUrl>publish\</PublishUrl>
@@ -31,6 +31,7 @@
     <ApplicationVersion>4.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -124,6 +125,7 @@
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="My Project\Resources.Designer.vb">
       <AutoGen>True</AutoGen>

--- a/UXL-Launcher/VB Code-behind/LaunchApp.vb
+++ b/UXL-Launcher/VB Code-behind/LaunchApp.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/VB Code-behind/OfficeLocater.vb
+++ b/UXL-Launcher/VB Code-behind/OfficeLocater.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/UXLLauncher_ThemeEngine.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
+++ b/UXL-Launcher/VB Code-behind/Themes/WindowsThemeSettings.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
+++ b/UXL-Launcher/VB Code-behind/debugmodeStuff.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
+++ b/UXL-Launcher/VB Code-behind/isolated-error-handler.vb
@@ -1,5 +1,5 @@
 ﻿'UXL Launcher - UXL Launcher provides launchers for most Microsoft Office apps in one place.
-'Copyright (C) 2013-2020 Drew Naylor
+'Copyright (C) 2013-2021 Drew Naylor
 'Microsoft Office and all related words are copyright
 'and trademark Microsoft Corporation. More details in the About window.
 'Microsoft is not affiliated with either the UXL Launcher project or Drew Naylor

--- a/theme-editor/App.config
+++ b/theme-editor/App.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
   <appSettings>
-    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
-    <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true"/>
+    <add key="ClientSettingsProvider.ServiceUri" value=""/>
   </appSettings>
 </configuration>

--- a/theme-editor/My Project/AssemblyInfo.vb
+++ b/theme-editor/My Project/AssemblyInfo.vb
@@ -12,7 +12,7 @@ Imports System.Runtime.InteropServices
 <Assembly: AssemblyDescription("")>
 <Assembly: AssemblyCompany("")>
 <Assembly: AssemblyProduct("PortableThemeEngine Theme Editor")>
-<Assembly: AssemblyCopyright("Copyright (C) 2020 Drew Naylor. Licensed under Gnu GPLv3+.")>
+<Assembly: AssemblyCopyright("Copyright (C) 2020-2021 Drew Naylor. Licensed under Gnu GPLv3+.")>
 <Assembly: AssemblyTrademark("")>
 
 <Assembly: ComVisible(False)>

--- a/theme-editor/My Project/Resources.Designer.vb
+++ b/theme-editor/My Project/Resources.Designer.vb
@@ -22,7 +22,7 @@ Namespace My.Resources
     '''<summary>
     '''  A strongly-typed resource class, for looking up localized strings, etc.
     '''</summary>
-    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0"),  _
+    <Global.System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0"),  _
      Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
      Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
      Global.Microsoft.VisualBasic.HideModuleNameAttribute()>  _

--- a/theme-editor/My Project/Settings.Designer.vb
+++ b/theme-editor/My Project/Settings.Designer.vb
@@ -13,42 +13,42 @@ Option Explicit On
 
 
 Namespace My
-
-    <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(), _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0"), _
-     Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
+    
+    <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0"),  _
+     Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
-
-        Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings), MySettings)
-
+        
+        Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings()),MySettings)
+        
 #Region "My.Settings Auto-Save Functionality"
 #If _MyType = "WindowsForms" Then
-        Private Shared addedHandler As Boolean
+    Private Shared addedHandler As Boolean
 
-        Private Shared addedHandlerLockObject As New Object
+    Private Shared addedHandlerLockObject As New Object
 
-        <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
-        Private Shared Sub AutoSaveSettings(ByVal sender As Global.System.Object, ByVal e As Global.System.EventArgs)
-            If My.Application.SaveMySettingsOnExit Then
-                My.Settings.Save()
-            End If
-        End Sub
+    <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _
+    Private Shared Sub AutoSaveSettings(sender As Global.System.Object, e As Global.System.EventArgs)
+        If My.Application.SaveMySettingsOnExit Then
+            My.Settings.Save()
+        End If
+    End Sub
 #End If
 #End Region
-
+        
         Public Shared ReadOnly Property [Default]() As MySettings
             Get
-
+                
 #If _MyType = "WindowsForms" Then
-                   If Not addedHandler Then
-                        SyncLock addedHandlerLockObject
-                            If Not addedHandler Then
-                                AddHandler My.Application.Shutdown, AddressOf AutoSaveSettings
-                                addedHandler = True
-                            End If
-                        End SyncLock
-                    End If
+               If Not addedHandler Then
+                    SyncLock addedHandlerLockObject
+                        If Not addedHandler Then
+                            AddHandler My.Application.Shutdown, AddressOf AutoSaveSettings
+                            addedHandler = True
+                        End If
+                    End SyncLock
+                End If
 #End If
                 Return defaultInstance
             End Get
@@ -57,13 +57,13 @@ Namespace My
 End Namespace
 
 Namespace My
-
-    <Global.Microsoft.VisualBasic.HideModuleNameAttribute(), _
-     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), _
-     Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()> _
+    
+    <Global.Microsoft.VisualBasic.HideModuleNameAttribute(),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()>  _
     Friend Module MySettingsProperty
-
-        <Global.System.ComponentModel.Design.HelpKeywordAttribute("My.Settings")> _
+        
+        <Global.System.ComponentModel.Design.HelpKeywordAttribute("My.Settings")>  _
         Friend ReadOnly Property Settings() As Global.theme_editor.My.MySettings
             Get
                 Return Global.theme_editor.My.MySettings.Default

--- a/theme-editor/ThemeEditorWindow.vb
+++ b/theme-editor/ThemeEditorWindow.vb
@@ -1,5 +1,5 @@
 ﻿'PortableThemeEngine Theme Editor - Theme editor for editing PortableThemeEngine themes.
-'Copyright (C) 2020 Drew Naylor. Licensed under Gnu GPLv3+.
+'Copyright (C) 2020-2021 Drew Naylor. Licensed under Gnu GPLv3+.
 'Any companies mentioned own their respective copyrights/trademarks.
 '(Note that the copyright years include the years left out by the hyphen.)
 '

--- a/theme-editor/ThemeProcessor.vb
+++ b/theme-editor/ThemeProcessor.vb
@@ -1,5 +1,5 @@
 ﻿'PortableThemeEngine Theme Editor - Theme editor for editing PortableThemeEngine themes.
-'Copyright (C) 2020 Drew Naylor. Licensed under Gnu GPLv3+.
+'Copyright (C) 2020-2021 Drew Naylor. Licensed under Gnu GPLv3+.
 'Any companies mentioned own their respective copyrights/trademarks.
 '(Note that the copyright years include the years left out by the hyphen.)
 '

--- a/theme-editor/theme-editor.vbproj
+++ b/theme-editor/theme-editor.vbproj
@@ -11,8 +11,9 @@
     <AssemblyName>theme-editor</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>WindowsForms</MyType>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -91,6 +92,7 @@
     <Compile Include="My Project\Application.Designer.vb">
       <AutoGen>True</AutoGen>
       <DependentUpon>Application.myapp</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <Compile Include="My Project\Resources.Designer.vb">
       <AutoGen>True</AutoGen>


### PR DESCRIPTION
Most of the work in this branch was migrating to .NET Framework 4.8 and VS2019, but there were also copyright year updates and a boilerplate text update for a file I forgot to change. The "Git" name for the development phase has been dropped in favor of "Dev" since it's clearer. UXL Launcher has had its version bumped to 5.0 and it's now using the "Dev" string in the titlebar instead of "Stable". PortableThemeEngine has also been bumped to 3.0, though this is due to the .NET Framework 4.8 migration, although this kinda makes sense considering pre-themed controls is kinda a major feature.

Fixes #206, and partially #207.